### PR TITLE
Add aws-lambda-typing as dependency for lambda-handler

### DIFF
--- a/packages/lambda-handler/pyproject.toml
+++ b/packages/lambda-handler/pyproject.toml
@@ -2,7 +2,11 @@
 name = "lambda-handler"
 version = "0.1.0"
 readme = "README.md"
-dependencies = ["boto3>=1.40.60", "pydantic>=2.12.5"]
+dependencies = [
+  "aws-lambda-typing>=2.20.0",
+  "boto3>=1.40.60",
+  "pydantic>=2.12.5",
+]
 
 [dependency-groups]
 dev = ["moto"]

--- a/packages/text-to-code-lambda/pyproject.toml
+++ b/packages/text-to-code-lambda/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["aws-lambda-typing>=2.20.0", "moto"]
+dev = ["moto"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
aws-lambda-typing is used in the lambda-handler and so it needs to be a dependency.