### PR TITLE
refactor: simplify lambda handler functions by handling S3 client internally

### DIFF
--- a/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
+++ b/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
@@ -7,7 +7,6 @@ from aws_lambda_powertools.utilities.data_classes import SQSEvent
 from aws_lambda_powertools.utilities.data_classes import event_source
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from botocore.client import BaseClient
 
 import lambda_handler
 from augmentation.models import TTCAugmenterConfig
@@ -38,8 +37,6 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
     :param context: The AWS Lambda context object.
     :return: A dictionary containing processing results and any batch item failures.
     """
-    s3_client = lambda_handler.create_s3_client()
-
     logger.info("Received event", record_count=len(event["Records"]))
 
     failures = []
@@ -47,7 +44,7 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
 
     for record in event.records:
         try:
-            _process_record(record, s3_client)
+            _process_record(record)
             successes.append(record.message_id)
         except Exception as e:
             logger.exception(
@@ -83,7 +80,7 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
     return result
 
 
-def _process_record(record: SQSRecord, s3_client: BaseClient) -> None:
+def _process_record(record: SQSRecord) -> None:
     """Process a single SQS record containing an S3 event.
 
     :param record: The SQS record with an EventBridge S3 event in the body.
@@ -108,8 +105,8 @@ def _process_record(record: SQSRecord, s3_client: BaseClient) -> None:
     ):
         logger.info("Processing S3 object", status="processing")
 
-        ttc_output = _load_ttc_output(persistence_id, s3_client, bucket_name)
-        original_eicr = _load_original_eicr(persistence_id, s3_client, bucket_name)
+        ttc_output = _load_ttc_output(persistence_id, bucket_name)
+        original_eicr = _load_original_eicr(persistence_id, bucket_name)
         nonstandard_codes = _parse_nonstandard_codes(ttc_output)
 
         augmenter_input = TTCAugmenterInput(
@@ -135,11 +132,11 @@ def _process_record(record: SQSRecord, s3_client: BaseClient) -> None:
             metadata=metadata,
         )
 
-        _save_augmentation_outputs(persistence_id, output, s3_client, bucket_name)
+        _save_augmentation_outputs(persistence_id, output, bucket_name)
         logger.info("Augmentation processing completed", status="success")
 
 
-def _load_ttc_output(persistence_id: str, s3_client: BaseClient, bucket_name: str) -> dict:
+def _load_ttc_output(persistence_id: str, bucket_name: str) -> dict:
     """Load TTC output from S3.
 
     :param persistence_id: The persistence ID for the S3 object key.
@@ -155,12 +152,12 @@ def _load_ttc_output(persistence_id: str, s3_client: BaseClient, bucket_name: st
         status="processing",
     )
     content = lambda_handler.get_file_content_from_s3(
-        bucket_name=bucket_name, object_key=object_key, s3_client=s3_client
+        bucket_name=bucket_name, object_key=object_key
     )
     return json.loads(content)
 
 
-def _load_original_eicr(persistence_id: str, s3_client: BaseClient, bucket_name: str) -> str:
+def _load_original_eicr(persistence_id: str, bucket_name: str) -> str:
     """Load original eICR XML from S3.
 
     :param persistence_id: The persistence ID for the S3 object key.
@@ -175,9 +172,7 @@ def _load_original_eicr(persistence_id: str, s3_client: BaseClient, bucket_name:
         s3_key=object_key,
         status="processing",
     )
-    return lambda_handler.get_file_content_from_s3(
-        bucket_name=bucket_name, object_key=object_key, s3_client=s3_client
-    )
+    return lambda_handler.get_file_content_from_s3(bucket_name=bucket_name, object_key=object_key)
 
 
 def _parse_nonstandard_codes(ttc_output: dict) -> list[NonstandardCodeInstance]:
@@ -200,14 +195,12 @@ def _parse_nonstandard_codes(ttc_output: dict) -> list[NonstandardCodeInstance]:
 def _save_augmentation_outputs(
     persistence_id: str,
     output: TTCAugmenterOutput,
-    s3_client: BaseClient,
     bucket_name: str,
 ) -> None:
     """Save augmented eICR and metadata to S3.
 
     :param persistence_id: The persistence ID for the S3 object key.
     :param output: The augmentation output containing the augmented eICR and metadata.
-    :param s3_client: The S3 client to use for uploading files.
     :param bucket_name: The S3 bucket name to write to.
     """
     augmented_eicr_key = f"{AUGMENTED_EICR_PREFIX}{persistence_id}"
