### PR TITLE
docs: Fix the Python badge to show our actual Python version bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # DIBBs Text to Code
 
 [![codecov](https://codecov.io/github/CDCgov/dibbs-text-to-code/graph/badge.svg)](https://codecov.io/github/CDCgov/dibbs-text-to-code)
-[![python](https://img.shields.io/badge/python-3.11%2B-yellow)](https://docs.python.org/3.11/)
+![python](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FCDCgov%2Fdibbs-text-to-code%2Frefs%2Fheads%2Fmain%2Fpyproject.toml)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 **General disclaimer** This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/cdc/#cdc_about_cio_mission-our-mission). GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.
 


### PR DESCRIPTION
## Description

Our Python version badge implies our repo will work with any version of Python >= 3.11. However, we in fact have an upper-bound of <3.13. This new baadge gets the bounds from the pyproject.toml automatically.

In addition, I added a Ruff badge. 

## Related Issues

Closes # n/a

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
