### PR TITLE
Consolidate eICR input prefixes into TTC_INPUT_PREFIX

### DIFF
--- a/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
+++ b/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
@@ -20,7 +20,7 @@ logger = structlog.get_logger()
 
 # Environment variables
 S3_BUCKET = os.getenv("S3_BUCKET", "dibbs-text-to-code")
-EICR_INPUT_PREFIX = os.getenv("EICR_INPUT_PREFIX", "eCRMessageV2/")
+TTC_INPUT_PREFIX = os.getenv("TTC_INPUT_PREFIX", "TextToCodeSubmissionV2/")
 TTC_OUTPUT_PREFIX = os.getenv("TTC_OUTPUT_PREFIX", "TTCAugmentationMetadataV2/")
 AUGMENTED_EICR_PREFIX = os.getenv("AUGMENTED_EICR_PREFIX", "AugmentationEICRV2/")
 AUGMENTATION_METADATA_PREFIX = os.getenv("AUGMENTATION_METADATA_PREFIX", "AugmentationMetadataV2/")
@@ -142,7 +142,7 @@ def _load_original_eicr(persistence_id: str, s3_client: BaseClient, bucket_name:
     :param bucket_name: The S3 bucket name.
     :return: The raw eICR XML string.
     """
-    object_key = f"{EICR_INPUT_PREFIX}{persistence_id}"
+    object_key = f"{TTC_INPUT_PREFIX}{persistence_id}"
     logger.info(f"Retrieving eICR from s3://{bucket_name}/{object_key}")
     return lambda_handler.get_file_content_from_s3(
         bucket_name=bucket_name, object_key=object_key, s3_client=s3_client

--- a/packages/augmentation-lambda/tests/conftest.py
+++ b/packages/augmentation-lambda/tests/conftest.py
@@ -13,7 +13,7 @@ from lambda_handler.test_constants import AWS_SECRET_ACCESS_KEY
 from lambda_handler.test_constants import S3_BUCKET
 from lambda_handler.test_constants import TEST_PERSISTENCE_ID
 
-EICR_INPUT_PREFIX = "eCRMessageV2/"
+TTC_INPUT_PREFIX = "TextToCodeSubmissionV2/"
 TTC_OUTPUT_PREFIX = "TTCAugmentationMetadataV2/"
 AUGMENTED_EICR_PREFIX = "AugmentationEICRV2/"
 AUGMENTATION_METADATA_PREFIX = "AugmentationMetadataV2/"
@@ -53,7 +53,7 @@ TEST_TTC_OUTPUT = {
 def pytest_configure() -> None:
     """Configure env variables for pytest."""
     os.environ["S3_BUCKET"] = S3_BUCKET
-    os.environ["EICR_INPUT_PREFIX"] = EICR_INPUT_PREFIX
+    os.environ["TTC_INPUT_PREFIX"] = TTC_INPUT_PREFIX
     os.environ["TTC_OUTPUT_PREFIX"] = TTC_OUTPUT_PREFIX
     os.environ["AUGMENTED_EICR_PREFIX"] = AUGMENTED_EICR_PREFIX
     os.environ["AUGMENTATION_METADATA_PREFIX"] = AUGMENTATION_METADATA_PREFIX
@@ -139,7 +139,7 @@ def mock_aws_setup(monkeypatch: pytest.MonkeyPatch) -> boto3.client:
             eicr_content = f.read()
         s3.put_object(
             Bucket=S3_BUCKET,
-            Key=f"{EICR_INPUT_PREFIX}{TEST_PERSISTENCE_ID}",
+            Key=f"{TTC_INPUT_PREFIX}{TEST_PERSISTENCE_ID}",
             Body=eicr_content,
         )
 

--- a/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
+++ b/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
@@ -115,11 +115,11 @@ class TestHandler:
         # Copy eICR to custom bucket
         eicr_obj = mock_aws_setup.get_object(
             Bucket=S3_BUCKET,
-            Key=f"eCRMessageV2/{TEST_PERSISTENCE_ID}",
+            Key=f"TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
         )
         mock_aws_setup.put_object(
             Bucket=custom_bucket,
-            Key=f"eCRMessageV2/{TEST_PERSISTENCE_ID}",
+            Key=f"TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
             Body=eicr_obj["Body"].read(),
         )
         # Copy TTC output to custom bucket
@@ -171,7 +171,7 @@ class TestHandler:
         # Remove the eICR from S3
         mock_aws_setup.delete_object(
             Bucket=S3_BUCKET,
-            Key=f"eCRMessageV2/{TEST_PERSISTENCE_ID}",
+            Key=f"TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
         )
 
         event = {

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -30,7 +30,6 @@ logger = Logger(service="ttc")
 
 # Environment variables
 S3_BUCKET = os.getenv("S3_BUCKET", "dibbs-text-to-code")
-EICR_INPUT_PREFIX = os.getenv("EICR_INPUT_PREFIX", "eCRMessageV2/")
 SCHEMATRON_ERROR_PREFIX = os.getenv("SCHEMATRON_ERROR_PREFIX", "ValidationResponseV2/")
 TTC_INPUT_PREFIX = os.getenv("TTC_INPUT_PREFIX", "TextToCodeSubmissionV2/")
 TTC_OUTPUT_PREFIX = os.getenv("TTC_OUTPUT_PREFIX", "TTCAugmentationMetadataV2/")
@@ -174,7 +173,7 @@ def _load_original_eicr(persistence_id: str, s3_client: BaseClient, bucket_name:
     :param bucket_name: The S3 bucket name to read from.
     :return: The original eICR content.
     """
-    object_key = f"{EICR_INPUT_PREFIX}{persistence_id}"
+    object_key = f"{TTC_INPUT_PREFIX}{persistence_id}"
     logger.info(f"Retrieving eICR from s3://{bucket_name}/{object_key}")
     original_eicr_content = lambda_handler.get_file_content_from_s3(
         bucket_name=bucket_name, object_key=object_key, s3_client=s3_client

--- a/packages/text-to-code-lambda/tests/conftest.py
+++ b/packages/text-to-code-lambda/tests/conftest.py
@@ -16,7 +16,6 @@ from lambda_handler.test_constants import S3_BUCKET
 from lambda_handler.test_constants import TEST_PERSISTENCE_ID
 from text_to_code_lambda import lambda_function
 
-EICR_INPUT_PREFIX = "eCRMessageV2/"
 SCHEMATRON_ERROR_PREFIX = "ValidationResponseV2/"
 TTC_INPUT_PREFIX = "TextToCodeSubmissionV2/"
 TTC_OUTPUT_PREFIX = "TTCAugmentationMetadataV2/"
@@ -27,7 +26,6 @@ OPENSEARCH_ENDPOINT_URL = "https://test-opensearch-endpoint.com"
 def pytest_configure() -> None:
     """Configure env variables for pytest."""
     os.environ["S3_BUCKET"] = S3_BUCKET
-    os.environ["EICR_INPUT_PREFIX"] = EICR_INPUT_PREFIX
     os.environ["SCHEMATRON_ERROR_PREFIX"] = SCHEMATRON_ERROR_PREFIX
     os.environ["TTC_INPUT_PREFIX"] = TTC_INPUT_PREFIX
     os.environ["TTC_OUTPUT_PREFIX"] = TTC_OUTPUT_PREFIX
@@ -145,7 +143,7 @@ def mock_aws_setup(monkeypatch: pytest.MonkeyPatch) -> boto3.client:
             ecr_message = f.read()
         s3.put_object(
             Bucket=S3_BUCKET,
-            Key=f"{EICR_INPUT_PREFIX}{TEST_PERSISTENCE_ID}",
+            Key=f"{TTC_INPUT_PREFIX}{TEST_PERSISTENCE_ID}",
             Body=ecr_message,
         )
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -51,7 +51,7 @@ Each Lambda function has its own IAM role scoped to least-privilege S3 permissio
 - **TTC Lambda IAM Role** (`aws_iam_role.ttc_lambda_role`): Attached policies:
   - `AWSLambdaVPCAccessExecutionRole` — allows ENI creation for VPC placement
   - `AWSLambdaBasicExecutionRole` — allows CloudWatch Logs writes
-  - Inline S3 policy — `s3:GetObject`/`s3:HeadObject` on `eCRMessageV2/` and `ValidationResponseV2/` prefixes; `s3:PutObject` on `TTCAugmentationMetadataV2/` and `TTCMetadataV2/` prefixes
+  - Inline S3 policy — `s3:GetObject`/`s3:HeadObject` on `TextToCodeSubmissionV2/` and `ValidationResponseV2/` prefixes; `s3:PutObject` on `TTCAugmentationMetadataV2/` and `TTCMetadataV2/` prefixes
   - Inline OpenSearch policy — grants OpenSearch HTTP actions (`ESHttpGet/Post/Put/Delete/Head/Patch/Options`)
 - **Index Lambda IAM Role** (`aws_iam_role.index_lambda_role`): Attached policies:
   - `AWSLambdaVPCAccessExecutionRole` — allows ENI creation for VPC placement
@@ -83,7 +83,7 @@ At runtime, the Lambda runs the real `text_to_code_lambda.lambda_function.handle
 4. Generates embeddings and executes KNN queries against OpenSearch
 5. Returns standardized code mappings (LOINC/SNOMED)
 
-Environment variables injected at deploy time: `OPENSEARCH_ENDPOINT_URL`, `OPENSEARCH_INDEX`, `REGION`, `S3_BUCKET`, `RETRIEVER_MODEL_PATH`, `RERANKER_MODEL_PATH`, `EICR_INPUT_PREFIX`, `SCHEMATRON_ERROR_PREFIX`, `TTC_INPUT_PREFIX`, `TTC_OUTPUT_PREFIX`, `TTC_METADATA_PREFIX`.
+Environment variables injected at deploy time: `OPENSEARCH_ENDPOINT_URL`, `OPENSEARCH_INDEX`, `REGION`, `S3_BUCKET`, `RETRIEVER_MODEL_PATH`, `RERANKER_MODEL_PATH`, `SCHEMATRON_ERROR_PREFIX`, `TTC_INPUT_PREFIX`, `TTC_OUTPUT_PREFIX`, `TTC_METADATA_PREFIX`.
 
 #### Augmentation Lambda (`ttc-augmentation-lambda`, `Dockerfile.augmentation`)
 

--- a/terraform/_variables.tf
+++ b/terraform/_variables.tf
@@ -105,12 +105,6 @@ variable "index_name" {
 }
 
 ### S3 Prefix Variables (for TTC Lambda)
-variable "eicr_input_prefix" {
-  type        = string
-  default     = "eCRMessageV2/"
-  description = "S3 prefix for eICR input files"
-}
-
 variable "schematron_error_prefix" {
   type        = string
   default     = "ValidationResponseV2/"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -291,7 +291,7 @@ resource "aws_iam_role_policy" "ttc_lambda_s3_policy" {
         Effect = "Allow"
         Action = ["s3:GetObject", "s3:HeadObject"]
         Resource = [
-          "arn:aws:s3:::${var.s3_bucket}/${var.eicr_input_prefix}*",
+          "arn:aws:s3:::${var.s3_bucket}/${var.ttc_input_prefix}*",
           "arn:aws:s3:::${var.s3_bucket}/${var.schematron_error_prefix}*"
         ]
       },
@@ -386,7 +386,7 @@ resource "aws_iam_role_policy" "augmentation_lambda_s3_policy" {
         Effect = "Allow"
         Action = ["s3:GetObject", "s3:HeadObject"]
         Resource = [
-          "arn:aws:s3:::${var.s3_bucket}/${var.eicr_input_prefix}*",
+          "arn:aws:s3:::${var.s3_bucket}/${var.ttc_input_prefix}*",
           "arn:aws:s3:::${var.s3_bucket}/${var.ttc_output_prefix}*"
         ]
       },
@@ -428,7 +428,6 @@ resource "aws_lambda_function" "lambda" {
       S3_BUCKET               = var.s3_bucket
       RETRIEVER_MODEL_PATH    = "/opt/retriever_model"
       RERANKER_MODEL_PATH     = "/opt/reranker_model"
-      EICR_INPUT_PREFIX       = var.eicr_input_prefix
       SCHEMATRON_ERROR_PREFIX = var.schematron_error_prefix
       TTC_INPUT_PREFIX        = var.ttc_input_prefix
       TTC_OUTPUT_PREFIX       = var.ttc_output_prefix
@@ -665,7 +664,7 @@ resource "aws_lambda_function" "augmentation_lambda" {
   environment {
     variables = {
       S3_BUCKET                    = var.s3_bucket
-      EICR_INPUT_PREFIX            = var.eicr_input_prefix
+      TTC_INPUT_PREFIX             = var.ttc_input_prefix
       TTC_OUTPUT_PREFIX            = var.ttc_output_prefix
       AUGMENTED_EICR_PREFIX        = var.augmented_eicr_prefix
       AUGMENTATION_METADATA_PREFIX = var.augmentation_metadata_prefix


### PR DESCRIPTION
## Summary
- Drop the `EICR_INPUT_PREFIX` env var. Both the TTC and Augmentation Lambdas now read the original eICR from `TTC_INPUT_PREFIX` (default `TextToCodeSubmissionV2/`), which is also the EventBridge trigger prefix.
- Update Terraform IAM read policies, Lambda env vars, and the `eicr_input_prefix` variable accordingly; refresh `CLAUDE.md` and `terraform/README.md`.

This fixes the deployed-pipeline mismatch where the S3 event triggered on `TextToCodeSubmissionV2/` but the Lambda tried to fetch the eICR from `eCRMessageV2/`.

## Test plan
- [x] `uv run pytest packages/text-to-code-lambda packages/augmentation-lambda`
- [x] `uv run ruff check`
- [x] `terraform fmt -check && terraform validate`
- [ ] End-to-end: upload an eICR to `s3://<bucket>/TextToCodeSubmissionV2/<persistence_id>` in the deployed environment and confirm both Lambdas succeed