### PR TITLE
refactor: Declassify embedder and reranker

### DIFF
--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -19,11 +19,11 @@ from text_to_code.models import Candidate
 from text_to_code.models import SchematronErrorDetail
 from text_to_code.models import query as query_models
 from text_to_code.services import eicr_processor
-from text_to_code.services import embedder
 from text_to_code.services import evaluator
-from text_to_code.services import reranker
 from text_to_code.services import schematron_processor
+from text_to_code.services.embedder import embed
 from text_to_code.services.query import QueryBuilder
+from text_to_code.services.reranker import rerank
 
 # Initialize the logger
 logger = Logger(service="ttc")
@@ -37,11 +37,6 @@ AWS_REGION = os.getenv("AWS_REGION")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
 OPENSEARCH_ENDPOINT_URL = os.getenv("OPENSEARCH_ENDPOINT_URL")
 OPENSEARCH_INDEX = os.getenv("OPENSEARCH_INDEX", "ttc-index")
-
-# Instantiate wrapper objects for the sentence-transformers models
-# to re-use across invocations
-RETRIEVER = embedder.Embedder()
-RERANKER = reranker.Reranker()
 
 # Constants
 NO_DATA_FIELDS_MESSAGE = (
@@ -290,7 +285,7 @@ def _process_schematron_errors(
             ttc_metadata_output["schematron_errors"][data_field].append(metadata_error)
             continue
 
-        vector_embedding = RETRIEVER.embed(selected_candidate.value)
+        vector_embedding = embed(selected_candidate.value)
 
         vector_parameters = query_models.VectorSearchParams(
             vector=vector_embedding.tolist(), data_field=data_field
@@ -310,7 +305,7 @@ def _process_schematron_errors(
         # text strings of the ANN LOINC codes
         results_list = opensearch_retrieved_scores.hits.hits
         retrieved_loinc_names = [hit.source.description for hit in results_list]
-        ranked_results = RERANKER.rerank(selected_candidate.value, retrieved_loinc_names)
+        ranked_results = rerank(selected_candidate.value, retrieved_loinc_names)
 
         if results_list:
             ttc_output["schematron_errors"][data_field].append(

--- a/packages/text-to-code-lambda/tests/test_lambda_function.py
+++ b/packages/text-to-code-lambda/tests/test_lambda_function.py
@@ -277,8 +277,8 @@ class TestHandler:
             return_value=None,
         )
 
-        retriever_embed_mock = mocker.patch.object(lambda_function.RETRIEVER, "embed")
-        reranker_mock = mocker.patch.object(lambda_function.RERANKER, "rerank")
+        retriever_embed_mock = mocker.patch.object(lambda_function, "embed")
+        reranker_mock = mocker.patch.object(lambda_function, "rerank")
 
         resp = lambda_function.handler(example_sqs_event, {})
 
@@ -370,7 +370,7 @@ class TestHandler:
         )
 
         reranker_mock = mocker.patch.object(
-            lambda_function.RERANKER,
+            lambda_function,
             "rerank",
             return_value=[],
         )

--- a/packages/text-to-code/src/text_to_code/services/embedder.py
+++ b/packages/text-to-code/src/text_to_code/services/embedder.py
@@ -6,16 +6,13 @@ from text_to_code.models.registry import TTC_RETRIEVER
 _RETRIEVER = SentenceTransformer(TTC_RETRIEVER)
 
 
-class Embedder:
-    """Transforms nonstandard text."""
+def embed(text: str) -> Tensor:
+    """Encode a text string into a vector representation.
 
-    def embed(self, text: str) -> Tensor:
-        """Encode a text string into a vector representation.
+    The dimensionality and values of the vector form are determined
+    by the application's default Retriever Model.
 
-        The dimensionality and values of the vector form are determined
-        by the application's default Retriever Model.
-
-        :param text: Text string to embed.
-        :returns: Tensor representation of input text.
-        """
-        return _RETRIEVER.encode(text)
+    :param text: Text string to embed.
+    :returns: Tensor representation of input text.
+    """
+    return _RETRIEVER.encode(text)

--- a/packages/text-to-code/src/text_to_code/services/reranker.py
+++ b/packages/text-to-code/src/text_to_code/services/reranker.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from sentence_transformers import CrossEncoder
 
 from text_to_code.models.registry import TTC_RERANKER
@@ -5,7 +7,14 @@ from text_to_code.models.registry import TTC_RERANKER
 _RERANKER = CrossEncoder(TTC_RERANKER)
 
 
-def rerank(nonstandard_in: str, hits: list[str]) -> list[dict]:
+class ScoredResult(TypedDict):
+    """The search result with its score."""
+
+    code_string: str
+    score: float
+
+
+def rerank(nonstandard_in: str, hits: list[str]) -> list[ScoredResult]:
     """Re-sorts hits by cross-encoder score values.
 
     Given a list of text strings returned from OpenSearch, score and sort
@@ -19,5 +28,7 @@ def rerank(nonstandard_in: str, hits: list[str]) -> list[dict]:
       scored search results, sorted in descending order of score.
     """
     ranks = _RERANKER.rank(nonstandard_in, hits)
-    sorted_ranks = [{"code_string": hits[r["corpus_id"]], "score": r["score"]} for r in ranks]
+    sorted_ranks: list[ScoredResult] = [
+        {"code_string": hits[r["corpus_id"]], "score": r["score"]} for r in ranks
+    ]
     return sorted_ranks

--- a/packages/text-to-code/src/text_to_code/services/reranker.py
+++ b/packages/text-to-code/src/text_to_code/services/reranker.py
@@ -5,22 +5,19 @@ from text_to_code.models.registry import TTC_RERANKER
 _RERANKER = CrossEncoder(TTC_RERANKER)
 
 
-class Reranker:
-    """Scores and sorts OpenSearch results."""
+def rerank(nonstandard_in: str, hits: list[str]) -> list[dict]:
+    """Re-sorts hits by cross-encoder score values.
 
-    def rerank(self, nonstandard_in: str, hits: list[str]) -> list[dict]:
-        """Re-sorts hits by cross-encoder score values.
+    Given a list of text strings returned from OpenSearch, score and sort
+    the search hits using the Text-to-Code system's default Reranker model.
+    The model will generate a cross-encoding score value measuring each
+    search result's information similarity to the original nonstandard input.
 
-        Given a list of text strings returned from OpenSearch, score and sort
-        the search hits using the Text-to-Code system's default Reranker model.
-        The model will generate a cross-encoding score value measuring each
-        search result's information similarity to the original nonstandard input.
-
-        :param nonstandard_in: The original narrative free-text input to TTC.
-        :param hits: The list of OpenSearch results, in text string form.
-        :returns: A list of dictionaries representing the newly cross-encoder
-          scored search results, sorted in descending order of score.
-        """
-        ranks = _RERANKER.rank(nonstandard_in, hits)
-        sorted_ranks = [{"code_string": hits[r["corpus_id"]], "score": r["score"]} for r in ranks]
-        return sorted_ranks
+    :param nonstandard_in: The original narrative free-text input to TTC.
+    :param hits: The list of OpenSearch results, in text string form.
+    :returns: A list of dictionaries representing the newly cross-encoder
+      scored search results, sorted in descending order of score.
+    """
+    ranks = _RERANKER.rank(nonstandard_in, hits)
+    sorted_ranks = [{"code_string": hits[r["corpus_id"]], "score": r["score"]} for r in ranks]
+    return sorted_ranks

--- a/packages/text-to-code/tests/unit/test_embedder.py
+++ b/packages/text-to-code/tests/unit/test_embedder.py
@@ -1,18 +1,14 @@
 import pytest
 
-from text_to_code.services.embedder import Embedder
+from text_to_code.services.embedder import embed
 
 
 class TestEmbedder:
-    @pytest.fixture(scope="class")
-    def embedder(self) -> Embedder:
-        return Embedder()
-
     @pytest.mark.parametrize(
         ("input_text"), ["Influenza virus A and B and SARS-CoV-2 (COVID-19)", "COVID"]
     )
-    def test_embed(self, embedder: Embedder, input_text: str) -> None:
-        embedding = embedder.embed(input_text)
+    def test_embed(self, input_text: str) -> None:
+        embedding = embed(input_text)
 
         expected_embedding_length = 1024
 

--- a/packages/text-to-code/tests/unit/test_reranker.py
+++ b/packages/text-to-code/tests/unit/test_reranker.py
@@ -1,19 +1,13 @@
-import pytest
-
-from text_to_code.services.reranker import Reranker
+from text_to_code.services.reranker import rerank
 
 
 class TestReranker:
-    @pytest.fixture(scope="class")
-    def reranker(self) -> Reranker:
-        return Reranker()
-
-    def test_reranker_empty_hits(self, reranker: Reranker) -> None:
-        ranks = reranker.rerank("Influenza virus A and B and SARS-CoV-2 (COVID-19)", [])
+    def test_reranker_empty_hits(self) -> None:
+        ranks = rerank("Influenza virus A and B and SARS-CoV-2 (COVID-19)", [])
         assert len(ranks) == 0
 
-    def test_reranker_single_search_result(self, reranker: Reranker) -> None:
-        ranks = reranker.rerank(
+    def test_reranker_single_search_result(self) -> None:
+        ranks = rerank(
             "Influenza virus A and B and SARS-CoV-2 (COVID-19)",
             ["Influenza virus A and B and SARS-CoV-2 (COVID-19)"],
         )
@@ -24,7 +18,7 @@ class TestReranker:
             {"code_string": "Influenza virus A and B and SARS-CoV-2 (COVID-19)", "score": 0.989}
         ]
 
-    def test_reranker_multiple_hits(self, reranker: Reranker) -> None:
+    def test_reranker_multiple_hits(self) -> None:
         nonstandard_in = "albumin/creatinine ratio (acr)"
         search_hits = [
             "Albumin/Creatinine [Ratio] in Urine",
@@ -32,7 +26,7 @@ class TestReranker:
             "Albumin/Creatinine [Ratio] in 24 hour Urine",
             "Albumin/Creatinine (U) [Molar ratio]",
         ]
-        ranks = reranker.rerank(nonstandard_in, search_hits)
+        ranks = rerank(nonstandard_in, search_hits)
         ranks = [
             {"code_string": r["code_string"], "score": round(float(r["score"]), 3)} for r in ranks
         ]

--- a/packages/utils/tests/test_path.py
+++ b/packages/utils/tests/test_path.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest.mock
 
 import pytest
+
 from utils import path as utils
 
 


### PR DESCRIPTION
## Description

Currently the embedder and reranker methods are in wrapper classes. There is no need for them to be in a class. Embedder has no state at all, and the reranker does have state but at the module level (which I suppose is a code smell, but seems reasonable for such a simple module in this situation).

Also adds a `ScoredResult` class for better typing of the `rerank` function.

## Related Issues

Closes # n/a

## Additional Notes
If anyone has  a reason to keep these classes, I'm open to keep them, but this seemed like a pretty easy little refactor that simplifies things a little with no downside.