### PR TITLE
Fix description_vector and loinc_type in query model and service

### DIFF
--- a/packages/text-to-code/src/text_to_code/models/query.py
+++ b/packages/text-to-code/src/text_to_code/models/query.py
@@ -29,9 +29,11 @@ class VectorSearchParams(BaseModel):
 
     vector: list[float] = Field(description="The vector to search for.")
     vector_field: str = Field(
-        default="descriptionVector", description="The field to perform the vector search on."
+        default="description_vector", description="The field to perform the vector search on."
     )
-    filter_field: str = Field(default="type", description="The field to filter on, e.g., 'type'.")
+    filter_field: str = Field(
+        default="loinc_type", description="The field to filter on, e.g., 'loinc_type'."
+    )
     data_field: DataField = Field(
         description="The value of the field to filter on, e.g., 'Lab Test Name Ordered' or 'Lab Test Name Resulted'."
     )

--- a/packages/text-to-code/src/text_to_code/services/query.py
+++ b/packages/text-to-code/src/text_to_code/services/query.py
@@ -7,7 +7,7 @@ class KNNQuery(pydantic.BaseModel):
     """Builds a KNN query."""
 
     field: str = pydantic.Field(
-        default="descriptionVector", description="The field to perform the vector search on."
+        default="description_vector", description="The field to perform the vector search on."
     )
     vector: list[float] = pydantic.Field(description="The vector to search for.")
     k: int = pydantic.Field(default=10, description="The number of nearest neighbors to retrieve.")
@@ -34,7 +34,9 @@ class TermsFilter(pydantic.BaseModel):
     codes of type "Observation" or "Both" for the lab test result data field.
     """
 
-    field: str = pydantic.Field(default="type", description="The field to filter on, e.g., 'type'.")
+    field: str = pydantic.Field(
+        default="loinc_type", description="The field to filter on, e.g., 'loinc_type'."
+    )
     value: list[str] = pydantic.Field(
         description="The value(s) to filter the specified field by, e.g., ['order','both'] or ['observation', 'both']."
     )

--- a/packages/text-to-code/tests/unit/models/test_query.py
+++ b/packages/text-to-code/tests/unit/models/test_query.py
@@ -47,8 +47,8 @@ class TestVectorSearchParams:
         data_field = DataField.LAB_TEST_NAME_ORDERED
         size = 5
         k = 3
-        custom_vector_field = "customVectorField"
-        custom_filter_field = "type"
+        custom_vector_field = "custom_vector_field"
+        custom_filter_field = "loinc_type"
         params = VectorSearchParams(
             vector=vector,
             data_field=data_field,

--- a/packages/text-to-code/tests/unit/test_query.py
+++ b/packages/text-to-code/tests/unit/test_query.py
@@ -7,10 +7,10 @@ from text_to_code.services.query import TermsFilter
 
 class TestKNNQuery:
     def test_knn_query_defaults(self):
-        query = KNNQuery(field="descriptionVector", vector=[0.1, 0.2, 0.3])
+        query = KNNQuery(field="description_vector", vector=[0.1, 0.2, 0.3])
         expected_opensearch_query = {
             "knn": {
-                "descriptionVector": {
+                "description_vector": {
                     "vector": [0.1, 0.2, 0.3],
                     "k": 10,
                 }
@@ -34,7 +34,7 @@ class TestKNNQuery:
 class TestTermFilter:
     def test_term_filter_defaults(self):
         filter = TermsFilter(value=["Order"])
-        expected_opensearch_query = {"terms": {"type": ["Order"]}}
+        expected_opensearch_query = {"terms": {"loinc_type": ["Order"]}}
         assert filter.to_opensearch() == expected_opensearch_query
 
     def test_term_filter_custom_field(self):
@@ -44,7 +44,7 @@ class TestTermFilter:
 
     def test_term_filter_multiple_values(self):
         filter = TermsFilter(value=["Order", "Observation"])
-        expected_opensearch_query = {"terms": {"type": ["Order", "Observation"]}}
+        expected_opensearch_query = {"terms": {"loinc_type": ["Order", "Observation"]}}
         assert filter.to_opensearch() == expected_opensearch_query
 
 
@@ -53,15 +53,15 @@ class TestQueryBuilder:
         size = 5
         vector = [0.1, 0.2, 0.3]
         data_field = DataField.LAB_TEST_NAME_ORDERED
-        vector_field = "descriptionVector"
+        vector_field = "description_vector"
         filter_value = ["Order", "Both"]
-        filter_field = "type"
+        filter_field = "loinc_type"
         k = 10
 
         expected_query = {
             "size": size,
             "_source": {
-                "excludes": ["descriptionVector"],
+                "excludes": ["description_vector"],
                 "includes": ["id", "loinc_code", "loinc_name_type", "description", "loinc_type"],
             },
             "query": {
@@ -101,18 +101,18 @@ class TestQueryBuilder:
         expected_query = {
             "size": 10,
             "_source": {
-                "excludes": ["descriptionVector"],
+                "excludes": ["description_vector"],
                 "includes": ["id", "loinc_code", "loinc_name_type", "description", "loinc_type"],
             },
             "query": {
                 "bool": {
                     "filter": [
-                        {"terms": {"type": ["Order", "Both"]}},
+                        {"terms": {"loinc_type": ["Order", "Both"]}},
                     ],
                     "must": [
                         {
                             "knn": {
-                                "descriptionVector": {
+                                "description_vector": {
                                     "vector": vector,
                                     "k": 10,
                                 }
@@ -132,13 +132,13 @@ class TestQueryBuilder:
     def test_query_builder_with_multiple_filters(self):
         vector = [0.1, 0.2, 0.3]
         data_field = DataField.LAB_TEST_NAME_ORDERED
-        filter_field = "type"
+        filter_field = "loinc_type"
         filter_value = ["Order", "Both"]
 
         expected_query = {
             "size": 10,
             "_source": {
-                "excludes": ["descriptionVector"],
+                "excludes": ["description_vector"],
                 "includes": ["id", "loinc_code", "loinc_name_type", "description", "loinc_type"],
             },
             "query": {
@@ -149,7 +149,7 @@ class TestQueryBuilder:
                     "must": [
                         {
                             "knn": {
-                                "descriptionVector": {
+                                "description_vector": {
                                     "vector": vector,
                                     "k": 10,
                                 }


### PR DESCRIPTION
## Description

Manual testing led us to discover that our query model and service had `descriptionVector` camel cased instead of snake cased, even though our index had it snake cased. We were also trying to filter by `type` instead of `loinc_type`. With these changes, we were able to generate a working query.
