### PR TITLE
Update CODEOWNERS + PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Define owners for all files in the repository
-
--       @m-goggins @bamader @ericbuckley @BradySkylight
+*       @m-goggins @bamader @ericbuckley @BradySkylight

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Related Issues
 
-[Link any related issues or tasks from your project management system.]
+Closes #[Link any related issues or tasks from your project management system.]
 
 ## Additional Notes
 


### PR DESCRIPTION
## Description
I noticed that the Codeowners are not automatically being assigned as reviewers. I think this minor fix to the file will do it. Also slightly modified the PR template to encourage linking the issues in Zenhub so that they close automatically when the PR is merged. 

## Related Issues

n/a

## Additional Notes
I added a new ruleset to the codebase as well to automatically assign CodeOwners as reviewers
