### PR TITLE
refactor: make all models frozen

### DIFF
--- a/packages/augmentation/src/augmentation/models/application.py
+++ b/packages/augmentation/src/augmentation/models/application.py
@@ -1,8 +1,6 @@
 from enum import Enum
 
-from pydantic import BaseModel
-from pydantic import ConfigDict
-
+from shared_models import FrozenBaseModel
 from shared_models import NonstandardCodeInstance
 
 
@@ -32,7 +30,7 @@ class NonstandardCodeInstanceMetadata(NonstandardCodeInstance):
     """XPath to the translation added to the augmented eICR with the standard code."""
 
 
-class Metadata(BaseModel):
+class Metadata(FrozenBaseModel):
     """Model to hold augmentation metadata."""
 
     original_eicr_id: str
@@ -42,13 +40,8 @@ class Metadata(BaseModel):
     error: str | None = None
 
 
-class TTCAugmenterOutput(BaseModel):
+class TTCAugmenterOutput(FrozenBaseModel):
     """Output of the augmentation service."""
-
-    model_config = ConfigDict(
-        frozen=True,
-        extra="forbid",
-    )
 
     persistence_id: str
     augmented_eicr: str

--- a/packages/augmentation/src/augmentation/models/config.py
+++ b/packages/augmentation/src/augmentation/models/config.py
@@ -1,24 +1,19 @@
-from pydantic import BaseModel
-from pydantic import ConfigDict
+from pydantic import Field
 from pydantic import model_validator
 
 from shared_models import DataField
+from shared_models import FrozenBaseModel
 
 from .application import ApplicationCode
 from .document import DocumentType
 
 
-class AugmenterConfig(BaseModel):
+class AugmenterConfig(FrozenBaseModel):
     """Basic configuration controlling augmentation behavior."""
 
     # TODO: this is very much a shell and can be modified
     #  in the ticket related to creating an Augmenter config model
     #  and retrieving said config from S3 Bucket
-
-    model_config = ConfigDict(
-        frozen=True,
-        extra="forbid",
-    )
 
     application_code: ApplicationCode
     document_type: DocumentType
@@ -35,20 +30,22 @@ class TTCAugmenterConfig(AugmenterConfig):
     # TODO:
     # this is just an example of what the rules for eICR augmentation might look like
     # typically we should expect these to come from the configuration in S3
-    rules: dict = {
-        "document": [
-            "document_id_header",
-            "author_header",
-        ],
-        DataField.LAB_TEST_NAME_ORDERED: [
-            "author_entry",
-            "translation",
-        ],
-        DataField.LAB_TEST_NAME_RESULTED: [
-            "author_entry",
-            "translation",
-        ],
-    }
+    rules: dict = Field(
+        default={
+            "document": [
+                "document_id_header",
+                "author_header",
+            ],
+            DataField.LAB_TEST_NAME_ORDERED: [
+                "author_entry",
+                "translation",
+            ],
+            DataField.LAB_TEST_NAME_RESULTED: [
+                "author_entry",
+                "translation",
+            ],
+        }
+    )
     # TODO: The function code is currently a constant (used for both lab orders and results), but will need to be dynamic when additional fields with different function codes are introduced.
     author_function_code: str = "code-text-to-code"
     author_function_code_system: str = "2.16.840.1.113883.10.20.15.2.7.1"

--- a/packages/lambda-handler/src/lambda_handler/lambda_handler.py
+++ b/packages/lambda-handler/src/lambda_handler/lambda_handler.py
@@ -11,8 +11,11 @@ from opensearchpy import OpenSearch
 from opensearchpy import RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
+from lambda_handler.models.opensearch import OpenSearchHitSource
 from utils import get_env_variable
 
+from .models import OpenSearchHit
+from .models import OpenSearchHits
 from .models import OpenSearchResult
 
 logger = Logger(service="lambda-handler", child=True)
@@ -290,4 +293,29 @@ def retrieve_opensearch_results(
         status="success",
     )
 
