### PR TITLE
Refresh Lambda base images and clear AWS Inspector findings

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+  schedule:
+    # Weekly rebuild so AWS-published base-image patches land without
+    # waiting for a code change. Mondays 10:00 UTC (6 AM ET / 3 AM PT).
+    - cron: "0 10 * * 1"
+
   workflow_dispatch:
     inputs:
       ref:
@@ -79,6 +84,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          pull: true
           platforms: linux/amd64
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile.ttc
+++ b/Dockerfile.ttc
@@ -12,6 +12,10 @@ RUN microdnf install -y gcc-c++ make && microdnf clean all
 RUN pip install --no-cache-dir torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir huggingface_hub
 
+# Torch's build environment can leave behind an older setuptools that shadows
+# the workspace pin and trips CVE-2025-47273. Upgrade explicitly.
+RUN pip install --no-cache-dir --upgrade 'setuptools>=78.1.1'
+
 # Download retriever at build time (private repo, needs token)
 RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
   python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='NCHS/ttc-retriever-mvp', local_dir='/opt/retriever_model', ignore_patterns=['*.git*', '*.md', 'onnx/*', 'openvino/*', 'pytorch_model.bin', 'tf_model.h5', 'flax_model.msgpack', 'model.onnx'])"

--- a/terraform/inspector.tf
+++ b/terraform/inspector.tf
@@ -1,0 +1,37 @@
+#############
+# Inspector v2 suppression rules
+#############
+# CVE-2026-3219 (pip TAR/ZIP confusion) has no upstream fix as of the review
+# date below. pip ships inside the public.ecr.aws/lambda/python:3.12 base
+# image but is never invoked at Lambda runtime, so the practical risk is nil.
+# Scope the suppression to our three ECR repos and revisit at the review date
+# in case pip publishes a fix or the base image stops shipping the affected
+# version.
+resource "aws_inspector2_filter" "pip_cve_2026_3219" {
+  name        = "ttc-suppress-pip-cve-2026-3219"
+  action      = "SUPPRESS"
+  description = "pip 25.x (CVE-2026-3219): no fix available; pip is not invoked at Lambda runtime. Review by 2026-08-10."
+  reason      = "Vulnerable code present in base image but not on the runtime execution path."
+
+  filter_criteria {
+    vulnerability_id {
+      comparison = "EQUALS"
+      value      = "CVE-2026-3219"
+    }
+
+    ecr_image_repository_name {
+      comparison = "EQUALS"
+      value      = aws_ecr_repository.ttc_lambda.name
+    }
+    ecr_image_repository_name {
+      comparison = "EQUALS"
+      value      = aws_ecr_repository.index_lambda.name
+    }
+    ecr_image_repository_name {
+      comparison = "EQUALS"
+      value      = aws_ecr_repository.augmentation_lambda.name
+    }
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
## Summary
- `pull: true` + weekly cron on `docker-image-push.yml` so AWS-published `public.ecr.aws/lambda/python:3.12` patches actually land instead of being shadowed by warm GHA build cache
- Upgrade `setuptools` in `Dockerfile.ttc` after torch installs to clear CVE-2025-47273 (torch leaves an older copy that shadows the `uv.lock` pin)
- New `terraform/inspector.tf` suppresses CVE-2026-3219 (pip — no upstream fix, not on the Lambda runtime path) scoped to the three ECR repos, with a 90-day review date in the description

Closes #548.

## Notes

- The weekly cron pushes refreshed `latest`/`main` tags to GHCR/APHL ECR, but production Lambdas will be pinned to commit-SHA tags after #547, so let's make sure the new release workflow also includes `pull: true`.
- The Inspector suppression rule requires `terraform apply` after merge.

## Test plan
- [ ] Confirm CI build picks up a newer base image (compare base layer digest in build logs before/after)
- [ ] Once deployed, re-run AWS Inspector and verify 0 High findings remain on the three ECR images
- [ ] After `terraform apply`, confirm CVE-2026-3219 is suppressed (Medium count drops accordingly)
- [ ] Verify the Monday 10:00 UTC scheduled run fires