### PR TITLE
Fix augmentation Lambda IAM: add S3 read permissions

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -382,6 +382,15 @@ resource "aws_iam_role_policy" "augmentation_lambda_s3_policy" {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid    = "AllowS3Read"
+        Effect = "Allow"
+        Action = ["s3:GetObject", "s3:HeadObject"]
+        Resource = [
+          "arn:aws:s3:::${var.s3_bucket}/${var.eicr_input_prefix}*",
+          "arn:aws:s3:::${var.s3_bucket}/${var.ttc_output_prefix}*"
+        ]
+      },
+      {
         Sid    = "AllowS3Write"
         Effect = "Allow"
         Action = ["s3:PutObject"]


### PR DESCRIPTION
## Summary
- Add `s3:GetObject` and `s3:HeadObject` permissions for `eCRMessageV2/` and `TTCAugmentationMetadataV2/` prefixes to the augmentation Lambda's IAM policy
- The Lambda reads from these prefixes but only had `s3:PutObject` on output prefixes, causing `AccessDenied` errors
- Follows the same pattern used by the TTC Lambda's S3 policy

Closes #431