### PR TITLE
Add index push to github workflow

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -74,7 +74,6 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
 
       - name: Build and push image
-        if: ${{ matrix.name != 'index' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.index == 'true' }}
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -90,7 +89,6 @@ jobs:
             "huggingface_token=${{ secrets.HF_TOKEN }}"
 
       - name: Configure APHL AWS credentials
-        if: ${{ matrix.name != 'index' || steps.changes.outputs.index == 'true'}}
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.APHL_AWS_ACCESS_KEY_ID }}
@@ -98,12 +96,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Login to APHL ECR
-        if: ${{ matrix.name != 'index' || steps.changes.outputs.index == 'true' }}
         id: aphl-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Push to APHL ECR
-        if: ${{ matrix.name != 'index' || steps.changes.outputs.index == 'true' }}
         run: |
           GHCR_IMAGE="ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-text-to-code/${{ matrix.name }}:latest"
           ECR_IMAGE="${{ secrets.APHL_ECR_REPOSITORY_URL }}/${{ matrix.name }}:latest"

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -90,7 +90,7 @@ jobs:
             "huggingface_token=${{ secrets.HF_TOKEN }}"
 
       - name: Configure APHL AWS credentials
-        if: ${{ matrix.name != 'index' }}
+        if: ${{ matrix.name != 'index' || steps.changes.outputs.index == 'true'}}
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.APHL_AWS_ACCESS_KEY_ID }}
@@ -98,12 +98,12 @@ jobs:
           aws-region: us-east-1
 
       - name: Login to APHL ECR
-        if: ${{ matrix.name != 'index' }}
+        if: ${{ matrix.name != 'index' || steps.changes.outputs.index == 'true' }}
         id: aphl-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Push to APHL ECR
-        if: ${{ matrix.name != 'index' }}
+        if: ${{ matrix.name != 'index' || steps.changes.outputs.index == 'true' }}
         run: |
           GHCR_IMAGE="ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-text-to-code/${{ matrix.name }}:latest"
           ECR_IMAGE="${{ secrets.APHL_ECR_REPOSITORY_URL }}/${{ matrix.name }}:latest"


### PR DESCRIPTION
## Description

This PR adds a push to APHL's eCR Repo for the Index Lambda docker container on merge-to-main for our repo. Previously, only TTC and Augmentation were pushed; now, the workflow file has been modified to also push the Index Lambda whenever changes are detected to its file contents (using the same check which we use to build and push the Index image to GHCR).

## Related Issues

Closes #436 

## Additional Notes

I _think_ we'll be okay without a separate repo URL, since on line 109 we push the image to a location based on its name (TTC, Augmentation, or Index), but if that's wrong I can definitely add another variable.