### PR TITLE
Creating jsonl embeddings

### DIFF
--- a/packages/model-tuning/src/model_tuning/jsonl_converter.py
+++ b/packages/model-tuning/src/model_tuning/jsonl_converter.py
@@ -34,18 +34,22 @@ def clean_embedding_data(data: dict) -> tuple[dict, np.ndarray]:
     """
     codes = data["codes"]
     embeddings = data["embeddings"]
+    loinc_types = data["loinc_types"]
     # Convert to numpy if tensor
     if isinstance(embeddings, torch.Tensor):
         print("Converting embeddings from torch.Tensor to numpy array")
         embeddings = embeddings.cpu().numpy()
-    return codes, embeddings
+    return codes, embeddings, loinc_types
 
 
-def write_jsonl_files(codes: list, embeddings: np.ndarray, model: str, chunk_size=CHUNK_SIZE):
+def write_jsonl_files(
+    codes: list, embeddings: np.ndarray, loinc_types: list, model: str, chunk_size=CHUNK_SIZE
+):
     """
     Writes the codes and embeddings to JSONL files in chunks.
     :param codes: List of LOINC standard names.
     :param embeddings: Numpy array of embeddings.
+    :param loinc_types: List of LOINC types corresponding to the codes.
     :param model: Model name used in the output file names.
     :param chunk_size: Number of entries per JSONL file.
     """
@@ -59,6 +63,7 @@ def write_jsonl_files(codes: list, embeddings: np.ndarray, model: str, chunk_siz
                 "id": str(i + j),
                 "description": codes[i + j],
                 "descriptionVector": embeddings[i + j].tolist(),
+                "type": loinc_types[i + j].tolist(),
             }
             for j in range(min(chunk_size, len(codes) - i))
         ]
@@ -70,5 +75,5 @@ def write_jsonl_files(codes: list, embeddings: np.ndarray, model: str, chunk_siz
 
 if __name__ == "__main__":
     data = open_embedding_file(input_file)
-    codes, embeddings = clean_embedding_data(data)
-    write_jsonl_files(codes, embeddings, model)
+    codes, embeddings, loinc_types = clean_embedding_data(data)
+    write_jsonl_files(codes, embeddings, loinc_types, model)


### PR DESCRIPTION
## Description

Adds a script to run after the embedding scripts to parse out 1000-line long `.jsonl` files for each model.

So far only ran for qwen. A few of the other pickles I tried to load were corrupted when I tried to load them, not sure if others are encountering the same issue for the ellen models.

Sample jsonls for qwen: https://drive.google.com/drive/u/0/folders/1GZIPJ8uok3A9PQcdOeMhy1Nz-onaiYzF


## Related Issues

Closes #148 

## Additional Notes


## Checklist

Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
