### PR TITLE
Add str as allowed type for OpenSearch total_hits

### DIFF
--- a/packages/lambda-handler/src/lambda_handler/models/opensearch.py
+++ b/packages/lambda-handler/src/lambda_handler/models/opensearch.py
@@ -38,7 +38,7 @@ class OpenSearchHit(BaseModel):
 class OpenSearchHits(BaseModel):
     """Represents all of the search result hits returned from OpenSearch."""
 
-    total_hits: dict[str, int] = Field(
+    total_hits: dict[str, str | int] = Field(
         alias="total", description="The total number of hits returned from OpenSearch."
     )
     hits: list[OpenSearchHit] = Field(


### PR DESCRIPTION
TTC lambda is currently erroring when serializing the OpenSearch search response because total_hits.relation is a string and not an int. This changes our model to allow both str and int.