### PR TITLE
Use local paths for models in TTC lambda

### DIFF
--- a/packages/text-to-code/src/text_to_code/models/registry.py
+++ b/packages/text-to-code/src/text_to_code/models/registry.py
@@ -1,3 +1,5 @@
+import os
+
 from shared_models import DataField
 
 from .labs import BaseLabField
@@ -11,8 +13,8 @@ EICR_REGISTRY: dict[DataField, type[BaseLabField]] = {
 
 # Text-to-Code Retrieval model, used for searching approximate neighborhoods
 # to find semantically similar candidates
-TTC_RETRIEVER: str = "NCHS/ttc-retriever-mvp"
+TTC_RETRIEVER: str = os.getenv("RETRIEVER_MODEL_PATH") or "NCHS/ttc-retriever-mvp"
 
 # Text-to-Code Reranker model, used for re-scoring and re-sorting the hits
 # found by the approximate neighbor search
-TTC_RERANKER: str = "NCHS/ttc-reranker-mvp"
+TTC_RERANKER: str = os.getenv("RERANKER_MODEL_PATH") or "NCHS/ttc-reranker-mvp"


### PR DESCRIPTION
Since we bundle the models directly into our Docker image, use the local file paths when initializing the SentenceTransformers instead of downloading in TTC lambda.