### PR TITLE
Add opensearchpy to lambda-handler dependencies

### DIFF
--- a/packages/lambda-handler/pyproject.toml
+++ b/packages/lambda-handler/pyproject.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 dependencies = [
   "aws-lambda-typing>=2.20.0",
   "boto3>=1.40.60",
+  "opensearch-py>=2.0.0",
   "pydantic>=2.12.5",
 ]
 


### PR DESCRIPTION
Needs to be an explicit dependency since it's used in lambda-handler