### PR TITLE
Skip Slack review notification for Dependabot PRs

### DIFF
--- a/.github/workflows/slack_notifier_review.yml
+++ b/.github/workflows/slack_notifier_review.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   slack-ready-for-review:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
 
     steps:
       - name: Send GitHub trigger payload to Slack


### PR DESCRIPTION
## Summary

- Adds `github.actor != 'dependabot[bot]'` condition to the Slack review notifier workflow so it doesn't fire for automated Dependabot PRs
- Dependabot-triggered workflows don't have access to repo secrets (`SLACK_WEBHOOK_URL`), causing the check to fail on every Dependabot PR
- It's not worth risking leaking the webhook URL in case dependabot is compromised
- The daily open-PRs cron (`slack_notifier_open_pulls.yml`) already surfaces these to the team

Resolves #402 