### PR TITLE
chore: create requirements.txt in dockerfile.app

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -24,11 +24,13 @@ RUN pip install --upgrade pip  --break-system-packages
 
 WORKDIR /code
 
-COPY ./requirements.txt /code/requirements.txt
-RUN pip install -r requirements.txt
-
 COPY ./packages/api/src/api /code/app
 COPY ./packages/api/pyproject.toml /code/pyproject.toml
+
+# Create a requirements.txt from the pyproject.toml
+RUN uv pip compile /code/pyproject.toml -o /code/requirements.txt
+RUN pip install -r requirements.txt
+
 COPY --from=client-builder /frontend/dist /code/dist
 
 EXPOSE 8080


### PR DESCRIPTION
I am once again asking you to approve a PR for the GHCR workflow. This time I've edited `Dockerfile.app` so that it will create the `requirements.txt`, our Python setup is a little different to Refiner.