-    return OpenSearchResult(**response)
+    hits_json = response["hits"]
+    hits = OpenSearchHits(
+        total=hits_json["total"],
+        hits=[
+            OpenSearchHit(
+                _index=hit["_index"],
+                _id=hit["_id"],
+                _score=hit["_score"],
+                _source=OpenSearchHitSource(
+                    id=hit["_source"]["id"],
+                    loinc_code=hit["_source"]["loinc_code"],
+                    loinc_name_type=hit["_source"]["loinc_name_type"],
+                    description=hit["_source"]["description"],
+                    loinc_type=hit["_source"]["loinc_type"],
+                ),
+            )
+            for hit in hits_json["hits"]
+        ],
+    )
+
+    return OpenSearchResult(
+        took=response["took"],
+        timed_out=response["timed_out"],
+        _shards=response["_shards"],
+        hits=hits,
+    )

--- a/packages/lambda-handler/src/lambda_handler/models/opensearch.py
+++ b/packages/lambda-handler/src/lambda_handler/models/opensearch.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel
 from pydantic import Field
 
+from shared_models import FrozenBaseModel
 
-class OpenSearchHitSource(BaseModel):
+
+class OpenSearchHitSource(FrozenBaseModel):
     """Represents a single search result _source returned from OpenSearch."""
 
     id: int = Field(description="The unique ID from the embedding data of the search result hit.")
@@ -14,7 +15,7 @@ class OpenSearchHitSource(BaseModel):
     loinc_type: str = Field(description="The LOINC type of the search result hit.")
 
 
-class OpenSearchHit(BaseModel):
+class OpenSearchHit(FrozenBaseModel):
     """Represents a single search result hit returned from OpenSearch."""
 
     index: str = Field(
@@ -29,10 +30,10 @@ class OpenSearchHit(BaseModel):
     )
 
 
-class OpenSearchHits(BaseModel):
+class OpenSearchHits(FrozenBaseModel):
     """Represents all of the search result hits returned from OpenSearch."""
 
