### PR TITLE
chore: fix script name

### DIFF
--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           # Get the branch/ref and version tag
           REF_NAME="${{ github.event.inputs.ref || github.ref_name }}"
-          VERSION_TAG=$(dev_scripts/version.sh)
+          VERSION_TAG=$(dev_scripts/version_name.sh)
 
           # Sanitize ref so it's a valid image tag
           if [ -z "$VERSION_TAG" ]; then


### PR DESCRIPTION
## Description

The `dev_script/version_name.sh` was not correctly named in the [my previous PR](https://github.com/CDCgov/dibbs-text-to-code/pull/151).

## Related Issues

Closes #147 

## Additional Notes

