### PR TITLE
Fix Lambda-incompatible OCI image manifest in dev push workflow

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -81,6 +81,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           platforms: linux/amd64
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- APHL reported that Lambda rejects TTC container images built by the `docker-image-push.yml` workflow because `docker/build-push-action` v4+ defaults to OCI image format with provenance attestations (`application/vnd.oci.image.config.v1+json`)
- AWS Lambda only supports Docker v2 manifests (`application/vnd.docker.distribution.manifest.v2+json`)
- Adds `provenance: false` to the build-push-action step, matching the fix already present in `release.yml`

Reference: CDCgov/dibbs-ecr-refiner hit the same issue and applied the same fix.

## Test plan
- [ ] Trigger the `docker-image-push.yml` workflow (push to main or manual dispatch)
- [ ] Verify the GHCR image manifest format: `docker buildx imagetools inspect ghcr.io/<owner>/dibbs-text-to-code/ttc:latest`
- [ ] Confirm APHL can successfully create Lambda functions from the new images