@@ -217,7 +210,6 @@ def _save_augmentation_outputs(
         file_obj=io.BytesIO(output.augmented_eicr.encode("utf-8")),
         bucket_name=bucket_name,
         object_key=augmented_eicr_key,
-        s3_client=s3_client,
     )
     logger.info(
         "Saved augmented eICR to S3",
@@ -230,7 +222,6 @@ def _save_augmentation_outputs(
         file_obj=io.BytesIO(output.metadata.model_dump_json().encode("utf-8")),
         bucket_name=bucket_name,
         object_key=augmentation_metadata_key,
-        s3_client=s3_client,
     )
 
     logger.info(

--- a/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
+++ b/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
@@ -102,7 +102,6 @@ class TestHandler:
         augmented_eicr = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
             object_key=f"{AUGMENTED_EICR_PREFIX}{TEST_PERSISTENCE_ID}",
-            s3_client=mock_aws_setup,
         )
         snapshot.assert_match(augmented_eicr, "handler_writes_outputs_augmented_eicr.xml")
 
@@ -110,7 +109,6 @@ class TestHandler:
         metadata_raw = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
             object_key=f"{AUGMENTATION_METADATA_PREFIX}{TEST_PERSISTENCE_ID}",
-            s3_client=mock_aws_setup,
         )
         metadata = json.loads(metadata_raw)
         snapshot.assert_match(
@@ -178,7 +176,6 @@ class TestHandler:
         augmented_eicr = lambda_handler.get_file_content_from_s3(
             bucket_name=custom_bucket,
             object_key=f"{AUGMENTED_EICR_PREFIX}{TEST_PERSISTENCE_ID}",
-            s3_client=mock_aws_setup,
         )
         snapshot.assert_match(
             augmented_eicr,

--- a/packages/index-lambda/src/index_lambda/lambda_function.py
+++ b/packages/index-lambda/src/index_lambda/lambda_function.py
@@ -50,8 +50,7 @@ def handler(event: dict, context: LambdaContext) -> dict:
     :param event: The event dict passed by AWS Lambda. Reads "action" key.
     :param context: The context dict passed by AWS Lambda (not used).
     """
-    aws_auth = lambda_handler.create_aws_auth()
-    os_client = lambda_handler.create_opensearch_client(aws_auth)
+    os_client = lambda_handler.create_opensearch_client()
     index_name = get_env_variable("INDEX_NAME")
 
     action = event.get("action", "create_index") if event else "create_index"

--- a/packages/index-lambda/tests/test_index_lambda_function.py
+++ b/packages/index-lambda/tests/test_index_lambda_function.py
@@ -73,7 +73,7 @@ def patch_lambda_handler(
         """Mock create_aws_auth function that returns a dummy AWS auth object."""
         return object()
 
-    def mock_create_opensearch_client(aws_auth: object) -> MockOpenSearchClient:
+    def mock_create_opensearch_client() -> MockOpenSearchClient:
         """Mock create_opensearch_client function that returns a MockOpenSearchClient."""
         return mock_client
 

--- a/packages/lambda-handler/src/lambda_handler/lambda_handler.py
+++ b/packages/lambda-handler/src/lambda_handler/lambda_handler.py
@@ -1,5 +1,5 @@
 import os
-import typing
+from typing import BinaryIO
 
 import boto3
 from aws_lambda_powertools import Logger
@@ -90,7 +90,7 @@ def create_s3_client() -> BaseClient:
     return _cached_s3_client
 
 
-def create_opensearch_client(aws_auth: AWS4Auth | None = None) -> OpenSearch:
+def create_opensearch_client() -> OpenSearch:
     """Creates an OpenSearch client.
 
     :param aws_auth: AWS4Auth object for authentication
@@ -100,7 +100,7 @@ def create_opensearch_client(aws_auth: AWS4Auth | None = None) -> OpenSearch:
 
     if _cached_opensearch_client is None:
         endpoint_url = get_env_variable("OPENSEARCH_ENDPOINT_URL")
-        auth = aws_auth or create_aws_auth()
+        auth = create_aws_auth()
         _cached_opensearch_client = OpenSearch(
             hosts=[{"host": strip_protocol(endpoint_url), "port": 443}],
             http_auth=auth,
@@ -113,17 +113,14 @@ def create_opensearch_client(aws_auth: AWS4Auth | None = None) -> OpenSearch:
     return _cached_opensearch_client
 
 
-def get_file_content_from_s3(
-    bucket_name: str, object_key: str, s3_client: BaseClient | None = None
-) -> str:
+def get_file_content_from_s3(bucket_name: str, object_key: str) -> str:
     """Extracts the file content from an S3 bucket.
 
     :param bucket_name: The name of the S3 bucket.
     :param object_key: The key of the S3 object.
-    :param s3_client: Optional pre-created S3 client. If None, a new client is created.
     :return: The content of the file as a string.
     """
-    client = s3_client or create_s3_client()
+    client = create_s3_client()
 
     logger.info(
         "Retrieving file content from S3",
@@ -171,20 +168,14 @@ def get_eventbridge_data_from_s3_event(event: lambda_events.EventBridgeEvent) ->
     return {"bucket_name": bucket_name, "object_key": object_key}
 
 
-def put_file(
-    file_obj: typing.BinaryIO,
-    bucket_name: str,
-    object_key: str,
-    s3_client: BaseClient | None = None,
-) -> None:
+def put_file(file_obj: BinaryIO, bucket_name: str, object_key: str) -> None:
     """Uploads a file object to a S3 bucket.
 
     :param file_obj: The file object to upload.
     :param bucket_name: The name of the S3 bucket to upload to.
     :param object_key: The key to assign to the uploaded object in S3.
-    :param s3_client: Optional pre-created S3 client. If None, a new client is created.
     """
-    client = s3_client or create_s3_client()
+    client = create_s3_client()
     logger.info(
         "Uploading file to S3",
         bucket_name=bucket_name,

--- a/packages/lambda-handler/tests/test_lambda_handler.py
+++ b/packages/lambda-handler/tests/test_lambda_handler.py
@@ -134,8 +134,7 @@ class TestCreateOpenSearchClient:
     def test_create_opensearch_client(self, moto_setup):
         """Test create OpenSearch client."""
         expected_port = 443  # The expected default port for the OpenSearch client.
-        auth = lambda_handler.create_aws_auth()
-        client = lambda_handler.create_opensearch_client(auth)
+        client = lambda_handler.create_opensearch_client()
 
         assert client.transport.hosts[0]["host"] == "test-opensearch-endpoint.com"
         assert client.transport.hosts[0]["port"] == expected_port

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -9,7 +9,6 @@ from aws_lambda_powertools.utilities.data_classes import SQSEvent
 from aws_lambda_powertools.utilities.data_classes import SQSRecord
 from aws_lambda_powertools.utilities.data_classes import event_source
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from botocore.client import BaseClient
 from opensearchpy import OpenSearch
 
 import lambda_handler
@@ -53,9 +52,7 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
     :param context: The Lambda context object.
     :return: A dictionary containing the status code, message, and any relevant data about the processing results.
     """
-    auth = lambda_handler.create_aws_auth()
-    opensearch_client = lambda_handler.create_opensearch_client(auth)
-    s3_client = lambda_handler.create_s3_client()
+    opensearch_client = lambda_handler.create_opensearch_client()
 
     logger.info("Received event", record_count=len(event["Records"]), status="processing")
 
@@ -64,7 +61,7 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
 
     for record in event.records:
         try:
-            process_record(record, s3_client, opensearch_client)
+            process_record(record, opensearch_client)
             successes.append(record.message_id)
         except Exception as e:
             logger.exception(
@@ -100,7 +97,7 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
     return result
 
 
-def process_record(record: SQSRecord, s3_client: BaseClient, opensearch_client: OpenSearch) -> None:
+def process_record(record: SQSRecord, opensearch_client: OpenSearch) -> None:
     """Process each SQS record.
 
     :param record: The SQS record to process
@@ -133,7 +130,7 @@ def process_record(record: SQSRecord, s3_client: BaseClient, opensearch_client: 
         trigger_s3_key=object_key,
     ):
         logger.info("Processing TTC event", status="processing")
-        _process_record_pipeline(persistence_id, s3_client, opensearch_client, bucket_name)
+        _process_record_pipeline(persistence_id, opensearch_client, bucket_name)
 
 
 def _initialize_ttc_outputs(persistence_id: str) -> tuple[dict, dict]:
@@ -160,13 +157,10 @@ def _initialize_ttc_outputs(persistence_id: str) -> tuple[dict, dict]:
     return ttc_output, ttc_metadata_output
 
 
-def _load_schematron_data_fields(
-    persistence_id: str, s3_client: BaseClient, bucket_name: str
-) -> list:
+def _load_schematron_data_fields(persistence_id: str, bucket_name: str) -> list:
     """Load Schematron errors from S3 and extract relevant fields.
 
     :param persistence_id: The persistence ID extracted from the S3 object key
-    :param s3_client: The S3 client to use for fetching files.
     :param bucket_name: The S3 bucket name to read from.
     :return: The relevant Schematron data fields for TTC processing.
     """
@@ -180,7 +174,6 @@ def _load_schematron_data_fields(
     schematron_errors = lambda_handler.get_file_content_from_s3(
         bucket_name=bucket_name,
         object_key=object_key,
-        s3_client=s3_client,
     )
 
     # Process Schematron errors to identify relevant data fields for TTC processing
@@ -188,7 +181,7 @@ def _load_schematron_data_fields(
     return schematron_processor.get_data_fields_from_schematron_error(schematron_errors)
 
 
-def _load_original_eicr(persistence_id: str, s3_client: BaseClient, bucket_name: str) -> str:
+def _load_original_eicr(persistence_id: str, bucket_name: str) -> str:
     """Load the original eICR from S3.
 
     :param persistence_id: The persistence ID extracted from the S3 object key
@@ -204,7 +197,7 @@ def _load_original_eicr(persistence_id: str, s3_client: BaseClient, bucket_name:
         status="processing",
     )
     original_eicr_content = lambda_handler.get_file_content_from_s3(
-        bucket_name=bucket_name, object_key=object_key, s3_client=s3_client
+        bucket_name=bucket_name, object_key=object_key
     )
     logger.info("Retrieved eICR content", status="success")
     return original_eicr_content
@@ -368,14 +361,12 @@ def _process_schematron_errors(
 def _save_ttc_metadata_output(
     persistence_id: str,
     ttc_metadata_output: dict,
-    s3_client: BaseClient,
     bucket_name: str,
 ) -> None:
     """Save TTC metadata output to S3.
 
     :param persistence_id: The persistence ID extracted from the S3 object key
     :param ttc_metadata_output: The TTC metadata output dictionary.
-    :param s3_client: The S3 client to use for uploading files.
     :param bucket_name: The S3 bucket name to write to.
     """
     metadata_key = f"{TTC_METADATA_PREFIX}{persistence_id.removesuffix('.xml')}.json"
@@ -390,7 +381,6 @@ def _save_ttc_metadata_output(
         file_obj=io.BytesIO(json.dumps(ttc_metadata_output, default=str).encode("utf-8")),
         bucket_name=bucket_name,
         object_key=metadata_key,
-        s3_client=s3_client,
     )
     logger.info(
         "Saved TTC metadata output to S3",
@@ -404,7 +394,6 @@ def _save_ttc_outputs(
     persistence_id: str,
     ttc_output: dict,
     ttc_metadata_output: dict,
-    s3_client: BaseClient,
     bucket_name: str,
 ) -> None:
     """Save TTC output and metadata output to S3.
@@ -412,7 +401,6 @@ def _save_ttc_outputs(
     :param persistence_id: The persistence ID extracted from the S3 object key
     :param ttc_output: The TTC output dictionary.
     :param ttc_metadata_output: The TTC metadata output dictionary.
-    :param s3_client: The S3 client to use for uploading files.
     :param bucket_name: The S3 bucket name to write to.
     """
     # Save the TTC output to S3 for the Augmentation Lambda to consume
@@ -426,7 +414,6 @@ def _save_ttc_outputs(
         file_obj=io.BytesIO(json.dumps(ttc_output, default=str).encode("utf-8")),
         bucket_name=bucket_name,
         object_key=f"{TTC_OUTPUT_PREFIX}{persistence_id}",
-        s3_client=s3_client,
     )
     logger.info(
         "Saved TTC output to S3",
@@ -436,12 +423,11 @@ def _save_ttc_outputs(
     )
 
     # Save the TTC metadata output for completing model evaluation and analysis of TTC results
-    _save_ttc_metadata_output(persistence_id, ttc_metadata_output, s3_client, bucket_name)
+    _save_ttc_metadata_output(persistence_id, ttc_metadata_output, bucket_name)
 
 
 def _process_record_pipeline(
     persistence_id: str,
-    s3_client: BaseClient,
     opensearch_client: OpenSearch,
     bucket_name: str,
 ) -> dict:
@@ -460,14 +446,13 @@ def _process_record_pipeline(
         - Creating the metadata object to save in S3 for analysis of TTC results
 
     :param persistence_id: The persistence ID extracted from the S3 object key
-    :param s3_client: The S3 client to use for S3 operations.
     :param opensearch_client: The OpenSearch client.
     :param bucket_name: The S3 bucket name extracted from the triggering event.
     """
     ttc_output, ttc_metadata_output = _initialize_ttc_outputs(persistence_id)
 
     logger.info("Starting TTC processing", status="processing")
-    schematron_data_fields = _load_schematron_data_fields(persistence_id, s3_client, bucket_name)
+    schematron_data_fields = _load_schematron_data_fields(persistence_id, bucket_name)
 
     if not schematron_data_fields:
         logger.warning(
@@ -476,7 +461,7 @@ def _process_record_pipeline(
         )
         ttc_output["message"] = NO_DATA_FIELDS_MESSAGE
         ttc_metadata_output["reason_for_skipping"] = NO_DATA_FIELDS_MESSAGE
-        _save_ttc_metadata_output(persistence_id, ttc_metadata_output, s3_client, bucket_name)
+        _save_ttc_metadata_output(persistence_id, ttc_metadata_output, bucket_name)
         logger.info("TTC processing completed", status="no_matches_found")
         return {
             "statusCode": 200,
@@ -484,7 +469,7 @@ def _process_record_pipeline(
             "result": "no_matches_found",
         }
 
-    original_eicr_content = _load_original_eicr(persistence_id, s3_client, bucket_name)
+    original_eicr_content = _load_original_eicr(persistence_id, bucket_name)
     processor = eicr_processor.EicrProcessor(original_eicr_content)
     _populate_eicr_metadata(processor, ttc_output, ttc_metadata_output)
     _process_schematron_errors(
@@ -494,7 +479,7 @@ def _process_record_pipeline(
         ttc_output,
         ttc_metadata_output,
     )
-    _save_ttc_outputs(persistence_id, ttc_output, ttc_metadata_output, s3_client, bucket_name)
+    _save_ttc_outputs(persistence_id, ttc_output, ttc_metadata_output, bucket_name)
 
     has_matches = any(len(matches) > 0 for matches in ttc_output["schematron_errors"].values())
 

--- a/packages/text-to-code-lambda/tests/test_lambda_function.py
+++ b/packages/text-to-code-lambda/tests/test_lambda_function.py
@@ -108,12 +108,10 @@ class TestHandler:
             "schematron_errors": {},
             "processed_at": "<processed_at>",
         }
-        s3_client = lambda_handler.create_s3_client()
 
         lambda_function._save_ttc_metadata_output(
             persistence_id=mock_aws_setup.persistence_id,
             ttc_metadata_output=ttc_metadata_output,
-            s3_client=s3_client,
             bucket_name=S3_BUCKET,
         )
 
@@ -399,11 +397,8 @@ class TestHandler:
             return_value=None,
         )
 
-        s3_client = lambda_handler.create_s3_client()
-
         resp = lambda_function._process_record_pipeline(
             persistence_id=mock_aws_setup.persistence_id,
-            s3_client=s3_client,
             opensearch_client=mock_opensearch,
             bucket_name=S3_BUCKET,
         )


### PR DESCRIPTION
## Description

Currently the lambda handler functions accept an S3 Client a parameter. However the Lambda Handler already creates a an S3 client internally and we do not have a use case where we would need to pass in a different client. Removing this parameter simplifies the Lambda handler, and the TTC and Augmentation Lambda functions.

## Related Issues

Closes # n/a

## Additional Notes

This comes out of the refactoring in [544](https://github.com/CDCgov/dibbs-text-to-code/pull/544).