### PR TITLE
Add function to insert LOINC related names

### DIFF
--- a/scripts/terminology_valueset_sync.py
+++ b/scripts/terminology_valueset_sync.py
@@ -26,6 +26,10 @@ import os
 import sys
 
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 # Set Terminology URLS
 LOINC_BASE_URL = "https://loinc.regenstrief.org/searchapi/loincs?"
@@ -223,6 +227,9 @@ def save_valueset_csv_file(filename: str, contents: dict):  # noqa: D103
         print("Empty file contents!  Failed to save CSV!")
         return
 
+    if not os.path.exists(CSV_DIRECTORY):
+        os.makedirs(CSV_DIRECTORY)
+
     try:
         full_file_path = os.path.join(CSV_DIRECTORY, filename)
         csv_headers = contents[0].keys()
@@ -247,15 +254,21 @@ def main(  # noqa: D103
     lab_interp: bool,
     lab_names: bool,
 ):  # noqa: D103
+    print("Starting Terminology ValueSet Sync...")
     if all_vs or lab_orders:
+        print("Getting LOINC Lab Orders...")
         get_loinc_lab_orders()
     if all_vs or lab_obs:
+        print("Getting LOINC Lab Observations...")
         get_loinc_lab_results()
     if all_vs or lab_values:
+        print("Getting SNOMED Lab Result Values...")
         get_umls_snomed_lab_values()
     if all_vs or lab_interp:
+        print("Getting HL7 Lab Result Interpretations...")
         get_hl7_lab_interp()
     if all_vs or lab_names:
+        print("Getting LOINC Lab Names...")
         get_loinc_lab_names()
 
 

--- a/src/dibbs_text_to_code/augmentation.py
+++ b/src/dibbs_text_to_code/augmentation.py
@@ -31,3 +31,38 @@ def scramble_word_order(
         words.insert(new_pos, word)
 
     return " ".join(words)
+
+
+def insert_loinc_related_names(
+    text: str, loinc_names: list[str], max_inserts: int, min_inserts: int = 1
+) -> str:
+    """
+    Inserts 1 or more LOINC related names into the input text at random positions.
+
+    :param text: The input text to modify.
+    :param loinc_names: A list of LOINC related names to insert.
+    :param num_inserts: The number of LOINC names to insert.
+    :return: The text with LOINC related name(s) inserted.
+    """
+    words = text.split()
+    if not loinc_names or len(words) < 1:
+        return text
+
+    # Ensure num_inserts does not exceed the number of loinc_names
+    max_possible_inserts = min(len(loinc_names), len(words), max_inserts)
+    if max_possible_inserts < min_inserts:
+        return text
+    num_inserts = random.randint(min_inserts, max_possible_inserts)
+
+    # Select unique indices to insert at
+    indices_to_insert = sorted(random.sample(range(len(words)), num_inserts), reverse=True)
+
+    # Select unique LOINC names to insert
+    loinc_names_to_insert = random.sample(loinc_names, num_inserts)
+
+    for _ in range(num_inserts):
+        name_to_insert = loinc_names_to_insert.pop()
+        idx_to_insert = indices_to_insert.pop()
+        words.insert(idx_to_insert, name_to_insert)
+
+    return " ".join(words)

--- a/src/dibbs_text_to_code/augmentation.py
+++ b/src/dibbs_text_to_code/augmentation.py
@@ -49,13 +49,13 @@ def insert_loinc_related_names(
         return text
 
     # Ensure num_inserts does not exceed the number of loinc_names
-    max_possible_inserts = min(len(loinc_names), len(words), max_inserts)
-    if max_possible_inserts < min_inserts:
-        return text
-    num_inserts = random.randint(min_inserts, max_possible_inserts)
+    # max_possible_inserts = min(len(loinc_names), len(words), max_inserts)
+    # if max_possible_inserts < min_inserts:
+    #     return text
+    num_inserts = random.randint(min_inserts, min(len(loinc_names), max_inserts))
 
-    # Select unique indices to insert at
-    indices_to_insert = sorted(random.sample(range(len(words)), num_inserts), reverse=True)
+    # Select indices to insert at (can repeat)
+    indices_to_insert = [random.randrange(len(words) + 1) for _ in range(num_inserts)]
 
     # Select unique LOINC names to insert
     loinc_names_to_insert = random.sample(loinc_names, num_inserts)

--- a/tests/unit/test_augmentation.py
+++ b/tests/unit/test_augmentation.py
@@ -36,7 +36,7 @@ class TestScrambleWordOrder:
             "Blood",
             ["Blood", "Erythrocytes", "Calculation", "CalcRBC", "Volume fraction"],
             3,
-            "Blood",
+            "Erythrocytes Blood Volume fraction",
         ),
         # No LOINC names
         ("Hematocrit of Blood", [], 3, "Hematocrit of Blood"),
@@ -45,7 +45,7 @@ class TestScrambleWordOrder:
             "Hematocrit [Volume Fraction] of Blood by calculation",
             ["Blood", "Erythrocytes", "Calculation", "CalcRBC", "Volume fraction"],
             5,
-            "Erythrocytes Hematocrit [Volume Fraction] of Calculation Blood by calculation",
+            "Erythrocytes Hematocrit [Volume Fraction] of Volume fraction Blood by calculation",
         ),
     ],
 )

--- a/tests/unit/test_augmentation.py
+++ b/tests/unit/test_augmentation.py
@@ -24,3 +24,34 @@ class TestScrambleWordOrder:
     def test_scramble_word_order(self, text, max_perms, expected):
         result = augmentation.scramble_word_order(text, max_perms=max_perms)
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    "text, loinc_names, max_inserts,expected ",
+    [
+        # Empty string
+        ("", ["Blood", "Erythrocytes", "Calculation", "CalcRBC", "Volume fraction"], 3, ""),
+        # Single word
+        (
+            "Blood",
+            ["Blood", "Erythrocytes", "Calculation", "CalcRBC", "Volume fraction"],
+            3,
+            "Blood",
+        ),
+        # No LOINC names
+        ("Hematocrit of Blood", [], 3, "Hematocrit of Blood"),
+        # More inserts than LOINC names
+        (
+            "Hematocrit [Volume Fraction] of Blood by calculation",
+            ["Blood", "Erythrocytes", "Calculation", "CalcRBC", "Volume fraction"],
+            5,
+            "Erythrocytes Hematocrit [Volume Fraction] of Calculation Blood by calculation",
+        ),
+    ],
+)
+class TestInsertLoincRelatedNames:
+    def test_insert_loinc_related_names(self, text, loinc_names, max_inserts, expected):
+        result = augmentation.insert_loinc_related_names(
+            text, loinc_names, min_inserts=2, max_inserts=max_inserts
+        )
+        assert result == expected


### PR DESCRIPTION
## Description

This PR add a function to randomly insert a number of LOINC related names (according to the min and max inserts) into a given string.

## Related Issues
Closes #65 

## Additional Notes
I didn't add any of the functionality to parse the appropriate related names for a given LOINC `text`, figuring that would be a separate function. 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
