### PR TITLE
Try to speed up deploy workflow with caching

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -79,33 +79,58 @@ jobs:
           AUG_ECR_URL=$(terraform output -raw augmentation_ecr_repository_url)
           echo "aug_ecr_url=$AUG_ECR_URL" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Buildx
+        if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
+        uses: docker/setup-buildx-action@v4
+
       - name: Build and push Index Docker image
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        run: |
-          INDEX_ECR_URL="${{ steps.ecr-url.outputs.index_ecr_url }}"
-          docker build -f Dockerfile.index -t "$INDEX_ECR_URL:${{ github.sha }}" -t "$INDEX_ECR_URL:latest" --secret id=huggingface_token,env=HF_TOKEN .
-          docker push "$INDEX_ECR_URL:${{ github.sha }}"
-          docker push "$INDEX_ECR_URL:latest"
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.index
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          tags: |
+            ${{ steps.ecr-url.outputs.index_ecr_url }}:${{ github.sha }}
+            ${{ steps.ecr-url.outputs.index_ecr_url }}:latest
+          cache-from: type=gha,scope=index
+          cache-to: type=gha,mode=max,scope=index
+          secrets: |
+            "huggingface_token=${{ secrets.HF_TOKEN }}"
 
       - name: Build and push TTC Docker image
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        run: |
-          ECR_URL="${{ steps.ecr-url.outputs.ecr_url }}"
-          docker build -f Dockerfile.ttc -t "$ECR_URL:${{ github.sha }}" -t "$ECR_URL:latest" --secret id=huggingface_token,env=HF_TOKEN .
-          docker push "$ECR_URL:${{ github.sha }}"
-          docker push "$ECR_URL:latest"
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.ttc
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          tags: |
+            ${{ steps.ecr-url.outputs.ecr_url }}:${{ github.sha }}
+            ${{ steps.ecr-url.outputs.ecr_url }}:latest
+          cache-from: type=gha,scope=ttc
+          cache-to: type=gha,mode=max,scope=ttc
+          secrets: |
+            "huggingface_token=${{ secrets.HF_TOKEN }}"
 
       - name: Build and push Augmentation Docker image
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        run: |
-          AUG_ECR_URL="${{ steps.ecr-url.outputs.aug_ecr_url }}"
-          docker build -f Dockerfile.augmentation -t "$AUG_ECR_URL:${{ github.sha }}" -t "$AUG_ECR_URL:latest" .
-          docker push "$AUG_ECR_URL:${{ github.sha }}"
-          docker push "$AUG_ECR_URL:latest"
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.augmentation
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          tags: |
+            ${{ steps.ecr-url.outputs.aug_ecr_url }}:${{ github.sha }}
+            ${{ steps.ecr-url.outputs.aug_ecr_url }}:latest
+          cache-from: type=gha,scope=augmentation
+          cache-to: type=gha,mode=max,scope=augmentation
 
       - name: Terraform Plan
         if: ${{ !inputs.apply && !inputs.destroy || !(github.event_name == 'push' && github.ref_name == 'main') }}

--- a/Dockerfile.ttc
+++ b/Dockerfile.ttc
@@ -6,23 +6,11 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 # Install build tools for C++ extensions
 RUN microdnf install -y gcc-c++ make && microdnf clean all
 
-# Copy and install workspace packages in dependency order
-COPY ./packages/shared-models ${LAMBDA_TASK_ROOT}/shared-models
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/shared-models"
-
-COPY ./packages/lambda-handler ${LAMBDA_TASK_ROOT}/lambda-handler
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/lambda-handler"
-
-COPY ./packages/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code
-# Install CPU-only PyTorch to reduce image size (Lambda doesn't have GPUs)
+# Heavy, rarely-changing layers first so they stay cached across source changes.
+# Install CPU-only PyTorch before any workspace package — a transitive pin
+# could otherwise pull the full CUDA wheel before our override lands.
 RUN pip install --no-cache-dir torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code"
-
-COPY ./packages/text-to-code-lambda ${LAMBDA_TASK_ROOT}/text-to-code-lambda
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code-lambda"
-
-# Remove build tools no longer needed at runtime
-RUN rpm -e --nodeps gcc-c++ gcc cpp make && microdnf clean all && rm -rf /var/cache/*
+RUN pip install --no-cache-dir huggingface_hub
 
 # Download retriever at build time (private repo, needs token)
 RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
@@ -32,6 +20,22 @@ RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
 RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
     python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='NCHS/ttc-reranker-mvp', local_dir='/opt/reranker_model', ignore_patterns=['*.git*', '*.md', 'onnx/*', 'openvino/*', 'pytorch_model.bin', 'tf_model.h5', 'flax_model.msgpack', 'model.onnx'])" \
   && rm -rf /root/.cache/huggingface
+
+# Workspace packages (change frequently) come after the heavy layers.
+COPY ./packages/shared-models ${LAMBDA_TASK_ROOT}/shared-models
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/shared-models"
+
+COPY ./packages/lambda-handler ${LAMBDA_TASK_ROOT}/lambda-handler
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/lambda-handler"
+
+COPY ./packages/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code"
+
+COPY ./packages/text-to-code-lambda ${LAMBDA_TASK_ROOT}/text-to-code-lambda
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code-lambda"
+
+# Remove build tools no longer needed at runtime
+RUN rpm -e --nodeps gcc-c++ gcc cpp make && microdnf clean all && rm -rf /var/cache/*
 
 # Clean up package source copies
 RUN rm -rf ${LAMBDA_TASK_ROOT}/shared-models ${LAMBDA_TASK_ROOT}/lambda-handler ${LAMBDA_TASK_ROOT}/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code-lambda


### PR DESCRIPTION
Try to make our deploy workflow a bit faster by:
- Use `docker/build-push-action` with `gha` caching
- Reorder `Dockerfile.ttc` to put package and model downloads first so they get cached since they don't change often