### PR TITLE
added obeservation text

### DIFF
--- a/packages/text-to-code/src/text_to_code/models/eicr.py
+++ b/packages/text-to-code/src/text_to_code/models/eicr.py
@@ -7,11 +7,11 @@ from shared_models import CdaInstanceIdentifier
 class LabXPaths(StrEnum):
     """The list of Sub XPath expressions to extract text in various locations from lab elements."""
 
-    CODE_DISPLAY_NAME = "/code/@displayName"
-    CODE_ORIGINAL_TEXT = "/code/originalText"
-    CODE_TEXT = "/text"
-    CODE_TRANSLATION_DISPLAY_NAME = "/code/translation/@displayName"
-    CODE_TRANSLATION_ORIGINAL_TEXT = "/code/translation/originalText"
+    CODE_DISPLAY_NAME = "code/@displayName"
+    CODE_ORIGINAL_TEXT = "code/originalText"
+    OBSERVATION_TEXT = "text"
+    CODE_TRANSLATION_DISPLAY_NAME = "code/translation/@displayName"
+    CODE_TRANSLATION_ORIGINAL_TEXT = "code/translation/originalText"
 
 
 class Candidate(BaseModel):

--- a/packages/text-to-code/src/text_to_code/models/evaluator.py
+++ b/packages/text-to-code/src/text_to_code/models/evaluator.py
@@ -132,6 +132,7 @@ class LabTestNameOrderedEvaluationCriteria(BaseEvaluationCriteria):
             XPathPriority(xpath=LabXPaths.CODE_TRANSLATION_DISPLAY_NAME, priority=2),
             XPathPriority(xpath=LabXPaths.CODE_ORIGINAL_TEXT, priority=3),
             XPathPriority(xpath=LabXPaths.CODE_TRANSLATION_ORIGINAL_TEXT, priority=4),
+            XPathPriority(xpath=LabXPaths.OBSERVATION_TEXT, priority=5),
         ]
     )
 
@@ -162,6 +163,7 @@ class LabTestNameResultedEvaluationCriteria(BaseEvaluationCriteria):
             XPathPriority(xpath=LabXPaths.CODE_TRANSLATION_DISPLAY_NAME, priority=2),
             XPathPriority(xpath=LabXPaths.CODE_ORIGINAL_TEXT, priority=3),
             XPathPriority(xpath=LabXPaths.CODE_TRANSLATION_ORIGINAL_TEXT, priority=4),
+            XPathPriority(xpath=LabXPaths.OBSERVATION_TEXT, priority=5),
         ]
     )
 

--- a/packages/text-to-code/tests/assets/reference_test_eicr.xml
+++ b/packages/text-to-code/tests/assets/reference_test_eicr.xml
@@ -22,7 +22,7 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <tr>
+                    <tr ID="row_reference_1">
                       <td ID="simple_reference_1">
                         My reference
                       </td>
@@ -39,6 +39,9 @@
                 </table>
               </text>
               <observation>
+                <text>
+                  <reference value="#row_reference_1" />
+                </text>
                 <code>
                   <originalText>
                     <reference value="#simple_reference_1" />

--- a/packages/text-to-code/tests/unit/test_eicr_processor.py
+++ b/packages/text-to-code/tests/unit/test_eicr_processor.py
@@ -91,16 +91,16 @@ class TestReferences:
 
     def test_simple_reference(self, results: list[Candidate]):
         expected = "My reference"
-        assert results[0] == Candidate(value=expected, xpath=LabXPaths.CODE_ORIGINAL_TEXT)
+        assert Candidate(value=expected, xpath=LabXPaths.CODE_ORIGINAL_TEXT) in results
 
     def test_additional_text_in_original(self, results: list[Candidate]):
         expected = "This original text has additional text My reference Even more stuff here"
-        assert results[1] == Candidate(
-            value=expected, xpath=LabXPaths.CODE_TRANSLATION_ORIGINAL_TEXT
-        )
+        assert Candidate(value=expected, xpath=LabXPaths.CODE_TRANSLATION_ORIGINAL_TEXT) in results
 
     def test_complicated_reference(self, results: list[Candidate]):
         expected = "A more complicated reference With extra nodes"
-        assert results[2] == Candidate(
-            value=expected, xpath=LabXPaths.CODE_TRANSLATION_ORIGINAL_TEXT
-        )
+        assert Candidate(value=expected, xpath=LabXPaths.CODE_TRANSLATION_ORIGINAL_TEXT)
+
+    def test_row_reference(self, results: list[Candidate]):
+        expected = "My reference A more complicated reference With extra nodes"
+        assert Candidate(value=expected, xpath=LabXPaths.OBSERVATION_TEXT) in results


### PR DESCRIPTION
## Description
We currently are not creating candidates from `observation/text`, this adds a case found in the the Powerpoint of reference examples.

## Related Issues

Closes #347 

## Additional Notes

This is part of the output to #310 