### PR TITLE
chore: Update Dependabot config to be more chill

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,26 +7,26 @@ updates:
     open-pull-requests-limit: 2
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: 'wednesday'
       time: '12:00'
   - package-ecosystem: 'uv'
     directory: '/'
     open-pull-requests-limit: 2
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: 'wednesday'
       time: '12:00'
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 2
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: 'wednesday'
       time: '12:00'
   - package-ecosystem: 'docker'
     directory: '/'
     open-pull-requests-limit: 2
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: 'wednesday'
       time: '12:00'


### PR DESCRIPTION
## Description

Updates the Dependabot config so that:
- It will check for updates for:
  - Github actions
  - Python packages
  - NPM packages
  - Docker images
- Will only open 2 PRs of each type at a time.
- Will check weekly on Wednesday morning so we do not get spammed during the work day.

## Related Issues

Closes n/a
