### PR TITLE
Add debug logging for index lambda

### DIFF
--- a/packages/index-lambda/src/index_lambda/lambda_function.py
+++ b/packages/index-lambda/src/index_lambda/lambda_function.py
@@ -52,6 +52,8 @@ def handler(event: dict, context: dict) -> dict:
 
     if action == "clear_index":
         return _clear_index(os_client, index_name)
+    elif action == "set_slowlog":
+        return _set_slowlog(os_client, index_name, event.get("threshold_ms", 0))
     return _create_index(os_client, index_name)
 
 
@@ -73,6 +75,33 @@ def _clear_index(os_client: OpenSearch, index_name: str) -> dict:
         "action": "clear_index",
         "index_deleted": deleted,
         "index_recreated": True,
+    }
+
+
+def _set_slowlog(os_client: OpenSearch, index_name: str, threshold_ms: int) -> dict:
+    index = os_client.indices.get(index=index_name)
+    settings = os_client.indices.get_settings(index=index_name)
+    mappings = os_client.indices.get_mapping(index=index_name)
+
+    print(index)
+    print(settings)
+    print(mappings)
+
+    threshold = f"{threshold_ms}ms" if threshold_ms > 0 else "-1"
+    body = {
+        "index.search.slowlog.threshold.query.warn": threshold,
+        "index.search.slowlog.threshold.query.info": threshold,
+        "index.search.slowlog.threshold.fetch.warn": threshold,
+        "index.search.slowlog.threshold.fetch.info": threshold,
+    }
+    os_client.indices.put_settings(index=index_name, body=body)
+    return {
+        "statusCode": 200,
+        "action": "set_slowlog",
+        "threshold_ms": threshold_ms,
+        "index": index,
+        "settings": settings,
+        "mappings": mappings,
     }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -168,7 +168,7 @@ resource "aws_opensearch_domain" "os" {
   }
 
   advanced_security_options {
-    enabled = false
+    enabled = true
   }
 
   encrypt_at_rest {

--- a/uv.lock
+++ b/uv.lock
@@ -846,6 +846,7 @@ source = { editable = "packages/lambda-handler" }
 dependencies = [
     { name = "aws-lambda-typing" },
     { name = "boto3" },
+    { name = "opensearch-py" },
     { name = "pydantic" },
 ]
 
@@ -858,6 +859,7 @@ dev = [
 requires-dist = [
     { name = "aws-lambda-typing", specifier = ">=2.20.0" },
     { name = "boto3", specifier = ">=1.40.60" },
+    { name = "opensearch-py", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
 ]
 


### PR DESCRIPTION
Will allow us to inspect the Opensearch index and turn on warn and info logs.