### PR TITLE
Add TF Config and Index Lambda Extension

### DIFF
--- a/docs/runbooks/reingest-loinc-embeddings.md
+++ b/docs/runbooks/reingest-loinc-embeddings.md
@@ -37,11 +37,11 @@ aws s3 ls s3://<bucket>/reingestion/
 
 In the GitLab UI: **CI/CD → Pipelines → Run pipeline** for the re-ingestion project. Provide variables:
 
-| Variable | Example | Notes |
-|---|---|---|
-| `EXPECTED_DOC_COUNT` | `123456` | From the embeddings manifest. |
-| `ENVIRONMENT` | `prod` | Targets the right AWS account / OpenSearch domain. |
-| `STABILITY_POLLS` | `3` | Optional; default is 3 (90s of stable count before completion). |
+| Variable             | Example  | Notes                                                           |
+| -------------------- | -------- | --------------------------------------------------------------- |
+| `EXPECTED_DOC_COUNT` | `123456` | From the embeddings manifest.                                   |
+| `ENVIRONMENT`        | `prod`   | Targets the right AWS account / OpenSearch domain.              |
+| `STABILITY_POLLS`    | `3`      | Optional; default is 3 (90s of stable count before completion). |
 
 The pipeline runs the 7 steps below.
 
@@ -79,7 +79,7 @@ Drain is complete when this returns `0`.
 
 ### Step 3 — Drop and recreate the index
 
-**Expected duration:** < 30 s.
+**Expected duration:** < 60 s.
 
 ```sh
 aws lambda invoke \
@@ -89,7 +89,18 @@ aws lambda invoke \
   /tmp/index-out.json
 ```
 
-The pipeline asserts the response payload contains:
+Then,
+
+```sh
+aws lambda invoke \
+  --function-name ttc-index-lambda \
+  --payload '{"action":"clear_result_cache"}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/index-out.json
+```
+
+For each command, the pipeline asserts the response payload contains:
+
 ```json
 { "statusCode": 200, "index_recreated": true }
 ```
@@ -129,10 +140,12 @@ curl -s -X GET "https://<opensearch-endpoint>/<index>/_count" \
 ```
 
 Completion criteria (both must hold):
+
 - Count is stable across `STABILITY_POLLS` consecutive polls (default 3 → 90 s).
 - Count ≥ `EXPECTED_DOC_COUNT`.
 
 **Watch:**
+
 - OpenSearch console → Indices → `ttc-index` doc count climbing.
 - OSIS pipeline metrics: `aws osis get-pipeline --pipeline-name ttc-ingestion-pipeline` → look for `recordsIn` / `recordsOut`.
 - OSIS audit log group: `/aws/vendedlogs/OpenSearchIngestion/ttc-ingestion-pipeline/audit`.
@@ -156,6 +169,7 @@ Completion criteria (both must hold):
 **Expected duration:** < 1 min.
 
 The pipeline:
+
 1. Runs a fixed KNN query against `ttc-index` and asserts ≥ 1 hit.
 2. Polls `ApproximateNumberOfMessages` on `ttc-lambda-queue` for 60 s and asserts the backlog is decreasing.
 3. Confirms `ApproximateNumberOfMessages` on `ttc-lambda-dlq` is unchanged from the pre-flight baseline.
@@ -164,28 +178,34 @@ The pipeline:
 
 ## Estimated total wall-clock
 
-| Phase | Time |
-|---|---|
-| Halt + drain | 0–20 min (typically 5–10) |
-| Drop + recreate index | < 1 min |
-| S3 swap | < 2 min |
-| OSIS ingest | 10–15 min |
-| Resume + verify | < 2 min |
-| **Total** | **~25–35 min** |
+| Phase                 | Time                      |
+| --------------------- | ------------------------- |
+| Halt + drain          | 0–20 min (typically 5–10) |
+| Drop + recreate index | < 1 min                   |
+| S3 swap               | < 2 min                   |
+| OSIS ingest           | 10–15 min                 |
+| Resume + verify       | < 2 min                   |
+| **Total**             | **~25–35 min**            |
 
 ## Manual rollback
 
-Use this if step 3, 4, or 5 fails *before* TTC has been resumed.
+Use this if step 3, 4, or 5 fails _before_ TTC has been resumed.
 
 ```sh
 # 1. Restore the previous embeddings
 aws s3 rm s3://<bucket>/ingestion/ --recursive
 aws s3 sync s3://<bucket>/ingestion-backup-<ts>/ s3://<bucket>/ingestion/
 
-# 2. Recreate the index from the backup contents (OSIS will reload them)
+# 2. Recreate both indices (Vector Search and Result Cache) from the backup contents (OSIS will reload them)
 aws lambda invoke \
   --function-name ttc-index-lambda \
   --payload '{"action":"clear_index"}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/index-out.json
+
+aws lambda invoke \
+  --function-name ttc-index-lambda \
+  --payload '{"action":"clear_result_cache"}' \
   --cli-binary-format raw-in-base64-out \
   /tmp/index-out.json
 
@@ -200,15 +220,15 @@ aws lambda put-function-concurrency \
 
 ## Recovery — pipeline failed partway
 
