### PR TITLE
bug: Skip XML comment nodes when stripping namespaces in EicrProcessor

### DIFF
--- a/packages/text-to-code/src/text_to_code/services/eicr_processor.py
+++ b/packages/text-to-code/src/text_to_code/services/eicr_processor.py
@@ -155,8 +155,9 @@ def _create_xml_tree(xml: str) -> Element:
     """Remove all namespaces from an XML tree."""
     tree = etree.fromstring(xml.encode("utf-8"))
     for elem in tree.iter():
-        # Remove namespace from tag
-        elem.tag = etree.QName(elem).localname
+        # Skip comment nodes — their .tag is a callable, not a QName-compatible string
+        if not isinstance(elem, etree._Comment):
+            elem.tag = etree.QName(elem).localname
     # Remove namespace declarations
     etree.cleanup_namespaces(tree)
     return tree

--- a/packages/text-to-code/tests/unit/test_eicr_processor.py
+++ b/packages/text-to-code/tests/unit/test_eicr_processor.py
@@ -100,6 +100,16 @@ class TestBadEicr:
             EicrProcessor(eicr_output)
 
 
+class TestEicrWithInlineComments:
+    def test_eicr_with_inline_comments_does_not_crash(self):
+        eicr_path = EXAMPLE_EICRS_DIRECTORY / "test_eicr_covid.xml"
+        with eicr_path.open() as f:
+            eicr_output = f.read()
+
+        processor = EicrProcessor(eicr_output)
+        assert processor.eicr_metadata.eicr_id is not None
+
+
 class TestBasicEicrProcessor:
     @pytest.fixture(scope="class")
     def eicr_processor(self) -> EicrProcessor:


### PR DESCRIPTION
## Summary
- `EicrProcessor.__init__` crashed with `ValueError: Invalid input tag of type <class 'cython_function_or_method'>` when given an eICR containing in-body `<!-- ... -->` comments. APHL hit this while testing the deployed TTC Lambda.
- Root cause: `_create_xml_tree` walks every node from `tree.iter()` and calls `etree.QName(elem).localname`, but for comment nodes `elem.tag` is a callable (`etree.Comment`), not a QName-compatible string.
- Fix: skip comment nodes before calling `QName`, mirroring the guard already in place in the augmentation package's `clean_xml_tree` (`packages/augmentation/src/augmentation/services/eicr_utils.py`).
- Added a regression test that loads the existing comment-heavy `test_eicr_covid.xml` fixture (59 in-body comments) and asserts `EicrProcessor` constructs successfully and exposes a usable eICR ID.

## Test plan
- [x] `uv run pytest packages/text-to-code/tests/unit/test_eicr_processor.py` — 22 passed (21 prior + 1 new)
- [x] `ruff check packages/text-to-code` clean
- [x] `ty check packages/text-to-code` clean
- [x] Reproduced the original APHL failure locally; with the patch, the same eICR now parses cleanly and yields `eicr_id=mtgl-204-002-002442323-8888`
- [ ] After deploy: APHL retries the failing message and the Lambda processes it without raising