### PR TITLE
Temporarily remove VPC for OpenSearch debugging

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,12 @@ jobs:
   deploy_text_to_code:
     name: Terraform
     runs-on: ubuntu-latest
+    env:
+      # Temporary debug access to the public OpenSearch endpoint.
+      # Secrets should contain HCL list literals, e.g. ["203.0.113.42/32"].
+      # Unset/empty secrets fall back to the [] default in _variables.tf.
+      TF_VAR_debug_allowed_ips: ${{ secrets.DEBUG_ALLOWED_IPS }}
+      TF_VAR_debug_iam_principals: ${{ secrets.DEBUG_IAM_PRINCIPALS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/terraform/_outputs.tf
+++ b/terraform/_outputs.tf
@@ -29,11 +29,6 @@ output "augmentation_lambda_role_arn" {
   description = "The ARN of the IAM role attached to the augmentation lambda function"
 }
 
-output "opensearch_vpc_endpoint" {
-  value       = aws_opensearch_vpc_endpoint.os_vpc_endpoint.endpoint
-  description = "The VPC endpoint URL for the OpenSearch domain"
-}
-
 output "ecr_repository_url" {
   value       = aws_ecr_repository.ttc_lambda.repository_url
   description = "The URL of the ECR repository for the TTC Lambda container image"

--- a/terraform/_variables.tf
+++ b/terraform/_variables.tf
@@ -179,3 +179,16 @@ variable "augmentation_lambda_image_tag" {
   description = "The image tag for the augmentation Lambda container image in ECR"
 }
 
+### Debug Access Variables (temporary — revert when done)
+variable "debug_allowed_ips" {
+  description = "CIDR blocks permitted to hit the public OpenSearch endpoint with the debug IAM principals. Used only while vpc_options is stripped from aws_opensearch_domain.os."
+  type        = list(string)
+  default     = []
+}
+
+variable "debug_iam_principals" {
+  description = "Additional IAM user/role ARNs granted ES HTTP access to the public domain (e.g. a developer's SSO role). Paired with debug_allowed_ips."
+  type        = list(string)
+  default     = []
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,16 +141,30 @@ data "aws_iam_policy_document" "opensearch_access_policy" {
     actions   = var.lambda_os_actions
     resources = ["arn:aws:es:${var.region}:${data.aws_caller_identity.current.account_id}:domain/${var.opensearch_domain_name}/*"]
   }
+
+  dynamic "statement" {
+    for_each = length(var.debug_allowed_ips) > 0 && length(var.debug_iam_principals) > 0 ? [1] : []
+    content {
+      sid    = "AllowDebugFromAllowlist"
+      effect = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = var.debug_iam_principals
+      }
+      actions   = var.lambda_os_actions
+      resources = ["arn:aws:es:${var.region}:${data.aws_caller_identity.current.account_id}:domain/${var.opensearch_domain_name}/*"]
+      condition {
+        test     = "IpAddress"
+        variable = "aws:SourceIp"
+        values   = var.debug_allowed_ips
+      }
+    }
+  }
 }
 
 resource "aws_opensearch_domain" "os" {
   domain_name    = var.opensearch_domain_name
   engine_version = var.opensearch_engine_version
-
-  vpc_options {
-    subnet_ids         = module.vpc.private_subnets
-    security_group_ids = [aws_security_group.opensearch_sg.id]
-  }
 
   cluster_config {
     instance_type          = "r5.large.search"
@@ -201,14 +215,6 @@ resource "aws_opensearch_domain" "os" {
   }
 
   tags = { Name = var.opensearch_domain_name }
-}
-
-resource "aws_opensearch_vpc_endpoint" "os_vpc_endpoint" {
-  domain_arn = aws_opensearch_domain.os.arn
-  vpc_options {
-    security_group_ids = [aws_security_group.opensearch_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 }
 
 #############
@@ -415,14 +421,9 @@ resource "aws_lambda_function" "lambda" {
   timeout       = var.lambda_timeout
   memory_size   = 3008
 
-  vpc_config {
-    subnet_ids         = module.vpc.private_subnets
-    security_group_ids = [aws_security_group.lambda_sg.id, aws_security_group.opensearch_sg.id]
-  }
-
   environment {
     variables = {
-      OPENSEARCH_ENDPOINT_URL = "https://${aws_opensearch_vpc_endpoint.os_vpc_endpoint.endpoint}"
+      OPENSEARCH_ENDPOINT_URL = "https://${aws_opensearch_domain.os.endpoint}"
       OPENSEARCH_INDEX        = var.index_name
       REGION                  = var.region
       RETRIEVER_MODEL_PATH    = "/opt/retriever_model"
@@ -534,14 +535,6 @@ resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
   min_units = 1
   max_units = 4
 
-  vpc_options {
-    subnet_ids = module.vpc.private_subnets
-    security_group_ids = [
-      aws_security_group.opensearch_sg.id,
-      aws_security_group.lambda_sg.id
-    ]
-  }
-
   # Publishing to CloudWatch Logs
   log_publishing_options {
     is_logging_enabled = true
@@ -626,14 +619,9 @@ resource "aws_lambda_function" "index_lambda" {
   image_uri     = "${aws_ecr_repository.index_lambda.repository_url}:${var.index_lambda_image_tag}"
   timeout       = var.lambda_timeout
 
-  vpc_config {
-    subnet_ids         = module.vpc.private_subnets
-    security_group_ids = [aws_security_group.lambda_sg.id, aws_security_group.opensearch_sg.id]
-  }
-
   environment {
     variables = {
-      OPENSEARCH_ENDPOINT_URL = "https://${aws_opensearch_vpc_endpoint.os_vpc_endpoint.endpoint}"
+      OPENSEARCH_ENDPOINT_URL = "https://${aws_opensearch_domain.os.endpoint}"
       REGION                  = var.region
       INDEX_NAME              = var.index_name
       S3_BUCKET               = var.s3_bucket
@@ -654,11 +642,6 @@ resource "aws_lambda_function" "augmentation_lambda" {
   image_uri     = "${aws_ecr_repository.augmentation_lambda.repository_url}:${var.augmentation_lambda_image_tag}"
   timeout       = var.augmentation_lambda_timeout
   memory_size   = var.augmentation_lambda_memory_size
-
-  vpc_config {
-    subnet_ids         = module.vpc.private_subnets
-    security_group_ids = [aws_security_group.lambda_sg.id]
-  }
 
   environment {
     variables = {


### PR DESCRIPTION
## Summary

- Strips `vpc_options` from the OpenSearch domain so it gets a public endpoint, and pulls the three Lambdas and the OSIS ingestion pipeline out of the VPC so they keep working against the public endpoint during the debug window.
- Adds an IP-gated `AllowDebugFromAllowlist` statement to the OpenSearch access policy, driven by two new `debug_allowed_ips` / `debug_iam_principals` variables (default `[]`, so the statement is a no-op when unset).
- Wires those variables to `TF_VAR_*` env vars in `deploy.yaml`, sourced from `DEBUG_ALLOWED_IPS` / `DEBUG_IAM_PRINCIPALS` repo secrets (HCL list literals, e.g. `[\"203.0.113.42/32\"]`).

## Warning — not meant to be merged permanently

Applying this **destroys and recreates** the OpenSearch domain (force-replace triggered by removing `vpc_options`), so all indexed data is lost and must be re-ingested via OSIS after apply. Revert this PR once debugging is done and re-apply to restore the VPC topology (which also destroys+recreates the domain).

## Test plan

- [x] Add `DEBUG_ALLOWED_IPS` and `DEBUG_IAM_PRINCIPALS` as GitHub repo secrets (HCL list literals)
- [x] Run the Deploy workflow with \`apply=false\` and verify the plan shows: domain replaced, VPC endpoint destroyed, three Lambdas + OSIS updated in place, one output removed, access policy updated with debug statement
- [x] Run the Deploy workflow with \`apply=true\`
- [x] From an allowlisted IP with the listed principal: \`awscurl --service es --region us-east-2 https://\$(terraform output -raw opensearch_endpoint)/_cat/indices?v\` returns 200
- [ ] From a non-allowlisted IP with the same principal: request returns 403
- [ ] Trigger a TTC Lambda invocation and confirm CloudWatch shows a successful OpenSearch query against the public endpoint
- [ ] Re-run OSIS and confirm it can write to the public domain