### PR TITLE
fix: replace pull_request_target with pull_request in Slack workflows

### DIFF
--- a/.github/workflows/slack_notifier_merged.yml
+++ b/.github/workflows/slack_notifier_merged.yml
@@ -1,7 +1,7 @@
 name: "post merged pull to slack"
 
 on:
-    pull_request_target:
+    pull_request:
       branches: [main]
       types:
         - closed

--- a/.github/workflows/slack_notifier_review.yml
+++ b/.github/workflows/slack_notifier_review.yml
@@ -1,7 +1,7 @@
 name: "post ready pull to slack"
 
 on:
-    pull_request_target:
+    pull_request:
       branches: [main]
       types:
         - opened


### PR DESCRIPTION
## Summary
- Replaces `on: pull_request_target` with `on: pull_request` in both Slack notifier workflows
- `pull_request_target` grants forked PRs access to the base repo's secrets, which is a security risk
- These workflows only need to fire for same-repo PRs targeting `main`, so `pull_request` is the safer trigger

## Files changed
- `.github/workflows/slack_notifier_merged.yml`
- `.github/workflows/slack_notifier_review.yml`

## Test plan
- [ ] Verify Slack notification fires when a non-draft PR is opened against `main`
- [ ] Verify Slack notification fires when a PR is merged to `main`