### PR TITLE
Add aws-lambda-typing as dependency for lambda-handler

### DIFF
--- a/packages/lambda-handler/pyproject.toml
+++ b/packages/lambda-handler/pyproject.toml
@@ -2,7 +2,11 @@
 name = "lambda-handler"
 version = "0.1.0"
 readme = "README.md"
-dependencies = ["boto3>=1.40.60", "pydantic>=2.12.5"]
+dependencies = [
+  "aws-lambda-typing>=2.20.0",
+  "boto3>=1.40.60",
+  "pydantic>=2.12.5",
+]
 
 [dependency-groups]
 dev = ["moto"]

--- a/packages/text-to-code-lambda/pyproject.toml
+++ b/packages/text-to-code-lambda/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["aws-lambda-typing>=2.20.0", "moto"]
+dev = ["moto"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -844,6 +844,7 @@ name = "lambda-handler"
 version = "0.1.0"
 source = { editable = "packages/lambda-handler" }
 dependencies = [
+    { name = "aws-lambda-typing" },
     { name = "boto3" },
     { name = "pydantic" },
 ]
@@ -855,6 +856,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aws-lambda-typing", specifier = ">=2.20.0" },
     { name = "boto3", specifier = ">=1.40.60" },
     { name = "pydantic", specifier = ">=2.12.5" },
 ]
@@ -2036,7 +2038,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aws-lambda-typing" },
     { name = "moto" },
 ]
 
@@ -2049,10 +2050,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "aws-lambda-typing", specifier = ">=2.20.0" },
-    { name = "moto" },
-]
+dev = [{ name = "moto" }]
 
 [[package]]
 name = "thinc"


### PR DESCRIPTION
aws-lambda-typing is used in the lambda-handler and so it needs to be a dependency.