### PR TITLE
refactor: Skeleton of core Text to Code code

### DIFF
--- a/src/text-to-code/main.py
+++ b/src/text-to-code/main.py
@@ -1,3 +1,8 @@
+"""
+Core Text to Code code. This is the shared logic used for both the API/demo site and the Lambda.
+"""
+
+
 class SchematronError:
     location: str
 


### PR DESCRIPTION
I was having a hard time imagining the rough architecture of Text to Code, so I made this little skeleton. My thinking the logic that would be shared by both the API and the Lambda would live in `./src/text-to-code` separate from the other packages. This, to me, initially felt a bit off, but this is how [uv suggests organizing a workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) and this, along with Refiner's repo, has been my guide to repo organization.

As the main library and the packages get fleshed out we can move things into ["services" like Refiner](https://github.com/CDCgov/dibbs-ecr-refiner/tree/main/refiner/app/services).

I know there are a couple different tickets in flight, so this does not need to be merged if it would cause merge conflicts, but I at least hope this can focus our thoughts and discussions.