-| Failed step | Recovery |
-|---|---|
-| Step 1 | No state changed. Re-run pipeline. |
-| Step 2 | Halt is in place; nothing destructive yet. Wait for the stuck Lambda to finish, then re-run pipeline. |
-| Step 3 | Index drop failed. Rollback (above) is a no-op (index hasn't been emptied) — just resume TTC manually and re-run pipeline. |
-| Step 4 | Sync partially complete. Run manual rollback to restore from `ingestion-backup-<ts>/`, then re-run pipeline. |
-| Step 5 | OSIS not catching up. Investigate first; rollback is the same as step 6. |
-| Step 6 | **TTC is stuck halted.** Run the two AWS CLI commands manually and page on-call. |
-| Step 7 | Smoke test failed but TTC is running. Investigate logs; do not auto-rollback. |
+| Failed step | Recovery                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Step 1      | No state changed. Re-run pipeline.                                                                                         |
+| Step 2      | Halt is in place; nothing destructive yet. Wait for the stuck Lambda to finish, then re-run pipeline.                      |
+| Step 3      | Index drop failed. Rollback (above) is a no-op (index hasn't been emptied) — just resume TTC manually and re-run pipeline. |
+| Step 4      | Sync partially complete. Run manual rollback to restore from `ingestion-backup-<ts>/`, then re-run pipeline.               |
+| Step 5      | OSIS not catching up. Investigate first; rollback is the same as step 6.                                                   |
+| Step 6      | **TTC is stuck halted.** Run the two AWS CLI commands manually and page on-call.                                           |
+| Step 7      | Smoke test failed but TTC is running. Investigate logs; do not auto-rollback.                                              |
 
 ### Redriving DLQ messages
 
@@ -221,6 +241,7 @@ aws sqs start-message-move-task \
 ```
 
 Monitor:
+
 ```sh
 aws sqs list-message-move-tasks \
   --source-arn arn:aws:sqs:<region>:<account>:ttc-lambda-dlq

--- a/docs/spikes/502-reingestion-pause.md
+++ b/docs/spikes/502-reingestion-pause.md
@@ -24,17 +24,18 @@ A concrete mechanism for safely pausing TTC processing during re-ingestion, auto
 
 The operator drives a single GitLab pipeline. The pipeline is started **manually** for v1 (auto-trigger via S3 events is a future enhancement).
 
-| Step | Actor | Action | Verification |
-|---|---|---|---|
-| 1 | Operator | Upload new embeddings (NDJSON) to `s3://<bucket>/reingestion/`. | `aws s3 ls` or the AWS console shows the new files. |
-| 2 | Operator | Manually start the GitLab pipeline, supplying the expected document count as an input parameter (alternatively, we can hardcode this, but given LOINC updates, we probably want it to be configurable at trigger time). | Pipeline run begins. |
-| 3 | CI/CD | Capture current TTC reserved concurrency. Set TTC reserved concurrency to `0` **and** disable the TTC event source mapping. Augmentation is left running. | `get-function-concurrency` returns 0; `get-event-source-mapping` returns `State: Disabled`. |
-| 4 | CI/CD | Poll `ApproximateNumberOfMessagesNotVisible` on `ttc-lambda-queue` until it reaches 0. **Hard cap at 20 min** (15-min Lambda timeout + 5-min slop); fail loudly if exceeded. | CloudWatch metric / `get-queue-attributes`. |
-| 5 | CI/CD | Invoke `ttc-index-lambda` with payload `{"action":"clear_index"}`. | `statusCode == 200` and `index_recreated == true` in response payload. |
-| 6 | CI/CD | Empty `s3://<bucket>/ingestion/` (potentially taking a backup copy to `ingestion-backup-<ts>/`), then `aws s3 sync s3://<bucket>/reingestion/ s3://<bucket>/ingestion/`. The S3 ObjectCreated events feed the new SQS-driven OSIS source — see [OSIS reconfig](#osis-reconfiguration) below. | `aws s3 ls` shows new file set in `ingestion/`. |
-| 7 | CI/CD | Poll OpenSearch `GET /<index>/_count` every 30 s until: count is **stable for N consecutive polls** (recommend N = 3) **and** `≥ expected_count` supplied in step 2. Hard cap at 30 min. | `_count` API. |
-| 8 | CI/CD | Re-enable the TTC event source mapping; restore reserved concurrency to the value captured in step 3. | `State: Enabled`; concurrency restored. |
-| 9 | CI/CD | Smoke-test: run a fixed KNN query and assert non-zero hits; observe `ApproximateNumberOfMessages` on `ttc-lambda-queue` decreasing. | KNN result; queue depth trend. |
+| Step | Actor    | Action                                                                                                                                                                                                                                                                                       | Verification                                                                                |
+| ---- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 1    | Operator | Upload new embeddings (NDJSON) to `s3://<bucket>/reingestion/`.                                                                                                                                                                                                                              | `aws s3 ls` or the AWS console shows the new files.                                         |
+| 2    | Operator | Manually start the GitLab pipeline, supplying the expected document count as an input parameter (alternatively, we can hardcode this, but given LOINC updates, we probably want it to be configurable at trigger time).                                                                      | Pipeline run begins.                                                                        |
+| 3    | CI/CD    | Capture current TTC reserved concurrency. Set TTC reserved concurrency to `0` **and** disable the TTC event source mapping. Augmentation is left running.                                                                                                                                    | `get-function-concurrency` returns 0; `get-event-source-mapping` returns `State: Disabled`. |
+| 4    | CI/CD    | Poll `ApproximateNumberOfMessagesNotVisible` on `ttc-lambda-queue` until it reaches 0. **Hard cap at 20 min** (15-min Lambda timeout + 5-min slop); fail loudly if exceeded.                                                                                                                 | CloudWatch metric / `get-queue-attributes`.                                                 |
+| 5    | CI/CD    | Invoke `ttc-index-lambda` with payload `{"action":"clear_index"}`.                                                                                                                                                                                                                           | `statusCode == 200` and `index_recreated == true` in response payload.                      |
+| 6    | CI/CD    | Invoke `ttc-index-lambda` with payload `{"action":"clear_result_cache"}`.                                                                                                                                                                                                                    | `statusCode == 200` and `index_recreated == true` in response payload.                      |
+| 7    | CI/CD    | Empty `s3://<bucket>/ingestion/` (potentially taking a backup copy to `ingestion-backup-<ts>/`), then `aws s3 sync s3://<bucket>/reingestion/ s3://<bucket>/ingestion/`. The S3 ObjectCreated events feed the new SQS-driven OSIS source — see [OSIS reconfig](#osis-reconfiguration) below. | `aws s3 ls` shows new file set in `ingestion/`.                                             |
+| 8    | CI/CD    | Poll OpenSearch `GET /<index>/_count` every 30 s until: count is **stable for N consecutive polls** (recommend N = 3) **and** `≥ expected_count` supplied in step 2. Hard cap at 30 min.                                                                                                     | `_count` API.                                                                               |
+| 9    | CI/CD    | Re-enable the TTC event source mapping; restore reserved concurrency to the value captured in step 3.                                                                                                                                                                                        | `State: Enabled`; concurrency restored.                                                     |
+| 10   | CI/CD    | Smoke-test: run a fixed KNN query and assert non-zero hits; observe `ApproximateNumberOfMessages` on `ttc-lambda-queue` decreasing.                                                                                                                                                          | KNN result; queue depth trend.                                                              |
 
 Estimated total wall-clock: **~25–35 min** (drain ≤ 20 min, ingest 10–15 min, restore < 1 min).
 
@@ -62,7 +63,7 @@ With reserved concurrency at 0 and the ESM (event source mapping) still enabled,
 
 ### Index Lambda already supports atomic drop+recreate
 
-`packages/index-lambda/src/index_lambda/lambda_function.py:36-138` accepts `{"action": "clear_index"}` which deletes-then-creates the index in one invocation. No new code needed.
+`packages/index-lambda/src/index_lambda/lambda_function.py:36-138` accepts `{"action": "clear_index"}` and `{"action": "clear_result_cache"}`, each of which deletes-then-creates its respective index in one invocation. No new code needed.
 
 ### OSIS today uses 30-day scheduled scans
 
@@ -84,30 +85,32 @@ No `aws_cloudwatch_metric_alarm` or `aws_cloudwatch_dashboard` resources exist i
 
 The CI/CD job runs the AWS CLI directly (no Terraform run per pause/resume). To prevent IaC drift, the Terraform definitions of the ESM and the Lambda's `reserved_concurrent_executions` must use `lifecycle { ignore_changes = [enabled, reserved_concurrent_executions] }`. This is captured in [Follow-up tickets](#follow-up-tickets).
 
-| Option | Verdict | Rationale |
-|---|---|---|
-| A. Toggle `enabled` via Terraform | **Rejected** | Slow per pause/resume; requires Terraform credentials in CI/CD. |
-| B. `aws lambda update-event-source-mapping --no-enabled` | **Recommended (primary)** | Fast, clean stop of polling; in-flight drains naturally. Drift mitigated by `ignore_changes`. |
-| C. Feature-flag env var read at Lambda runtime | **Rejected** | Adds runtime complexity; messages still get invoked, hit OS, and must be NACKed; visibility-timeout interactions are messy. |
-| D. Reserved concurrency = 0 | **Recommended (secondary)** | APHL's stated preference. Used as defense-in-depth alongside (B). Note the in-flight-not-killed correction above. |
+| Option                                                   | Verdict                     | Rationale                                                                                                                   |
+| -------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| A. Toggle `enabled` via Terraform                        | **Rejected**                | Slow per pause/resume; requires Terraform credentials in CI/CD.                                                             |
+| B. `aws lambda update-event-source-mapping --no-enabled` | **Recommended (primary)**   | Fast, clean stop of polling; in-flight drains naturally. Drift mitigated by `ignore_changes`.                               |
+| C. Feature-flag env var read at Lambda runtime           | **Rejected**                | Adds runtime complexity; messages still get invoked, hit OS, and must be NACKed; visibility-timeout interactions are messy. |
+| D. Reserved concurrency = 0                              | **Recommended (secondary)** | APHL's stated preference. Used as defense-in-depth alongside (B). Note the in-flight-not-killed correction above.           |
 
 ### 2. How do we drain in-flight messages before dropping the index?
 
 Watch `ApproximateNumberOfMessagesNotVisible` on `ttc-lambda-queue`. Drain is complete when this value is 0. Worst-case duration is the Lambda timeout, **15 min** (900s — `terraform/main.tf:416-439`). The CI/CD job uses a hard cap of 20 min; if exceeded, the pipeline fails loudly without proceeding to the index drop.
 
-`ApproximateNumberOfMessages` (visible messages) will keep growing during the halt and is *not* a drain signal — it represents the backlog APHL has acknowledged is acceptable.
+`ApproximateNumberOfMessages` (visible messages) will keep growing during the halt and is _not_ a drain signal — it represents the backlog APHL has acknowledged is acceptable.
 
 ### 3. How do we detect OSIS ingestion completion?
 
 **Recommendation: poll `GET /<index>/_count` for stability + minimum-count gate.**
 
 Specifics:
+
 - Poll every 30s.
 - Require count to be stable across N consecutive polls (recommend N = 3 → 90s of stability).
 - Require count ≥ `expected_count`, supplied as a CI/CD parameter by the operator (read from a manifest produced by the model build).
 - Hard cap at 30 min.
 
 Alternatives considered:
+
 - **Shorten OSIS scan interval temporarily** — fragile, requires Terraform run to revert; obsolete after the OSIS reconfig below.
 - **CloudWatch Logs pattern matching on `/aws/osis/...`** — OSIS does not emit a deterministic completion marker.
 - **Sentinel "done" file via S3 event** — useful as a belt-and-suspenders signal; captured as an optional follow-up ticket.
@@ -125,7 +128,17 @@ aws lambda invoke \
   /tmp/index-out.json
 ```
 
-Then asserts the response payload contains `statusCode == 200` and `index_recreated == true`. The Lambda's existing `clear_index` branch in `packages/index-lambda/src/index_lambda/lambda_function.py:61-79` is a single delete-then-create, so no race window between drop and recreate.
+Followed by
+
+```sh
+aws lambda invoke \
+  --function-name ttc-index-lambda \
+  --payload '{"action":"clear_result_cache"}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/index-out.json
+```
+
+Then asserts each response payload contains `statusCode == 200` and `index_recreated == true`. The Lambda's existing `clear_index` branch in `packages/index-lambda/src/index_lambda/lambda_function.py:61-79` is a single delete-then-create, so no race window between drop and recreate.
 
 A TTC query that slips through between drop and first-document-load returns zero hits. Today the Lambda treats zero hits as a graceful "no match" and acks the SQS message (`packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py:299-338`) — bad data passes silently. With the ESM disabled (recommendation 1), this path is unreachable. As an additional safeguard, follow-up ticket 7 proposes failing the invocation when the index is empty/missing so any slip-through DLQs instead of silently degrading.
 
@@ -149,9 +162,9 @@ source:
         - bucket:
             name: ${bucket}
             filter:
-              include_prefix: ["${ingestion_prefix}"]
+              include_prefix: ['${ingestion_prefix}']
       scheduling:
-        interval: PT720H        # ← every 30 days
+        interval: PT720H # ← every 30 days
 ```
 
 Switch the source mode to **SQS-notification-driven**:
@@ -160,12 +173,13 @@ Switch the source mode to **SQS-notification-driven**:
 source:
   s3:
     notification_type: sqs
-    notification_source: eventbridge   # via S3 → EventBridge → SQS, or
-                                       # directly via S3 bucket notification → SQS
+    notification_source:
+      eventbridge # via S3 → EventBridge → SQS, or
+      # directly via S3 bucket notification → SQS
     sqs:
       queue_url: <new-osis-trigger-queue-url>
     codec:
-      ndjson: {}                       # existing codec
+      ndjson: {} # existing codec
 ```
 
 New AWS resources required (Terraform):
@@ -193,15 +207,15 @@ The trust policy uses the GitLab OIDC issuer. Captured in [Follow-up tickets](#f
 
 ## Failure modes and rollback
 
-| Failure | Detection | Response |
-|---|---|---|
-| Drain doesn't complete in 20 min | Step 4 timeout | Pipeline fails before any destructive action. Investigate why a Lambda invocation is running long; manually re-run pipeline once unstuck. No rollback needed. |
-| Index Lambda invocation fails | Step 5 non-200 | Pipeline fails. Re-enable ESM and restore concurrency immediately as a rollback. New embeddings still in `reingestion/`; no data loss. |
-| OSIS doesn't pick up new files | Step 7 count never rises | Check OSIS pipeline status (`get-pipeline`). If broken: copy `ingestion-backup-<ts>/` back to `ingestion/`, re-enable ESM, restore concurrency. Old embeddings are restored once OSIS catches up. |
-| Document count never reaches expected | Step 7 timeout | Same as above — restore from backup. |
-| Restore-concurrency / re-enable ESM step fails | Step 8 error | **Critical.** TTC stays halted. Manually run the two AWS CLI commands; alert on-call. |
-| TTC messages DLQ during halt despite ESM disable | DLQ alarm fires | Use `aws sqs start-message-move-task` to redrive once index is repopulated. |
-| Slip-through eICR processed against partial index | Smoke KNN returns degraded results | Identify affected eICRs (timestamp range from CloudWatch logs), reprocess them by re-publishing to the input prefix. Mitigated by ESM-disable (recommendation 1) and follow-up ticket 7. |
+| Failure                                           | Detection                          | Response                                                                                                                                                                                          |
+| ------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Drain doesn't complete in 20 min                  | Step 4 timeout                     | Pipeline fails before any destructive action. Investigate why a Lambda invocation is running long; manually re-run pipeline once unstuck. No rollback needed.                                     |
+| Index Lambda invocation fails                     | Step 5 non-200                     | Pipeline fails. Re-enable ESM and restore concurrency immediately as a rollback. New embeddings still in `reingestion/`; no data loss.                                                            |
+| OSIS doesn't pick up new files                    | Step 7 count never rises           | Check OSIS pipeline status (`get-pipeline`). If broken: copy `ingestion-backup-<ts>/` back to `ingestion/`, re-enable ESM, restore concurrency. Old embeddings are restored once OSIS catches up. |
+| Document count never reaches expected             | Step 7 timeout                     | Same as above — restore from backup.                                                                                                                                                              |
+| Restore-concurrency / re-enable ESM step fails    | Step 8 error                       | **Critical.** TTC stays halted. Manually run the two AWS CLI commands; alert on-call.                                                                                                             |
+| TTC messages DLQ during halt despite ESM disable  | DLQ alarm fires                    | Use `aws sqs start-message-move-task` to redrive once index is repopulated.                                                                                                                       |
+| Slip-through eICR processed against partial index | Smoke KNN returns degraded results | Identify affected eICRs (timestamp range from CloudWatch logs), reprocess them by re-publishing to the input prefix. Mitigated by ESM-disable (recommendation 1) and follow-up ticket 7.          |
 
 ## Out of scope
 

--- a/packages/index-lambda/src/index_lambda/lambda_function.py
+++ b/packages/index-lambda/src/index_lambda/lambda_function.py
@@ -16,8 +16,8 @@ class OpenSearchIndexMapping(TypedDict):
     data to-index), but these attributes are themselves required.
     """
 
-    settings: str
-    mappings: str
+    settings: dict
+    mappings: dict
 
 
 logger = Logger(service="index-lambda")

--- a/packages/index-lambda/src/index_lambda/lambda_function.py
+++ b/packages/index-lambda/src/index_lambda/lambda_function.py
@@ -36,16 +36,36 @@ INDEX_MAPPING = {
     },
 }
 
+RESULT_CACHE_INDEX_MAPPING = {
+    "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 1, "knn": False}},
+    "mappings": {
+        "properties": {
+            "cache_key": {"type": "keyword"},
+            "text": {"type": "keyword"},
+            "data_field": {"type": "keyword"},
+            "code": {"type": "object", "enabled": False},
+            "score": {"type": "float"},
+            "cached_at": {"type": "date"},
+        },
+    },
+}
+
 
 @logger.inject_lambda_context
 def handler(event: dict, context: LambdaContext) -> dict:
     """Lambda function to manage the OpenSearch index for LOINC code embeddings.
 
-    Supports two actions via the event dict:
+    Supports six actions via the event dict:
     - "clear_index": Deletes the existing index (if any) and recreates it empty.
       Use this before re-ingesting embeddings to avoid duplicates.
+    - "clear_result_cache": As above, but for the Result Cache index rather than
+      the Vector Search index.
     - "create_index" (default): Creates the index only if it doesn't exist,
       and self-heals incorrect mappings.
+    - "create_result_cache": As above, but for the Result Cache index.
+    - "set_slowlog": Changes logging parameters for AWS across multiple types
+      of logging information.
+    - "set_result_cache_slowlog": As above, but for the Result Cache index.
 
     :param event: The event dict passed by AWS Lambda. Reads "action" key.
     :param context: The context dict passed by AWS Lambda (not used).
@@ -53,42 +73,59 @@ def handler(event: dict, context: LambdaContext) -> dict:
     aws_auth = lambda_handler.create_aws_auth()
     os_client = lambda_handler.create_opensearch_client(aws_auth)
     index_name = get_env_variable("INDEX_NAME")
+    result_cache_index_name = get_env_variable("RESULT_CACHE_INDEX_NAME")
 
     action = event.get("action", "create_index") if event else "create_index"
-
+    logger_name = (
+        index_name
+        if action in ["create_index", "set_slowlog", "clear_index"]
+        else result_cache_index_name
+    )
     with logger.append_context_keys(
-        index_name=index_name,
+        index_name=logger_name,
         action=action,
     ):
         logger.info("Index Lambda started", status="processing")
 
         if action == "clear_index":
-            result = _clear_index(os_client, index_name)
+            result = _clear_index(os_client, index_name, INDEX_MAPPING, action)
+        elif action == "clear_result_cache":
+            result = _clear_index(
+                os_client, result_cache_index_name, RESULT_CACHE_INDEX_MAPPING, action
+            )
         elif action == "set_slowlog":
             result = _set_slowlog(os_client, index_name, event.get("threshold_ms", 0))
+        elif action == "set_result_cache_slowlog":
+            result = _set_slowlog(os_client, result_cache_index_name, event.get("threshold_ms", 0))
+        elif action == "create_index":
+            result = _create_index(os_client, index_name, INDEX_MAPPING)
         else:
-            result = _create_index(os_client, index_name)
+            result = _create_index(os_client, result_cache_index_name, RESULT_CACHE_INDEX_MAPPING)
 
         logger.info("Index Lambda completed", status="success")
 
         return result
 
 
-def _clear_index(os_client: OpenSearch, index_name: str) -> dict:
-    """Delete the index if it exists, then recreate it with correct mappings.
+def _clear_index(os_client: OpenSearch, index_name: str, index_mapping: dict, action: str) -> dict:
+    """Delete the specified index if it exists, then recreate it with the supplied mapping.
 
     :param os_client: The OpenSearch client
     :param index_name: The name of the index
+    :param index_mapping: The formally-specified mapping to create for this index.
+    :param action: The action from the event queue that kicked off the index clear.
+      We use this to specify appropriate logging information in the response.
     """
     deleted = False
     if os_client.indices.exists(index=index_name):
         os_client.indices.delete(index=index_name)
         deleted = True
 
-    os_client.indices.create(index=index_name, body=INDEX_MAPPING)
+    os_client.indices.create(index=index_name, body=index_mapping)
 
     logger.info(
         "OpenSearch index cleared",
+        index_name=index_name,
         index_deleted=deleted,
         index_recreated=True,
         status="success",
@@ -96,7 +133,8 @@ def _clear_index(os_client: OpenSearch, index_name: str) -> dict:
 
     return {
         "statusCode": 200,
-        "action": "clear_index",
+        "action": action,
+        "index_name": index_name,
         "index_deleted": deleted,
         "index_recreated": True,
     }
@@ -127,46 +165,42 @@ def _set_slowlog(os_client: OpenSearch, index_name: str, threshold_ms: int) -> d
         "action": "set_slowlog",
         "threshold_ms": threshold_ms,
         "index": index,
+        "index_name": index_name,
         "settings": settings,
         "mappings": mappings,
     }
 
 
-def _create_index(os_client: OpenSearch, index_name: str) -> dict:
-    """Create the index if it doesn't exist, self-healing incorrect mappings.
+def _create_index(os_client: OpenSearch, index_name: str, index_mapping: dict) -> dict:
+    """Create the specified index if it doesn't exist, self-healing incorrect mappings.
 
-    :param os_client: The OpenSearch client
-    :param index_name: The name of the index
+    :param os_client: The OpenSearch client.
+    :param index_name: The name of the index.
+    :param index_mapping: The properties mapping for the specified index.
     """
+    created = False
     if not os_client.indices.exists(index=index_name):
-        os_client.indices.create(index=index_name, body=INDEX_MAPPING)
-        logger.info("OpenSearch index created", status="success")
+        os_client.indices.create(index=index_name, body=index_mapping)
+        logger.info(f"OpenSearch index {index_name} created", status="success")
+        created = True
 
     status = os_client.indices.exists(index=index_name)
 
     settings = os_client.indices.get_settings(index=index_name)
     mappings = os_client.indices.get_mapping(index=index_name)
 
-    recreated = False
-    if (
-        mappings[index_name]["mappings"]["properties"].get("description_vector", {}).get("type")
-        != "knn_vector"
-    ):
-        os_client.indices.delete(index=index_name)
-        os_client.indices.create(index=index_name, body=INDEX_MAPPING)
-        recreated = True
-
     logger.info(
         "OpenSearch index validated",
+        index_name=index_name,
         index_exists=status,
-        index_recreated=recreated,
         status="success",
     )
 
     return {
         "statusCode": 200,
+        "index_name": index_name,
+        "ran_index_creation": created,
         "index_exists": status,
         "index_settings": settings,
         "index_mappings": mappings,
-        "index_recreated": recreated,
     }

--- a/packages/index-lambda/src/index_lambda/lambda_function.py
+++ b/packages/index-lambda/src/index_lambda/lambda_function.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from opensearchpy import OpenSearch
@@ -5,9 +7,22 @@ from opensearchpy import OpenSearch
 import lambda_handler
 from utils import get_env_variable
 
+
+class OpenSearchIndexMapping(TypedDict):
+    """Defines required dictionary properties for an OpenSearch Index Mapping.
+
+    Other attributes may be present, and each of these attributes may hold
+    dictionaries with unknown keys (since they're based on the shape of the
+    data to-index), but these attributes are themselves required.
+    """
+
+    settings: str
+    mappings: str
+
+
 logger = Logger(service="index-lambda")
 
-INDEX_MAPPING = {
+INDEX_MAPPING: OpenSearchIndexMapping = {
     "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 1, "knn": True}},
     "mappings": {
         "properties": {
@@ -36,7 +51,7 @@ INDEX_MAPPING = {
     },
 }
 
-RESULT_CACHE_INDEX_MAPPING = {
+RESULT_CACHE_INDEX_MAPPING: OpenSearchIndexMapping = {
     "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 1, "knn": False}},
     "mappings": {
         "properties": {
@@ -76,11 +91,7 @@ def handler(event: dict, context: LambdaContext) -> dict:
     result_cache_index_name = get_env_variable("RESULT_CACHE_INDEX_NAME")
 
     action = event.get("action", "create_index") if event else "create_index"
-    logger_name = (
-        index_name
-        if action in ["create_index", "set_slowlog", "clear_index"]
-        else result_cache_index_name
-    )
+    logger_name = result_cache_index_name if "result_cache" in action else index_name
     with logger.append_context_keys(
         index_name=logger_name,
         action=action,
@@ -94,20 +105,26 @@ def handler(event: dict, context: LambdaContext) -> dict:
                 os_client, result_cache_index_name, RESULT_CACHE_INDEX_MAPPING, action
             )
         elif action == "set_slowlog":
-            result = _set_slowlog(os_client, index_name, event.get("threshold_ms", 0))
+            result = _set_slowlog(os_client, index_name, event.get("threshold_ms", 0), action)
         elif action == "set_result_cache_slowlog":
-            result = _set_slowlog(os_client, result_cache_index_name, event.get("threshold_ms", 0))
+            result = _set_slowlog(
+                os_client, result_cache_index_name, event.get("threshold_ms", 0), action
+            )
         elif action == "create_index":
             result = _create_index(os_client, index_name, INDEX_MAPPING)
-        else:
+        elif action == "create_result_cache":
             result = _create_index(os_client, result_cache_index_name, RESULT_CACHE_INDEX_MAPPING)
+        else:
+            raise ValueError(f"Received unknown action: {action!r}")
 
         logger.info("Index Lambda completed", status="success")
 
         return result
 
 
-def _clear_index(os_client: OpenSearch, index_name: str, index_mapping: dict, action: str) -> dict:
+def _clear_index(
+    os_client: OpenSearch, index_name: str, index_mapping: OpenSearchIndexMapping, action: str
+) -> dict:
     """Delete the specified index if it exists, then recreate it with the supplied mapping.
 
     :param os_client: The OpenSearch client
@@ -140,7 +157,15 @@ def _clear_index(os_client: OpenSearch, index_name: str, index_mapping: dict, ac
     }
 
 
-def _set_slowlog(os_client: OpenSearch, index_name: str, threshold_ms: int) -> dict:
+def _set_slowlog(os_client: OpenSearch, index_name: str, threshold_ms: int, action: str) -> dict:
+    """Modify the slowlog settings for a specified index to change logging behavior.
+
+    :param os_client: The OpenSearch client
+    :param index_name: The name of the index
+    :param threshold_ms: The threshold in miliseconds that the log should use.
+    :param action: The action from the event queue that kicked off the index clear.
+      We use this to specify appropriate logging information in the response.
+    """
     index = os_client.indices.get(index=index_name)
     settings = os_client.indices.get_settings(index=index_name)
     mappings = os_client.indices.get_mapping(index=index_name)
@@ -162,7 +187,7 @@ def _set_slowlog(os_client: OpenSearch, index_name: str, threshold_ms: int) -> d
 
     return {
         "statusCode": 200,
-        "action": "set_slowlog",
+        "action": action,
         "threshold_ms": threshold_ms,
         "index": index,
         "index_name": index_name,
@@ -171,8 +196,10 @@ def _set_slowlog(os_client: OpenSearch, index_name: str, threshold_ms: int) -> d
     }
 
 
-def _create_index(os_client: OpenSearch, index_name: str, index_mapping: dict) -> dict:
-    """Create the specified index if it doesn't exist, self-healing incorrect mappings.
+def _create_index(
+    os_client: OpenSearch, index_name: str, index_mapping: OpenSearchIndexMapping
+) -> dict:
+    """Create the index if it doesn't exist; otherwise return the current settings and mappings.
 
     :param os_client: The OpenSearch client.
     :param index_name: The name of the index.
@@ -181,7 +208,7 @@ def _create_index(os_client: OpenSearch, index_name: str, index_mapping: dict) -
     created = False
     if not os_client.indices.exists(index=index_name):
         os_client.indices.create(index=index_name, body=index_mapping)
-        logger.info(f"OpenSearch index {index_name} created", status="success")
+        logger.info("OpenSearch index created", index_name=index_name, status="success")
         created = True
 
     status = os_client.indices.exists(index=index_name)

--- a/packages/index-lambda/tests/test_index_lambda_function.py
+++ b/packages/index-lambda/tests/test_index_lambda_function.py
@@ -1,73 +1,118 @@
 from index_lambda import lambda_function
 
 INDEX_NAME = "test-index"
+RESULT_CACHE_INDEX_NAME = "test-result-cache-index"
 SUCCESS_CODE = 200
 THRESHOLD_MS = 250
 
 
 class MockIndices:
-    def __init__(self, description_vector_type: str, *, initially_exists: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        description_vector_type: str | None = None,
+        index_initially_exists: bool = False,
+        result_cache_initially_exists: bool = False,
+    ) -> None:
         """Mock class for OpenSearch client's indices property."""
-        self._exists_calls = 0
-        self._initially_exists = initially_exists
-        self.description_vector_type = description_vector_type
-        self.delete_calls: list[str] = []
-        self.create_calls: list[str] = []
-        self.put_settings_calls: list[tuple[str, dict]] = []
+        self._exists_calls = {INDEX_NAME: 0, RESULT_CACHE_INDEX_NAME: 0}
+        self._initially_exists = {
+            INDEX_NAME: index_initially_exists,
+            RESULT_CACHE_INDEX_NAME: result_cache_initially_exists,
+        }
+        self.delete_calls: dict[list[str]] = {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
+        self.create_calls: dict[list[str]] = {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
+        self.put_settings_calls: dict[list[tuple[str, dict]]] = {
+            INDEX_NAME: [],
+            RESULT_CACHE_INDEX_NAME: [],
+        }
+        if description_vector_type is not None:
+            self.description_vector_type = description_vector_type
 
     def exists(self, index: str) -> bool:
         """Mock exists method that returns False on the first call and True on subsequent calls to simulate index creation."""
-        self._exists_calls += 1
-        if self._initially_exists:
+        self._exists_calls[index] += 1
+        if self._initially_exists[index]:
             return True
-        return self._exists_calls != 1
+        return self._exists_calls[index] != 1
 
     def create(self, index: str, body: dict) -> None:
         """Mock create method that tracks calls."""
-        self.create_calls.append(index)
+        self.create_calls[index].append(index)
 
     def delete(self, index: str) -> None:
         """Mock delete method that tracks calls."""
-        self.delete_calls.append(index)
+        self.delete_calls[index].append(index)
 
     def get(self, index: str) -> dict:
         """Mock get method that returns basic index metadata."""
-        return {INDEX_NAME: {"aliases": {}, "mappings": {}, "settings": {}}}
+        return {index: {"aliases": {}, "mappings": {}, "settings": {}}}
 
     def get_settings(self, index: str) -> dict:
-        """Mock get_settings method that returns a fixed settings dictionary."""
-        return {INDEX_NAME: {"settings": {"index": {"knn": "true"}}}}
+        """Mock get_settings method that returns a dummy settings dictionary."""
+        if index == INDEX_NAME:
+            return {index: {"settings": {"index": {"knn": "true"}}}}
+        if index == RESULT_CACHE_INDEX_NAME:
+            return {index: {"settings": {"index": {"knn": "false"}}}}
+        raise ValueError(f"Unexpected env var requested: {index}")
 
     def get_mapping(self, index: str) -> dict:
-        """Mock get_mapping method that returns a mapping dictionary with the specified description_vector type."""
-        return {
-            INDEX_NAME: {
-                "mappings": {
-                    "properties": {
-                        "description_vector": {"type": self.description_vector_type},
-                    },
+        """Mock get_mapping method that returns a mapping dictionary."""
+        if index == INDEX_NAME:
+            return {
+                index: {
+                    "mappings": {
+                        "properties": {
+                            "description_vector": {"type": self.description_vector_type},
+                        },
+                    }
                 }
             }
-        }
+        if index == RESULT_CACHE_INDEX_NAME:
+            return {
+                index: {
+                    "mappings": {
+                        "properties": {
+                            "cache_key": {"type": "keyword"},
+                        }
+                    }
+                }
+            }
+        raise ValueError(f"Unexpected env var requested: {index}")
 
     def put_settings(self, index: str, body: dict) -> None:
         """Mock put_settings method that tracks settings updates."""
-        self.put_settings_calls.append((index, body))
+        self.put_settings_calls[index].append((index, body))
 
 
 class MockOpenSearchClient:
-    def __init__(self, description_vector_type: str, *, initially_exists: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        description_vector_type: str | None = None,
+        index_initially_exists: bool = False,
+        result_cache_initially_exists: bool = False,
+    ) -> None:
         """Mock class for OpenSearch client."""
-        self.indices = MockIndices(description_vector_type, initially_exists=initially_exists)
+        self.indices = MockIndices(
+            description_vector_type=description_vector_type,
+            index_initially_exists=index_initially_exists,
+            result_cache_initially_exists=result_cache_initially_exists,
+        )
 
 
 def patch_lambda_handler(
     monkeypatch,
-    description_vector_type: str,
     *,
-    initially_exists: bool = False,
+    description_vector_type: str | None = None,
+    index_initially_exists: bool = False,
+    result_cache_initially_exists: bool = False,
 ) -> MockOpenSearchClient:
-    mock_client = MockOpenSearchClient(description_vector_type, initially_exists=initially_exists)
+    mock_client = MockOpenSearchClient(
+        description_vector_type=description_vector_type,
+        index_initially_exists=index_initially_exists,
+        result_cache_initially_exists=result_cache_initially_exists,
+    )
 
     def mock_create_aws_auth() -> object:
         """Mock create_aws_auth function that returns a dummy AWS auth object."""
@@ -81,6 +126,8 @@ def patch_lambda_handler(
         """Mock get_env_variable function that returns the INDEX_NAME for the INDEX_NAME variable."""
         if name == "INDEX_NAME":
             return INDEX_NAME
+        if name == "RESULT_CACHE_INDEX_NAME":
+            return RESULT_CACHE_INDEX_NAME
         raise ValueError(f"Unexpected env var requested: {name}")
 
     monkeypatch.setattr(lambda_function.lambda_handler, "create_aws_auth", mock_create_aws_auth)
@@ -94,15 +141,16 @@ def patch_lambda_handler(
 
 
 class TestHandler:
-    def test_handler_success(self, monkeypatch, mock_lambda_context):
-        """Test handler creates the index when it does not exist and returns expected response."""
-        patch_lambda_handler(monkeypatch, "knn_vector")
+    def test_handler_create_index_success(self, monkeypatch, mock_lambda_context):
+        """Test handler creates the vector search index when it does not exist and returns expected response."""
+        patch_lambda_handler(monkeypatch, description_vector_type="knn_vector")
 
         resp = lambda_function.handler({}, mock_lambda_context)
 
         assert resp["statusCode"] == SUCCESS_CODE
+        assert resp["index_name"] == INDEX_NAME
         assert resp["index_exists"] is True
-        assert resp["index_recreated"] is False
+        assert resp["ran_index_creation"] is True
         assert resp["index_settings"] == {INDEX_NAME: {"settings": {"index": {"knn": "true"}}}}
         assert resp["index_mappings"] == {
             INDEX_NAME: {
@@ -112,29 +160,33 @@ class TestHandler:
             }
         }
 
-    def test_handler_recreates_index_when_vector_mapping_incorrect(
-        self, monkeypatch, mock_lambda_context
-    ):
-        """Test handler recreates the index when description_vector mapping is not knn_vector."""
-        patch_lambda_handler(monkeypatch, "keyword")
+    def test_handler_create_result_cache_success(self, monkeypatch, mock_lambda_context):
+        """Test handler creates the result cache index when it already exists."""
+        patch_lambda_handler(monkeypatch, result_cache_initially_exists=True)
 
-        resp = lambda_function.handler({}, mock_lambda_context)
+        resp = lambda_function.handler({"action": "create_result_cache"}, mock_lambda_context)
 
         assert resp["statusCode"] == SUCCESS_CODE
-        assert resp["index_exists"] is True
-        assert resp["index_recreated"] is True
-        assert resp["index_settings"] == {INDEX_NAME: {"settings": {"index": {"knn": "true"}}}}
+        assert resp["index_name"] == RESULT_CACHE_INDEX_NAME
+        assert resp["ran_index_creation"] is False
+        assert resp["index_settings"] == {
+            RESULT_CACHE_INDEX_NAME: {"settings": {"index": {"knn": "false"}}}
+        }
         assert resp["index_mappings"] == {
-            INDEX_NAME: {
+            RESULT_CACHE_INDEX_NAME: {
                 "mappings": {
-                    "properties": {"description_vector": {"type": "keyword"}},
+                    "properties": {
+                        "cache_key": {"type": "keyword"},
+                    }
                 }
             }
         }
 
     def test_handler_clear_index_deletes_and_recreates(self, monkeypatch, mock_lambda_context):
         """Test clear_index action deletes existing index and recreates it."""
-        mock_client = patch_lambda_handler(monkeypatch, "knn_vector", initially_exists=True)
+        mock_client = patch_lambda_handler(
+            monkeypatch, description_vector_type="knn_vector", index_initially_exists=True
+        )
 
         resp = lambda_function.handler({"action": "clear_index"}, mock_lambda_context)
 
@@ -142,12 +194,36 @@ class TestHandler:
         assert resp["action"] == "clear_index"
         assert resp["index_deleted"] is True
         assert resp["index_recreated"] is True
-        assert mock_client.indices.delete_calls == [INDEX_NAME]
-        assert mock_client.indices.create_calls == [INDEX_NAME]
+        assert mock_client.indices.delete_calls == {
+            INDEX_NAME: [INDEX_NAME],
+            RESULT_CACHE_INDEX_NAME: [],
+        }
+        assert mock_client.indices.create_calls == {
+            INDEX_NAME: [INDEX_NAME],
+            RESULT_CACHE_INDEX_NAME: [],
+        }
+
+    def test_handler_clear_result_cache_without_initial_exist(
+        self, monkeypatch, mock_lambda_context
+    ):
+        """Test clear_result_cache action to clear the cache index when it doesn't exist initially."""
+        mock_client = patch_lambda_handler(monkeypatch)
+
+        resp = lambda_function.handler({"action": "clear_result_cache"}, mock_lambda_context)
+
+        assert resp["statusCode"] == SUCCESS_CODE
+        assert resp["action"] == "clear_result_cache"
+        assert resp["index_deleted"] is False
+        assert resp["index_recreated"] is True
+        assert mock_client.indices.delete_calls == {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
+        assert mock_client.indices.create_calls == {
+            INDEX_NAME: [],
+            RESULT_CACHE_INDEX_NAME: [RESULT_CACHE_INDEX_NAME],
+        }
 
     def test_handler_clear_index_when_no_existing_index(self, monkeypatch, mock_lambda_context):
         """Test clear_index action when the index doesn't exist yet."""
-        mock_client = patch_lambda_handler(monkeypatch, "knn_vector")
+        mock_client = patch_lambda_handler(monkeypatch, description_vector_type="knn_vector")
 
         resp = lambda_function.handler({"action": "clear_index"}, mock_lambda_context)
 
@@ -155,12 +231,17 @@ class TestHandler:
         assert resp["action"] == "clear_index"
         assert resp["index_deleted"] is False
         assert resp["index_recreated"] is True
-        assert mock_client.indices.delete_calls == []
-        assert mock_client.indices.create_calls == [INDEX_NAME]
+        assert mock_client.indices.delete_calls == {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
+        assert mock_client.indices.create_calls == {
+            INDEX_NAME: [INDEX_NAME],
+            RESULT_CACHE_INDEX_NAME: [],
+        }
 
     def test_handler_set_slowlog_updates_index_settings(self, monkeypatch, mock_lambda_context):
         """Test set_slowlog action updates slowlog thresholds and returns index metadata."""
-        mock_client = patch_lambda_handler(monkeypatch, "knn_vector", initially_exists=True)
+        mock_client = patch_lambda_handler(
+            monkeypatch, description_vector_type="knn_vector", index_initially_exists=True
+        )
 
         resp = lambda_function.handler(
             {"action": "set_slowlog", "threshold_ms": THRESHOLD_MS},
@@ -179,14 +260,17 @@ class TestHandler:
                 }
             }
         }
-        assert mock_client.indices.put_settings_calls == [
-            (
-                INDEX_NAME,
-                {
-                    "index.search.slowlog.threshold.query.warn": f"{THRESHOLD_MS}ms",
-                    "index.search.slowlog.threshold.query.info": f"{THRESHOLD_MS}ms",
-                    "index.search.slowlog.threshold.fetch.warn": f"{THRESHOLD_MS}ms",
-                    "index.search.slowlog.threshold.fetch.info": f"{THRESHOLD_MS}ms",
-                },
-            )
-        ]
+        assert mock_client.indices.put_settings_calls == {
+            INDEX_NAME: [
+                (
+                    INDEX_NAME,
+                    {
+                        "index.search.slowlog.threshold.query.warn": f"{THRESHOLD_MS}ms",
+                        "index.search.slowlog.threshold.query.info": f"{THRESHOLD_MS}ms",
+                        "index.search.slowlog.threshold.fetch.warn": f"{THRESHOLD_MS}ms",
+                        "index.search.slowlog.threshold.fetch.info": f"{THRESHOLD_MS}ms",
+                    },
+                )
+            ],
+            RESULT_CACHE_INDEX_NAME: [],
+        }

--- a/packages/index-lambda/tests/test_index_lambda_function.py
+++ b/packages/index-lambda/tests/test_index_lambda_function.py
@@ -1,3 +1,5 @@
+import pytest
+
 from index_lambda import lambda_function
 
 INDEX_NAME = "test-index"
@@ -20,9 +22,9 @@ class MockIndices:
             INDEX_NAME: index_initially_exists,
             RESULT_CACHE_INDEX_NAME: result_cache_initially_exists,
         }
-        self.delete_calls: dict[list[str]] = {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
-        self.create_calls: dict[list[str]] = {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
-        self.put_settings_calls: dict[list[tuple[str, dict]]] = {
+        self.delete_calls: dict[str, list[str]] = {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
+        self.create_calls: dict[str, list[str]] = {INDEX_NAME: [], RESULT_CACHE_INDEX_NAME: []}
+        self.put_settings_calls: dict[str, list[tuple[str, dict]]] = {
             INDEX_NAME: [],
             RESULT_CACHE_INDEX_NAME: [],
         }
@@ -141,6 +143,13 @@ def patch_lambda_handler(
 
 
 class TestHandler:
+    def test_handler_invalid_action(self, monkeypatch, mock_lambda_context):
+        """Test handler raises error if given an unknown or invalid action."""
+        patch_lambda_handler(monkeypatch, description_vector_type="knn_vector")
+
+        with pytest.raises(ValueError, match="Received unknown action: disallowed"):
+            lambda_function.handler({"action": "disallowed"}, mock_lambda_context)
+
     def test_handler_create_index_success(self, monkeypatch, mock_lambda_context):
         """Test handler creates the vector search index when it does not exist and returns expected response."""
         patch_lambda_handler(monkeypatch, description_vector_type="knn_vector")
@@ -161,7 +170,7 @@ class TestHandler:
         }
 
     def test_handler_create_result_cache_success(self, monkeypatch, mock_lambda_context):
-        """Test handler creates the result cache index when it already exists."""
+        """Test handler returns index metadata when result cache index already exists."""
         patch_lambda_handler(monkeypatch, result_cache_initially_exists=True)
 
         resp = lambda_function.handler({"action": "create_result_cache"}, mock_lambda_context)
@@ -273,4 +282,46 @@ class TestHandler:
                 )
             ],
             RESULT_CACHE_INDEX_NAME: [],
+        }
+
+    def test_handler_set_result_cache_slowlog(self, monkeypatch, mock_lambda_context):
+        """Test result cache can be updated using slowlog action."""
+        mock_client = patch_lambda_handler(monkeypatch, result_cache_initially_exists=True)
+
+        resp = lambda_function.handler(
+            {"action": "set_result_cache_slowlog", "threshold_ms": THRESHOLD_MS},
+            mock_lambda_context,
+        )
+
+        assert resp["statusCode"] == SUCCESS_CODE
+        assert resp["action"] == "set_result_cache_slowlog"
+        assert resp["threshold_ms"] == THRESHOLD_MS
+        assert resp["index"] == {
+            RESULT_CACHE_INDEX_NAME: {"aliases": {}, "mappings": {}, "settings": {}}
+        }
+        assert resp["settings"] == {
+            RESULT_CACHE_INDEX_NAME: {"settings": {"index": {"knn": "false"}}}
+        }
+        assert resp["mappings"] == {
+            RESULT_CACHE_INDEX_NAME: {
+                "mappings": {
+                    "properties": {
+                        "cache_key": {"type": "keyword"},
+                    }
+                }
+            }
+        }
+        assert mock_client.indices.put_settings_calls == {
+            INDEX_NAME: [],
+            RESULT_CACHE_INDEX_NAME: [
+                (
+                    RESULT_CACHE_INDEX_NAME,
+                    {
+                        "index.search.slowlog.threshold.query.warn": f"{THRESHOLD_MS}ms",
+                        "index.search.slowlog.threshold.query.info": f"{THRESHOLD_MS}ms",
+                        "index.search.slowlog.threshold.fetch.warn": f"{THRESHOLD_MS}ms",
+                        "index.search.slowlog.threshold.fetch.info": f"{THRESHOLD_MS}ms",
+                    },
+                )
+            ],
         }

--- a/packages/index-lambda/tests/test_index_lambda_function.py
+++ b/packages/index-lambda/tests/test_index_lambda_function.py
@@ -147,7 +147,7 @@ class TestHandler:
         """Test handler raises error if given an unknown or invalid action."""
         patch_lambda_handler(monkeypatch, description_vector_type="knn_vector")
 
-        with pytest.raises(ValueError, match="Received unknown action: disallowed"):
+        with pytest.raises(ValueError, match="Received unknown action: 'disallowed'"):
             lambda_function.handler({"action": "disallowed"}, mock_lambda_context)
 
     def test_handler_create_index_success(self, monkeypatch, mock_lambda_context):

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -69,9 +69,9 @@ Each Lambda function has its own IAM role scoped to least-privilege S3 permissio
 
 Deployed as a **container image** from ECR (`package_type = "Image"`) using `Dockerfile.index` at repo root. Responsible for creating the OpenSearch KNN Index and the OpenSearch Result Cache Index at deploy time. It is **invoked by Terraform** (`aws_lambda_invocation.index_bootstrap`) during `terraform apply`, before the ingestion pipeline is created.
 
-The first Index it creates--the Vector Search Index--has LOINC-specific field mappings including `description_vector` (1024-dimension `knn_vector` using HNSW/faiss/cosine), `loinc_type`, `loinc_code`, `loinc_name_type`, and other LOINC metadata fields. Uses the `lambda_handler` shared utilities and reads `OPENSEARCH_ENDPOINT_URL` from its environment.
+The first Index it creates–the Vector Search Index–has LOINC-specific field mappings including `description_vector` (1024-dimension `knn_vector` using HNSW/faiss/cosine), `loinc_type`, `loinc_code`, `loinc_name_type`, and other LOINC metadata fields. Uses the `lambda_handler` shared utilities and reads `OPENSEARCH_ENDPOINT_URL` from its environment.
 
-The second Index it creates--the Result Cache Index--contains the hashed results of previously computed embeddings and nearest neighbor queries, so that when the pipeline later receives eICRs containing a previously hashed value, the correct standardized code can simply be looked-up, rather than re-embedded and re-ranked. The Result Cache Index shares handling with the `lambda_handler` using the same functions but different actions than the Vector Search Index.
+The second Index it creates–the Result Cache Index–contains the hashed results of previously computed embeddings and nearest neighbor queries, so that when the pipeline later receives eICRs containing a previously hashed value, the correct standardized code can simply be looked-up, rather than re-embedded and re-ranked. The Result Cache Index shares handling with the `lambda_handler` using the same functions but different actions than the Vector Search Index.
 
 #### Main TTC Lambda (`ttc-lambda`, `Dockerfile.ttc`)
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -67,9 +67,11 @@ Each Lambda function has its own IAM role scoped to least-privilege S3 permissio
 
 #### Index Bootstrap Lambda (`ttc-index-lambda`, `packages/index-lambda`)
 
-Deployed as a **container image** from ECR (`package_type = "Image"`) using `Dockerfile.index` at repo root. Responsible for creating the OpenSearch KNN index at deploy time. It is **invoked by Terraform** (`aws_lambda_invocation.index_bootstrap`) during `terraform apply`, before the ingestion pipeline is created.
+Deployed as a **container image** from ECR (`package_type = "Image"`) using `Dockerfile.index` at repo root. Responsible for creating the OpenSearch KNN Index and the OpenSearch Result Cache Index at deploy time. It is **invoked by Terraform** (`aws_lambda_invocation.index_bootstrap`) during `terraform apply`, before the ingestion pipeline is created.
 
-The index it creates has LOINC-specific field mappings including `description_vector` (1024-dimension `knn_vector` using HNSW/faiss/cosine), `loinc_type`, `loinc_code`, `loinc_name_type`, and other LOINC metadata fields. Uses the `lambda_handler` shared utilities and reads `OPENSEARCH_ENDPOINT_URL` from its environment.
+The first Index it creates--the Vector Search Index--has LOINC-specific field mappings including `description_vector` (1024-dimension `knn_vector` using HNSW/faiss/cosine), `loinc_type`, `loinc_code`, `loinc_name_type`, and other LOINC metadata fields. Uses the `lambda_handler` shared utilities and reads `OPENSEARCH_ENDPOINT_URL` from its environment.
+
+The second Index it creates--the Result Cache Index--contains the hashed results of previously computed embeddings and nearest neighbor queries, so that when the pipeline later receives eICRs containing a previously hashed value, the correct standardized code can simply be looked-up, rather than re-embedded and re-ranked. The Result Cache Index shares handling with the `lambda_handler` using the same functions but different actions than the Vector Search Index.
 
 #### Main TTC Lambda (`ttc-lambda`, `Dockerfile.ttc`)
 
@@ -173,7 +175,7 @@ An **AWS OpenSearch Ingestion Service (OSIS)** pipeline (`aws_osis_pipeline.ttc_
 - Logs audit events to CloudWatch Logs (`/aws/vendedlogs/OpenSearchIngestion/ttc-ingestion-pipeline/audit-logs`, 14-day retention)
 - Scales between 1 and 4 OCUs (OpenSearch Compute Units)
 
-The pipeline **depends on** the index bootstrap invocation completing first, ensuring the KNN-enabled index exists before any data is loaded.
+The pipeline **depends on** the index bootstrap invocation completing first, ensuring the KNN-enabled index and the Result Cache Index exist before any data is loaded (wiping and refilling the Result Cache index as well as the normal Index for vector embeddings ensures that previously computed hashes do not survive either LOINC updates or model updates).
 
 Third-party deployers should ensure the following:
 
@@ -192,7 +194,7 @@ Terraform manages dependency ordering automatically, but conceptually the sequen
 3. Docker images built and pushed to ECR (in CI/CD, before full `terraform apply`)
 4. OpenSearch domain and VPC endpoint created
 5. Lambda IAM roles created (one per Lambda function)
-6. Index bootstrap Lambda deployed and **immediately invoked** — creates the KNN index in OpenSearch
+6. Index bootstrap Lambda deployed and **immediately invoked** — creates the KNN index and the Result Cache index in OpenSearch.
 7. Ingestion pipeline deployed — begins polling S3 for NDJSON embeddings to load
 8. Main TTC Lambda deployed with container image from ECR — loads model at cold start, ready to serve KNN queries
 9. Augmentation Lambda deployed with container image from ECR — ready to process augmentation requests

--- a/terraform/_variables.tf
+++ b/terraform/_variables.tf
@@ -101,7 +101,13 @@ variable "ingestion_prefix" {
 variable "index_name" {
   type        = string
   default     = "ttc-index"
-  description = "The name of the index in OpenSearch created by the index lambda function at deployment time"
+  description = "The name of the Vector Search index in OpenSearch created by the index lambda function at deployment time"
+}
+
+variable "result_cache_index_name" {
+  type        = string
+  default     = "ttc-result-cache"
+  description = "The name of the Result Cache index in OpenSearch created by the index lambda function at deployment time"
 }
 
 ### S3 Prefix Variables (for TTC Lambda)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -425,6 +425,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       OPENSEARCH_ENDPOINT_URL = "https://${aws_opensearch_domain.os.endpoint}"
       OPENSEARCH_INDEX        = var.index_name
+      RESULT_CACHE_INDEX      = var.result_cache_index_name
       REGION                  = var.region
       RETRIEVER_MODEL_PATH    = "/opt/retriever_model"
       RERANKER_MODEL_PATH     = "/opt/reranker_model"
@@ -590,7 +591,8 @@ resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
   EOT
 
   depends_on = [
-    aws_lambda_invocation.index_bootstrap
+    aws_lambda_invocation.index_bootstrap,
+    aws_lambda_invocation.result_cache_index_bootstrap
   ]
 }
 
@@ -612,6 +614,16 @@ resource "aws_lambda_invocation" "index_bootstrap" {
   depends_on = [aws_lambda_function.index_lambda]
 }
 
+resource "aws_lambda_invocation" "result_cache_index_bootstrap" {
+  function_name = aws_lambda_function.index_lambda.function_name
+  input = jsonencode({
+    action = "create_result_cache"
+    index  = var.result_cache_index_name
+  })
+
+  depends_on = [aws_lambda_function.index_lambda]
+}
+
 resource "aws_lambda_function" "index_lambda" {
   function_name = var.index_lambda_function_name
   role          = aws_iam_role.index_lambda_role.arn
@@ -624,6 +636,7 @@ resource "aws_lambda_function" "index_lambda" {
       OPENSEARCH_ENDPOINT_URL = "https://${aws_opensearch_domain.os.endpoint}"
       REGION                  = var.region
       INDEX_NAME              = var.index_name
+      RESULT_CACHE_INDEX_NAME = var.result_cache_index_name
       S3_BUCKET               = var.s3_bucket
     }
   }


### PR DESCRIPTION
## Description

This PR manages the terraform and the index lambda portion of creating a result cache for previously seen eICR inputs. In terraform, this change set includes:

* Adding a new environment variable for the result cache
* Creating a bootstrap function for the result cache index to initialize
* Adding the result cache bootstrap as a dependency to the pipeline
* Updating documentation (as well as spikes which reference the index procedures)

In the Index Lambda, this PR extends the existing functionality to also apply to the Result Cache index by defining some new actions (basically just counterparts of the Vector Search Index) and re-using functions there. Unit tests are updated and new tests are added accordingly.

Finally, our Index Lambda previously had a set of kruft code which was a carryover from our very first embedding trial. The block of code dealing with checking whether the OpenSearch Index had knn vectors in its property mappings (in the create function) is now no longer necessary: (1) the result cache index does not use KNN embeddings, and (2) (more importantly) the only reason this code was originally there is because our first AWS index upload back in September of 2025 did not have this property set correctly for some of its vectors. When we went to create the index, we had to do an additional check to see whether the index first needed to be deleted so things could be freshly set. Now, though, all of our vectors have the same uniform properties set, so this is a non-issue and will not be a problem going forward. The unit test dealing with this behavior has also been deleted.

## Related Issues

Partially addresses some tasks in #533 .
