### PR TITLE
ops: Fix just test e2e command

### DIFF
--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -6,7 +6,7 @@ unit *ARGS:
 
 [doc("Run e2e tests, forwarding optional arguments to pytest")]
 e2e *ARGS:
-    uv run pytest e -m "e2e" {{ ARGS }}
+    uv run pytest -m "e2e" {{ ARGS }}
 
 [doc("Run all tests, forwarding optional arguments to pytest")]
 all *ARGS:


### PR DESCRIPTION
## Description

There's a stray `e` in the `just test e2e` command causing it to fail.

## Related Issues

Closes # n/a