-    total_hits: dict[str, str | int] = Field(
+    total: dict[str, str | int] = Field(
         alias="total", description="The total number of hits returned from OpenSearch."
     )
     hits: list[OpenSearchHit] = Field(
@@ -40,7 +41,7 @@ class OpenSearchHits(BaseModel):
     )
 
 
-class OpenSearchShards(BaseModel):
+class OpenSearchShards(FrozenBaseModel):
     """Represents the shard information returned from OpenSearch."""
 
     total: int = Field(description="The total number of shards involved in the search.")
@@ -49,7 +50,7 @@ class OpenSearchShards(BaseModel):
     failed: int = Field(description="The number of shards that failed to return results.")
 
 
-class OpenSearchResult(BaseModel):
+class OpenSearchResult(FrozenBaseModel):
     """Represents the overall search result returned from OpenSearch, including hits and shard information."""
 
     took: int = Field(description="The time taken to execute the search in milliseconds.")

--- a/packages/shared-models/src/shared_models/__init__.py
+++ b/packages/shared-models/src/shared_models/__init__.py
@@ -4,7 +4,16 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 
 
-class CdaInstanceIdentifier(BaseModel):
+class FrozenBaseModel(BaseModel):
+    """A custom base model that all other models can inherit so that they are frozen and do not allow extra attributes."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+    )
+
+
+class CdaInstanceIdentifier(FrozenBaseModel):
     """CDA Instance Identifier (II) data type.
 
     https://build.fhir.org/ig/HL7/CDA-core-2.0/StructureDefinition-II.html
@@ -24,13 +33,8 @@ class DataField(StrEnum):
     LAB_TEST_NAME_ORDERED = "Lab Test Name Ordered"
 
 
-class Code(BaseModel):
+class Code(FrozenBaseModel):
     """Model for CDA "ConceptDescriptor". This is the type of the new translation."""
-
-    model_config = ConfigDict(
-        frozen=True,
-        extra="forbid",
-    )
 
     code: str | None = None
     code_system: str | None = None
@@ -41,13 +45,8 @@ class Code(BaseModel):
     original_text: str | None = None
 
 
-class NonstandardCodeInstance(BaseModel):
+class NonstandardCodeInstance(FrozenBaseModel):
     """Model with the information needed to update a nonstandard code."""
-
-    model_config = ConfigDict(
-        frozen=True,
-        extra="forbid",
-    )
 
     schematron_error: str
     """The text of the Schematron error. This is only needed so that the augmentation metadata can save it."""
@@ -59,12 +58,8 @@ class NonstandardCodeInstance(BaseModel):
     """The new translation."""
 
 
-class TTCAugmenterInput(BaseModel):
+class TTCAugmenterInput(FrozenBaseModel):
     """Input for the augmentation service."""
 
-    model_config = ConfigDict(
-        frozen=True,
-        extra="forbid",
-    )
     persistence_id: str
     nonstandard_codes: list[NonstandardCodeInstance]

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -290,7 +290,7 @@ def _process_schematron_errors(
             candidates=text_candidates, criteria=criteria
         )
 
-        error.candidate = selected_candidate
+        error_with_candidate = error.model_copy(update={"candidate": selected_candidate})
 
         logger.info(
             "Embedding the relevant text strings for each error in the eICR",
@@ -298,11 +298,11 @@ def _process_schematron_errors(
         )
 
         if selected_candidate is None:
-            unmatched_error = error.model_dump()
+            unmatched_error = error_with_candidate.model_dump()
             unmatched_error["reason"] = "No relevant text candidate was selected"
             ttc_output["unmatched_schematron_errors"][data_field].append(unmatched_error)
 
-            metadata_error = error.model_dump()
+            metadata_error = error_with_candidate.model_dump()
             metadata_error["reason"] = "No relevant text candidate was selected"
             ttc_metadata_output["schematron_errors"][data_field].append(metadata_error)
             continue

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/handler_no_opensearch_hits_ttc_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/handler_no_opensearch_hits_ttc_metadata_output.json
@@ -5,7 +5,7 @@
   "schematron_errors": {
     "Lab Test Name Ordered": [
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Ordered does not have a @code attribute",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/observation[1]",
@@ -18,7 +18,7 @@
         "reranker_processed_results": []
       },
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Ordered code and translation data elements @codeSystem attribute are not LOINC 2.16.840.1.113883.6.1",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/observation[1]",
@@ -33,7 +33,7 @@
     ],
     "Lab Test Name Resulted": [
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Resulted does not have a @code attribute",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/organizer[1]/component[1]/observation[1]",
@@ -46,7 +46,7 @@
         "reranker_processed_results": []
       },
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Resulted code and translation data elements @codeSystem attribute are not LOINC 2.16.840.1.113883.6.1",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[6]/section[1]/entry[1]/organizer[1]/component[1]/observation[1]",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/handler_no_opensearch_hits_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/handler_no_opensearch_hits_ttc_output.json
@@ -8,7 +8,7 @@
   "unmatched_schematron_errors": {
     "Lab Test Name Ordered": [
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Ordered does not have a @code attribute",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/observation[1]",
@@ -19,7 +19,7 @@
         "reason": "Selected candidate found, OpenSearch query returned results, but reranker did not return results."
       },
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Ordered code and translation data elements @codeSystem attribute are not LOINC 2.16.840.1.113883.6.1",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/observation[1]",
@@ -32,7 +32,7 @@
     ],
     "Lab Test Name Resulted": [
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Resulted does not have a @code attribute",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/organizer[1]/component[1]/observation[1]",
@@ -43,7 +43,7 @@
         "reason": "Selected candidate found, OpenSearch query returned results, but reranker did not return results."
       },
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Resulted code and translation data elements @codeSystem attribute are not LOINC 2.16.840.1.113883.6.1",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[6]/section[1]/entry[1]/organizer[1]/component[1]/observation[1]",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_success/handler_success_ttc_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_success/handler_success_ttc_metadata_output.json
@@ -5,7 +5,7 @@
   "schematron_errors": {
     "Lab Test Name Ordered": [
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Ordered does not have a @code attribute",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/observation[1]",
@@ -30,7 +30,7 @@
         ]
       },
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Ordered code and translation data elements @codeSystem attribute are not LOINC 2.16.840.1.113883.6.1",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/observation[1]",
@@ -57,7 +57,7 @@
     ],
     "Lab Test Name Resulted": [
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Resulted does not have a @code attribute",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[5]/section[1]/entry[1]/organizer[1]/component[1]/observation[1]",
@@ -82,7 +82,7 @@
         ]
       },
       {
-        "candidate": {},
+        "candidate": null,
         "eicr_id": null,
         "error": "Text to Code: Lab Test Name Resulted code and translation data elements @codeSystem attribute are not LOINC 2.16.840.1.113883.6.1",
         "error_context": "/ClinicalDocument/component[1]/structuredBody[1]/component[6]/section[1]/entry[1]/organizer[1]/component[1]/observation[1]",

--- a/packages/text-to-code/src/text_to_code/models/eicr.py
+++ b/packages/text-to-code/src/text_to_code/models/eicr.py
@@ -1,8 +1,7 @@
 from enum import StrEnum
 
-from pydantic import BaseModel
-
 from shared_models import CdaInstanceIdentifier
+from shared_models import FrozenBaseModel
 
 
 class LabXPaths(StrEnum):
@@ -15,7 +14,7 @@ class LabXPaths(StrEnum):
     CODE_TRANSLATION_ORIGINAL_TEXT = "code/translation/originalText"
 
 
-class Candidate(BaseModel):
+class Candidate(FrozenBaseModel):
     """Model representing a piece of text to be considered for encoding."""
 
     value: str
@@ -23,7 +22,7 @@ class Candidate(BaseModel):
     system: str | None = None
 
 
-class Metadata(BaseModel):
+class Metadata(FrozenBaseModel):
     """Model representing metadata about the eICR."""
 
     eicr_id: CdaInstanceIdentifier

--- a/packages/text-to-code/src/text_to_code/models/evaluator.py
+++ b/packages/text-to-code/src/text_to_code/models/evaluator.py
@@ -1,10 +1,10 @@
 from enum import StrEnum
 from typing import ClassVar
 
-from pydantic import BaseModel
 from pydantic import Field
 
 from shared_models import DataField
+from shared_models import FrozenBaseModel
 
 from ..models.eicr import LabXPaths
 
@@ -54,7 +54,7 @@ class TranslationSelectionStrategy(StrEnum):
     PREFER_SYSTEM_ORDER = "prefer_system_order"
 
 
-class TranslationPreference(BaseModel):
+class TranslationPreference(FrozenBaseModel):
     """Preferences for choosing among multiple translations when a system attribute is available.
 
     :param strategy: Strategy used when selecting among multiple translation candidates.
@@ -73,7 +73,7 @@ class TranslationPreference(BaseModel):
     )
 
 
-class XPathPriority(BaseModel):
+class XPathPriority(FrozenBaseModel):
     """A single prioritized source of candidate text.
 
     :param xpath: The LabXPaths entry identifying where the candidate text was extracted from.
@@ -85,7 +85,7 @@ class XPathPriority(BaseModel):
     priority: int = Field(..., ge=1)
 
 
-class BaseEvaluationCriteria(BaseModel):
+class BaseEvaluationCriteria(FrozenBaseModel):
     """Base configuration for selecting the most relevant text for a given DataField.
 
     :param data_field: The DataField this evaluation criteria applies to.

--- a/packages/text-to-code/src/text_to_code/models/labs.py
+++ b/packages/text-to-code/src/text_to_code/models/labs.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel
 from pydantic import Field
 from pydantic import field_validator
 
 from shared_models import DataField
+from shared_models import FrozenBaseModel
 
 from .eicr import LabXPaths
 from .schematron import LabTestNameOrderedSchematronErrors
@@ -10,7 +10,7 @@ from .schematron import LabTestNameResultedSchematronErrors
 from .schematron import SchematronErrors
 
 
-class BaseLabField(BaseModel):
+class BaseLabField(FrozenBaseModel):
     """Shared configuration for lab-related TTC processing."""
 
     # Made optional at type level for Ty appeasement, defaults filled in subclasses
@@ -30,7 +30,7 @@ class BaseLabField(BaseModel):
             raise ValueError("At least one Sub-XPath expression must be provided.")
         return v
 
-    xpaths: list[LabXPaths] = list(LabXPaths)
+    xpaths: list[LabXPaths] = Field(default=list(LabXPaths))
 
     schematron_errors: list[SchematronErrors] = Field(
         description="Relevant Schematron error messages.",

--- a/packages/text-to-code/src/text_to_code/models/query.py
+++ b/packages/text-to-code/src/text_to_code/models/query.py
@@ -1,10 +1,10 @@
 import typing
 
-from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
 
 from shared_models import DataField
+from shared_models import FrozenBaseModel
 
 
 class DataFieldTypeMapping:
@@ -24,7 +24,7 @@ class DataFieldTypeMapping:
             raise ValueError(f"No type mapping defined for {data_field}") from err
 
 
-class VectorSearchParams(BaseModel):
+class VectorSearchParams(FrozenBaseModel):
     """Parameters for performing a vector search."""
 
     vector: list[float] = Field(description="The vector to search for.")
@@ -51,7 +51,11 @@ class VectorSearchParams(BaseModel):
     def compute_filter_value(self) -> "VectorSearchParams":
         """Uses the DataFieldTypeMapping to get the filter values corresponding to the data_field."""
         if self.filter_field == type(self).model_fields["filter_field"].default:
-            self.filter_value = DataFieldTypeMapping.to_filter_values(self.data_field)
+            # We have to use `object.__setattr__` because this is a frozen model.
+            object.__setattr__(
+                self, "filter_value", DataFieldTypeMapping.to_filter_values(self.data_field)
+            )
         else:
             raise ValueError(f"Unsupported filter field: {self.filter_field}")
+
         return self

--- a/packages/text-to-code/src/text_to_code/models/schematron.py
+++ b/packages/text-to-code/src/text_to_code/models/schematron.py
@@ -1,9 +1,8 @@
 from enum import Enum
 
-from pydantic import BaseModel
-
 from shared_models import CdaInstanceIdentifier
 from shared_models import DataField
+from shared_models import FrozenBaseModel
 from text_to_code.models.eicr import Candidate
 
 
@@ -30,7 +29,7 @@ _SCHEMATRON_ENUM_TO_FIELD: dict[type[Enum], DataField] = {
 }
 
 
-class SchematronConfig(BaseModel):
+class SchematronConfig(FrozenBaseModel):
     """Config for Schematron configuration settings."""
 
     data_field: DataField
@@ -40,7 +39,7 @@ class SchematronConfig(BaseModel):
     """The list of Schematron error messages relevant to the data field."""
 
 
-class SchematronErrorDetail(BaseModel):
+class SchematronErrorDetail(FrozenBaseModel):
     """Structured details for a Schematron validation error."""
 
     eicr_id: CdaInstanceIdentifier | None = None

--- a/packages/text-to-code/src/text_to_code/services/query.py
+++ b/packages/text-to-code/src/text_to_code/services/query.py
@@ -1,16 +1,17 @@
-import pydantic
+from pydantic import Field
 
+from shared_models import FrozenBaseModel
 from text_to_code.models.query import VectorSearchParams
 
 
-class KNNQuery(pydantic.BaseModel):
+class KNNQuery(FrozenBaseModel):
     """Builds a KNN query."""
 
-    field: str = pydantic.Field(
+    field: str = Field(
         default="description_vector", description="The field to perform the vector search on."
     )
-    vector: list[float] = pydantic.Field(description="The vector to search for.")
-    k: int = pydantic.Field(default=10, description="The number of nearest neighbors to retrieve.")
+    vector: list[float] = Field(description="The vector to search for.")
+    k: int = Field(default=10, description="The number of nearest neighbors to retrieve.")
 
     def to_opensearch(self) -> dict:
         """Builds an OpenSearch-specific KNN query."""
@@ -24,7 +25,7 @@ class KNNQuery(pydantic.BaseModel):
         }
 
 
-class TermsFilter(pydantic.BaseModel):
+class TermsFilter(FrozenBaseModel):
     """Builds a terms filter for the query.
 
     The filter narrows down the search results to only include documents where the
@@ -34,10 +35,10 @@ class TermsFilter(pydantic.BaseModel):
     codes of type "Observation" or "Both" for the lab test result data field.
     """
 
-    field: str = pydantic.Field(
+    field: str = Field(
         default="loinc_type", description="The field to filter on, e.g., 'loinc_type'."
     )
-    value: list[str] = pydantic.Field(
+    value: list[str] = Field(
         description="The value(s) to filter the specified field by, e.g., ['order','both'] or ['observation', 'both']."
     )
 


### PR DESCRIPTION
## Description

Creates a base model that all other models inherit so that all models can be frozen and do not allow extra attributes. This matches how we are using the models. In addition it makes serialization/deserialization predictable as stray attributes cannot be added to models.

## Related Issues

Closes # n/a

## Additional Notes

This comes out of the refactoring in [544](https://github.com/CDCgov/dibbs-text-to-code/pull/544). By ensuring models are exactly what we expect we can simplify the serialization/deserialization.