### PR TITLE
Add requests_aws4auth as dependency for lambda-handler

### DIFF
--- a/packages/lambda-handler/pyproject.toml
+++ b/packages/lambda-handler/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "boto3>=1.40.60",
   "opensearch-py>=2.0.0",
   "pydantic>=2.12.5",
+  "requests_aws4auth>=1.3.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -848,6 +848,7 @@ dependencies = [
     { name = "boto3" },
     { name = "opensearch-py" },
     { name = "pydantic" },
+    { name = "requests-aws4auth" },
 ]
 
 [package.dev-dependencies]
@@ -861,6 +862,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.60" },
     { name = "opensearch-py", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "requests-aws4auth", specifier = ">=1.3.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Another package needed as an explicit dep for lambda-handler since it's causing aug lambda to fail.