### PR TITLE
ops: Just test subcommand

### DIFF
--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -1,0 +1,13 @@
+set working-directory := '../..'
+
+[doc("Run unit tests, forwarding optional arguments to pytest")]
+unit *ARGS:
+    uv run pytest -m "not e2e" {{ ARGS }}
+
+[doc("Run e2e tests, forwarding optional arguments to pytest")]
+e2e *ARGS:
+    uv run pytest e -m "e2e" {{ ARGS }}
+
+[doc("Run all tests, forwarding optional arguments to pytest")]
+all *ARGS:
+    uv run pytest {{ ARGS }}

--- a/README.md
+++ b/README.md
@@ -177,19 +177,19 @@ export HF_TOKEN="hf_your_token_here"
 To run all the unit tests, use the following command:
 
 ```sh
-pytest -m \"not e2e\"
+just test unit
 ```
 
 To run a single unit test, use the following command:
 
 ```sh
-pytest tests/unit/test_utils.py::test_function
+just test unit tests/unit/test_utils.py::test_function
 ```
 
 To update snapshots:
 
 ```sh
-pytest --snapshot-update
+just test all --snapshot-update
 ```
 
 ### e2e Tests:
@@ -197,7 +197,7 @@ pytest --snapshot-update
 To run e2e tests, use the following command:
 
 ```sh
-pytest -m e2e
+just test e2e
 ```
 
 e2e test use [boto3](https://github.com/boto/boto3) to mock the various AWS systems we use: S3, SQS, and Lambdas. However, it currently does not simulate EventBridge invoking the Lambdas and passing them the SQS event, instead SQS event is manually built and passed to the lambda handler function.

--- a/justfile
+++ b/justfile
@@ -12,15 +12,15 @@ mod dev './.justscripts/just/dev.just'
 
 alias b := bootstrap
 
+[group('sub-command')]
+[doc('Testing commands')]
+mod test './.justscripts/just/test.just'
+
 [doc("Initialize the development environment")]
 bootstrap:
     uv sync --all-packages
     pre-commit install
     npm i --save-dev
-
-[doc("Run tests, forwarding optional arguments to pytest")]
-test *ARGS:
-    uv run pytest {{ ARGS }}
 
 [doc("Sync Python environment")]
 sync:


### PR DESCRIPTION
## Description

Creates a bunch of just commands related to testing under a test subcommand. Splitting this work from the benchmarking PR, as this is still relevant regardless if the benchmarking PR is merged.

## Related Issues

Closes # n/a