### PR TITLE
fix(lambda): install utils package into lambda images

### DIFF
--- a/Dockerfile.augmentation
+++ b/Dockerfile.augmentation
@@ -14,6 +14,9 @@ RUN microdnf install -y gcc-c++ make && microdnf clean all
 COPY ./packages/shared-models ${LAMBDA_TASK_ROOT}/shared-models
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/shared-models"
 
+COPY ./packages/utils ${LAMBDA_TASK_ROOT}/utils
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/utils"
+
 COPY ./packages/lambda-handler ${LAMBDA_TASK_ROOT}/lambda-handler
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/lambda-handler"
 

--- a/Dockerfile.index
+++ b/Dockerfile.index
@@ -15,6 +15,9 @@ RUN microdnf install -y gcc-c++ make && microdnf clean all
 
 # Copy over just the pyproject.toml file and install the dependencies doing this
 # before copying the rest of the code allows for caching of the dependencies
+COPY ./packages/utils ${LAMBDA_TASK_ROOT}/utils
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/utils"
+
 COPY ./packages/lambda-handler ${LAMBDA_TASK_ROOT}/lambda-handler
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/lambda-handler"
 

--- a/Dockerfile.ttc
+++ b/Dockerfile.ttc
@@ -25,6 +25,9 @@ RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
 COPY ./packages/shared-models ${LAMBDA_TASK_ROOT}/shared-models
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/shared-models"
 
+COPY ./packages/utils ${LAMBDA_TASK_ROOT}/utils
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/utils"
+
 COPY ./packages/lambda-handler ${LAMBDA_TASK_ROOT}/lambda-handler
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/lambda-handler"
 
@@ -38,7 +41,7 @@ RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code-lambda"
 RUN rpm -e --nodeps gcc-c++ gcc cpp make && microdnf clean all && rm -rf /var/cache/*
 
 # Clean up package source copies
-RUN rm -rf ${LAMBDA_TASK_ROOT}/shared-models ${LAMBDA_TASK_ROOT}/lambda-handler ${LAMBDA_TASK_ROOT}/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code-lambda
+RUN rm -rf ${LAMBDA_TASK_ROOT}/shared-models ${LAMBDA_TASK_ROOT}/utils ${LAMBDA_TASK_ROOT}/lambda-handler ${LAMBDA_TASK_ROOT}/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code-lambda
 
 ENV RETRIEVER_MODEL_PATH="/opt/retriever_model"
 ENV RERANKER_MODEL_PATH="/opt/reranker_model"

--- a/packages/lambda-handler/pyproject.toml
+++ b/packages/lambda-handler/pyproject.toml
@@ -8,7 +8,11 @@ dependencies = [
   "opensearch-py>=2.0.0",
   "pydantic>=2.12.5",
   "requests_aws4auth>=1.3.1",
+  "utils",
 ]
+
+[tool.uv.sources]
+utils = { workspace = true }
 
 [dependency-groups]
 dev = ["moto"]

--- a/uv.lock
+++ b/uv.lock
@@ -851,6 +851,7 @@ dependencies = [
     { name = "opensearch-py" },
     { name = "pydantic" },
     { name = "requests-aws4auth" },
+    { name = "utils" },
 ]
 
 [package.dev-dependencies]
@@ -865,6 +866,7 @@ requires-dist = [
     { name = "opensearch-py", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "requests-aws4auth", specifier = ">=1.3.1" },
+    { name = "utils", editable = "packages/utils" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

The TTC Lambda has been failing at cold start with:

```
Runtime.ImportModuleError: Unable to import module 'text_to_code_lambda.lambda_function': No module named 'utils'
```

### Root cause

#491 (`refactor: Required environment variable logic`) added `from utils import get_env_variable` to `packages/lambda-handler/src/lambda_handler/lambda_handler.py` but did not declare `utils` as a dependency for any consumer that builds without the uv workspace on the path. In local dev / tests `utils` resolves via the workspace, but the lambda Dockerfiles install each workspace package individually with `pip install ./packages/<name>` and `utils` was never copied or installed — so `import lambda_handler` blows up at module load.

The traceback is misleading because AWS's `Runtime.ImportModuleError` only surfaces the top-level module name; the failing import is two hops in (`lambda_function` → `lambda_handler` → `utils`).

## Changes

- Declare `utils` as a workspace dependency of `lambda-handler` in `packages/lambda-handler/pyproject.toml` so the dependency is visible at the package level.
- `COPY` and `pip install` `packages/utils` ahead of `lambda-handler` in all three lambda Dockerfiles. (pip ignores `[tool.uv.sources]` and would otherwise try to fetch `utils` from PyPI.)
- Add `utils` to the cleanup `rm -rf` step in `Dockerfile.ttc` so the source copy doesn't ship in the image.

## Out of scope

`Dockerfile.app` (FastAPI service) builds its requirements from `packages/api/pyproject.toml` via `uv pip compile`. `packages/api/src/api/config.py` also imports `from utils import get_env_variable` and `api/pyproject.toml` does not list `utils` as a dependency, so the FastAPI image likely has the same latent issue. Leaving that for a separate PR since the failure mode and fix differ (uv-compile vs. multi-stage pip install).

## Test plan

- [ ] CI image builds for `Dockerfile.ttc`, `Dockerfile.augmentation`, `Dockerfile.index` succeed.
- [ ] `uv run pytest packages/lambda-handler/tests` passes (verified locally — 16/16).
- [ ] After deploy, TTC lambda cold-start no longer raises `Runtime.ImportModuleError`.