### PR TITLE
Fix vulnerabilities in lambda base image and add Trivy scan workflow

### DIFF
--- a/.github/scripts/security-summary.js
+++ b/.github/scripts/security-summary.js
@@ -1,0 +1,367 @@
+const fs = require("fs");
+
+/**
+ * Parse Trivy scan results and count vulnerabilities
+ */
+function parseScanResults(images) {
+  let totalCritical = 0;
+  let totalHigh = 0;
+  let totalMedium = 0;
+  let totalLow = 0;
+  const imageResults = [];
+
+  for (const image of images) {
+    try {
+      const results = JSON.parse(
+        fs.readFileSync(`trivy-${image}-results.json`, "utf8"),
+      );
+
+      let imageCritical = 0,
+        imageHigh = 0,
+        imageMedium = 0,
+        imageLow = 0;
+
+      if (results.Results) {
+        for (const result of results.Results) {
+          if (result.Vulnerabilities) {
+            for (const vuln of result.Vulnerabilities) {
+              switch (vuln.Severity) {
+                case "CRITICAL":
+                  imageCritical++;
+                  break;
+                case "HIGH":
+                  imageHigh++;
+                  break;
+                case "MEDIUM":
+                  imageMedium++;
+                  break;
+                case "LOW":
+                  imageLow++;
+                  break;
+              }
+            }
+          }
+        }
+      }
+
+      totalCritical += imageCritical;
+      totalHigh += imageHigh;
+      totalMedium += imageMedium;
+      totalLow += imageLow;
+
+      imageResults.push({
+        name: image,
+        critical: imageCritical,
+        high: imageHigh,
+        medium: imageMedium,
+        low: imageLow,
+        total: imageCritical + imageHigh + imageMedium + imageLow,
+      });
+    } catch (error) {
+      console.error(`Error parsing ${image}:`, error);
+      imageResults.push({
+        name: image,
+        error: true,
+        errorMessage: error.message,
+      });
+    }
+  }
+
+  return {
+    totalCritical,
+    totalHigh,
+    totalMedium,
+    totalLow,
+    totalVulns: totalCritical + totalHigh + totalMedium + totalLow,
+    imageResults,
+  };
+}
+
+/**
+ * Format results as GitHub markdown comment
+ */
+function formatGitHubComment(scanResults, repoOwner, repoName) {
+  const {
+    totalCritical,
+    totalHigh,
+    totalMedium,
+    totalLow,
+    totalVulns,
+    imageResults,
+  } = scanResults;
+
+  let message = `## 🔒 Security Scan Results\n\n`;
+
+  // Summary at the top
+  if (totalVulns > 0) {
+    message += `### ⚠️ Found ${totalVulns} vulnerabilities\n\n`;
+    message += `| Severity | Total |\n|----------|-------|\n`;
+    if (totalCritical > 0) message += `| 🔴 Critical | ${totalCritical} |\n`;
+    if (totalHigh > 0) message += `| 🟠 High | ${totalHigh} |\n`;
+    if (totalMedium > 0) message += `| 🟡 Medium | ${totalMedium} |\n`;
+    if (totalLow > 0) message += `| ⚪ Low | ${totalLow} |\n`;
+    message += `\n`;
+  } else {
+    message += `### ✅ No vulnerabilities found!\n\n`;
+  }
+
+  // Per-image breakdown
+  for (const result of imageResults) {
+    message += `### 📦 ${result.name}\n\n`;
+
+    if (result.error) {
+      message += `⚠️ Could not parse results for ${result.name}\n\n`;
+    } else if (result.total === 0) {
+      message += `✅ **No vulnerabilities found**\n\n`;
+    } else {
+      message += `| Severity | Count |\n|----------|-------|\n`;
+      if (result.critical > 0)
+        message += `| 🔴 Critical | ${result.critical} |\n`;
+      if (result.high > 0) message += `| 🟠 High | ${result.high} |\n`;
+      if (result.medium > 0) message += `| 🟡 Medium | ${result.medium} |\n`;
+      if (result.low > 0) message += `| ⚪ Low | ${result.low} |\n`;
+      message += `\n`;
+    }
+  }
+
+  message += `\n---\n`;
+  message += `**View detailed results**: [Security tab](https://github.com/${repoOwner}/${repoName}/security/code-scanning)\n`;
+  message += `*Last updated: ${new Date()
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d{3}Z$/, " UTC")}*`;
+
+  return message;
+}
+
+/**
+ * Format results as Slack message for scheduled scans
+ */
+function formatSlackMessage(scanResults, repoUrl, branch = "main") {
+  const {
+    totalCritical,
+    totalHigh,
+    totalMedium,
+    totalLow,
+    totalVulns,
+    imageResults,
+  } = scanResults;
+
+  let color = "good"; // green
+  let emoji = "✅";
+  let statusText = "No vulnerabilities found";
+
+  if (totalCritical > 0) {
+    color = "danger"; // red
+    emoji = "🔴";
+    statusText = `${totalCritical} Critical vulnerabilities detected!`;
+  } else if (totalHigh > 0) {
+    color = "warning"; // yellow
+    emoji = "🟠";
+    statusText = `${totalHigh} High vulnerabilities detected`;
+  } else if (totalVulns > 0) {
+    color = "#808080"; // gray
+    emoji = "ℹ️";
+    statusText = `${totalVulns} Medium/Low vulnerabilities`;
+  }
+
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `${emoji} Security Scan: ${branch}`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${statusText}*`,
+      },
+    },
+    {
+      type: "section",
+      fields: [
+        {
+          type: "mrkdwn",
+          text: `🔴 *Critical:* ${totalCritical}`,
+        },
+        {
+          type: "mrkdwn",
+          text: `🟠 *High:* ${totalHigh}`,
+        },
+        {
+          type: "mrkdwn",
+          text: `🟡 *Medium:* ${totalMedium}`,
+        },
+        {
+          type: "mrkdwn",
+          text: `⚪ *Low:* ${totalLow}`,
+        },
+      ],
+    },
+  ];
+
+  // Add per-image breakdown
+  const imageFields = imageResults
+    .filter((r) => !r.error)
+    .map((r) => {
+      const icon = r.total === 0 ? "✅" : "⚠️";
+      return {
+        type: "mrkdwn",
+        text: `${icon} *${r.name}:* ${r.critical}C / ${r.high}H / ${r.medium}M / ${r.low}L`,
+      };
+    });
+
+  if (imageFields.length > 0) {
+    blocks.push({
+      type: "section",
+      fields: imageFields,
+    });
+  }
+
+  // Add link to GitHub Security tab
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `<${repoUrl}/security/code-scanning|View detailed results in GitHub Security tab>`,
+    },
+  });
+
+  return {
+    attachments: [
+      {
+        color: color,
+        blocks: blocks,
+      },
+    ],
+  };
+}
+
+/**
+ * Send notification to Slack
+ */
+async function sendSlackNotification(scanResults, repoUrl, branch, webhookUrl) {
+  const payload = formatSlackMessage(scanResults, repoUrl, branch);
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    console.error("Failed to send Slack notification:", await response.text());
+    throw new Error(`Slack notification failed: ${response.status}`);
+  } else {
+    console.log("Slack notification sent successfully");
+  }
+}
+
+/**
+ * Post or update PR comment
+ */
+async function postGitHubComment(scanResults, github, context) {
+  const prNumber = context.payload.pull_request?.number;
+
+  if (!prNumber) {
+    console.log("Not a PR, skipping GitHub comment");
+    return;
+  }
+
+  const message = formatGitHubComment(
+    scanResults,
+    context.repo.owner,
+    context.repo.repo,
+  );
+
+  const comments = await github.rest.issues.listComments({
+    issue_number: prNumber,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+  });
+
+  const botComment = comments.data.find(
+    (comment) =>
+      comment.user.login === "github-actions[bot]" &&
+      comment.body.includes("Security Scan Results"),
+  );
+
+  if (botComment) {
+    await github.rest.issues.updateComment({
+      comment_id: botComment.id,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: message,
+    });
+    console.log("Updated existing security scan comment");
+  } else {
+    await github.rest.issues.createComment({
+      issue_number: prNumber,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: message,
+    });
+    console.log("Created new security scan comment");
+  }
+}
+
+/**
+ * For PR scans - posts comment to PR
+ */
+async function generatePRSummary(github, context, core) {
+  const images = ["index", "ttc", "augmentation"];
+
+  // Parse all scan results
+  const scanResults = parseScanResults(images);
+
+  // Warn if critical or high vulnerabilities found
+  if (scanResults.totalCritical > 0 || scanResults.totalHigh > 0) {
+    core.warning(
+      `Found ${scanResults.totalCritical} critical and ${scanResults.totalHigh} high severity vulnerabilities`,
+    );
+  }
+
+  // Post GitHub comment
+  await postGitHubComment(scanResults, github, context);
+}
+
+/**
+ * For scheduled scans - sends Slack notification
+ */
+async function generateScheduledSummary(github, context, core) {
+  const images = ["index", "ttc", "augmentation"];
+
+  // Parse all scan results
+  const scanResults = parseScanResults(images);
+
+  // Warn if critical or high vulnerabilities found
+  if (scanResults.totalCritical > 0 || scanResults.totalHigh > 0) {
+    core.warning(
+      `Found ${scanResults.totalCritical} critical and ${scanResults.totalHigh} high severity vulnerabilities`,
+    );
+  }
+
+  // Send Slack notification if webhook is configured
+  const slackWebhook = process.env.SLACK_WEBHOOK_URL;
+  if (slackWebhook) {
+    try {
+      const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+      const branch = context.ref.replace("refs/heads/", "");
+
+      await sendSlackNotification(scanResults, repoUrl, branch, slackWebhook);
+    } catch (error) {
+      console.error("Failed to send Slack notification:", error);
+      core.setFailed(`Slack notification failed: ${error.message}`);
+    }
+  } else {
+    console.log("SLACK_WEBHOOK_URL not configured, skipping notification");
+  }
+}
+
+module.exports = {
+  generatePRSummary,
+  generateScheduledSummary,
+};

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,176 @@
+name: "Scan GHCR Images for Vulnerabilities"
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to scan (e.g., latest, main, 1.0.0)"
+        required: false
+        default: "latest"
+      severity_level:
+        description: "Vulnerability severity threshold"
+        required: false
+        default: "CRITICAL,HIGH,MEDIUM,LOW"
+        type: choice
+        options:
+          - "CRITICAL,HIGH,MEDIUM,LOW"
+          - "CRITICAL,HIGH,MEDIUM"
+          - "CRITICAL,HIGH"
+          - "CRITICAL"
+      send_slack_notification:
+        description: "Send Slack notification"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Run once daily at 2 PM UTC
+    - cron: "0 14 * * *"
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  DEFAULT_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
+  DEFAULT_TAG: "latest"
+
+jobs:
+  scan-images:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image:
+          - index
+          - ttc
+          - augmentation
+      fail-fast: false # Continue scanning other images if one fails
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make repo owner lowercase
+        id: repo
+        run: |
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Set scan parameters
+        id: params
+        run: |
+          TAG="${{ github.event.inputs.image_tag || env.DEFAULT_TAG }}"
+          SEVERITY="${{ github.event.inputs.severity_level || env.DEFAULT_SEVERITY }}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "severity=$SEVERITY" >> $GITHUB_OUTPUT
+
+      - name: Check if image exists
+        id: check
+        run: |
+          IMAGE="ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-text-to-code/${{ matrix.image }}:${{ steps.params.outputs.tag }}"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+          # Try to pull image metadata to check if it exists
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image found: $IMAGE"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Image not found: $IMAGE"
+          fi
+
+      - name: Run Trivy vulnerability scanner (SARIF)
+        if: steps.check.outputs.exists == 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.check.outputs.image }}
+          format: "sarif"
+          output: "trivy-${{ matrix.image }}-results.sarif"
+          severity: ${{ steps.params.outputs.severity }}
+          ignore-unfixed: true
+          timeout: "10m"
+
+      - name: Run Trivy vulnerability scanner (JSON)
+        if: steps.check.outputs.exists == 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.check.outputs.image }}
+          format: "json"
+          output: "trivy-${{ matrix.image }}-results.json"
+          severity: ${{ steps.params.outputs.severity }}
+          ignore-unfixed: true
+          timeout: "10m"
+
+      - name: Display Trivy results as table
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.check.outputs.image }}
+          format: "table"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: steps.check.outputs.exists == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-${{ matrix.image }}-results.sarif"
+          category: "vulnerability-scan-${{ matrix.image }}"
+
+      - name: Upload JSON results as artifact
+        if: steps.check.outputs.exists == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-results-${{ matrix.image }}
+          path: trivy-${{ matrix.image }}-results.json
+          retention-days: 30
+
+      - name: Scan summary for ${{ matrix.image }}
+        if: always()
+        run: |
+          if [ "${{ steps.check.outputs.exists }}" = "true" ]; then
+            echo "Vulnerability scan completed for ${{ matrix.image }}"
+            echo "Image: ${{ steps.check.outputs.image }}"
+            echo "Severity: ${{ steps.params.outputs.severity }}"
+            echo "Results uploaded to Security tab with category: vulnerability-scan-${{ matrix.image }}"
+          else
+            echo "Skipped scanning ${{ matrix.image }} - image not found"
+            echo "Attempted image: ${{ steps.check.outputs.image }}"
+          fi
+
+  scan-complete:
+    runs-on: ubuntu-latest
+    needs: scan-images
+    if: always()
+
+    steps:
+      - name: Overall scan summary
+        run: |
+          echo "Image vulnerability scanning completed"
+          echo "Scan timestamp: $(date -u)"
+          echo "Scanned tag: ${{ github.event.inputs.image_tag || env.DEFAULT_TAG }}"
+          echo "Severity threshold: ${{ github.event.inputs.severity_level || env.DEFAULT_SEVERITY }}"
+          echo ""
+          echo "Check the Security tab for detailed vulnerability reports"
+          echo "Navigate to: Repository → Security → Code scanning alerts"
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: scan-images
+    # Always send message during a scheduled run but allow user to choose when running manually
+    if: always() && (github.event_name == 'schedule' || github.event.inputs.send_slack_notification == 'true')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download scan results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: trivy-results-*
+          merge-multiple: true
+
+      - name: Send Slack notification
+        uses: actions/github-script@v7
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          script: |
+            const script = require('./.github/scripts/security-summary.js');
+            await script.generateScheduledSummary(github, context, core);

--- a/Dockerfile.augmentation
+++ b/Dockerfile.augmentation
@@ -7,8 +7,13 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 ARG ENVIRONMENT=prod
 ENV ENVIRONMENT=${ENVIRONMENT}
 
-# Install build tools for compiling C++ extensions
-RUN microdnf install -y gcc-c++ make && microdnf clean all
+# Update OS packages for CVE fixes, install build tools for compiling C++ extensions,
+# and drop the Runtime Interface Emulator (only used for local Lambda emulation).
+# --releasever=latest is required: AL2023 base images pin to a snapshot release.
+RUN microdnf update -y --releasever=latest \
+    && microdnf install -y --releasever=latest gcc-c++ make \
+    && microdnf clean all \
+    && rm -f /usr/local/bin/aws-lambda-rie
 
 # Copy and install workspace packages in dependency order
 COPY ./packages/shared-models ${LAMBDA_TASK_ROOT}/shared-models
@@ -24,7 +29,8 @@ COPY ./packages/augmentation ${LAMBDA_TASK_ROOT}/augmentation
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/augmentation"
 
 COPY ./packages/augmentation-lambda ${LAMBDA_TASK_ROOT}/augmentation-lambda
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/augmentation-lambda"
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/augmentation-lambda" \
+    && pip install --no-cache-dir --upgrade "urllib3>=2.7.0"
 
 # Copy over the rest of the code
 COPY ./packages/augmentation-lambda/src ${LAMBDA_TASK_ROOT}/src

--- a/Dockerfile.index
+++ b/Dockerfile.index
@@ -10,8 +10,13 @@ ENV ENVIRONMENT=${ENVIRONMENT}
 # Initialize the index_lambda directory
 RUN mkdir -p "${LAMBDA_TASK_ROOT}/src/index_lambda"
 
-# Install build tools for compiling C++ extensions
-RUN microdnf install -y gcc-c++ make && microdnf clean all
+# Update OS packages for CVE fixes, install build tools for compiling C++ extensions,
+# and drop the Runtime Interface Emulator (only used for local Lambda emulation).
+# --releasever=latest is required: AL2023 base images pin to a snapshot release.
+RUN microdnf update -y --releasever=latest \
+    && microdnf install -y --releasever=latest gcc-c++ make \
+    && microdnf clean all \
+    && rm -f /usr/local/bin/aws-lambda-rie
 
 # Copy over just the pyproject.toml file and install the dependencies doing this
 # before copying the rest of the code allows for caching of the dependencies
@@ -22,7 +27,8 @@ COPY ./packages/lambda-handler ${LAMBDA_TASK_ROOT}/lambda-handler
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/lambda-handler"
 
 COPY ./packages/index-lambda ${LAMBDA_TASK_ROOT}/index-lambda
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/index-lambda"
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/index-lambda" \
+    && pip install --no-cache-dir --upgrade "urllib3>=2.7.0"
 
 # Copy over the rest of the code
 COPY ./packages/index-lambda/src ${LAMBDA_TASK_ROOT}/src

--- a/Dockerfile.ttc
+++ b/Dockerfile.ttc
@@ -3,8 +3,13 @@ FROM public.ecr.aws/lambda/python:3.12
 LABEL org.opencontainers.image.source=https://github.com/CDCgov/dibbs-text-to-code
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-# Install build tools for C++ extensions
-RUN microdnf install -y gcc-c++ make && microdnf clean all
+# Update OS packages for CVE fixes, install build tools for compiling C++ extensions,
+# and drop the Runtime Interface Emulator (only used for local Lambda emulation).
+# --releasever=latest is required: AL2023 base images pin to a snapshot release.
+RUN microdnf update -y --releasever=latest \
+    && microdnf install -y --releasever=latest gcc-c++ make \
+    && microdnf clean all \
+    && rm -f /usr/local/bin/aws-lambda-rie
 
 # Heavy, rarely-changing layers first so they stay cached across source changes.
 # Install CPU-only PyTorch before any workspace package — a transitive pin
@@ -39,7 +44,8 @@ COPY ./packages/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code"
 
 COPY ./packages/text-to-code-lambda ${LAMBDA_TASK_ROOT}/text-to-code-lambda
-RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code-lambda"
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code-lambda" \
+    && pip install --no-cache-dir --upgrade "urllib3>=2.7.0"
 
 # Remove build tools no longer needed at runtime
 RUN rpm -e --nodeps gcc-c++ gcc cpp make && microdnf clean all && rm -rf /var/cache/*


### PR DESCRIPTION
## Summary

Patches the HIGH/CRITICAL CVEs AWS Inspector is flagging on our Lambda container images, and adds a recurring Trivy scan workflow to catch new ones - since I believe Inspector is using Trivy under the hood.

### Vulnerability fixes (`Dockerfile.{index,ttc,augmentation}`)

Each Dockerfile already ran `microdnf install` for build tools — three small tweaks bring the images to **0 HIGH/CRITICAL findings**:

- **`microdnf update -y --releasever=latest`** before installing build tools. The AL2023 base image pins to a release snapshot, so a plain `microdnf update` is a no-op; `--releasever=latest` is required to pick up patched glibc/kernel-headers builds.
- **`rm -f /usr/local/bin/aws-lambda-rie`**. The Runtime Interface Emulator is bundled in the base image for local emulation only — Lambda doesn't use it in production — and ships with five Go stdlib CVEs.
- **`pip install --upgrade "urllib3>=2.7.0"`** appended to the final package install. `requests` / `opensearch-py` pull in urllib3 2.6.3, which has two HIGH CVEs (sensitive header leakage in proxied redirects, and a decompression-bomb safeguard bypass) fixed in 2.7.0.

Verified locally with `trivy image --severity HIGH,CRITICAL --ignore-unfixed` on all three rebuilt images — clean across OS, Python, and Go-binary targets.

### New scan workflow (`.github/workflows/scan.yml`)

Adapted from [dibbs-ecr-refiner's scan.yml](https://github.com/CDCgov/dibbs-ecr-refiner/blob/main/.github/workflows/scan.yml):

- Runs daily at 14:00 UTC, plus `workflow_dispatch` for ad-hoc runs (with tag and severity inputs).
- Matrix scans the three GHCR images: `index`, `ttc`, `augmentation`.
- Uploads SARIF to the **Security → Code scanning** tab under per-image categories.
- Optional Slack notification on scheduled runs (uses the existing `SLACK_WEBHOOK_URL` secret) via the ported `.github/scripts/security-summary.js` helper.
- Trivy action pinned to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0).

## Test plan

- [ ] Verify the workflow run on `main` post-merge succeeds for all three images.
- [ ] Confirm SARIF reports appear under **Security → Code scanning** with categories `vulnerability-scan-{index,ttc,augmentation}`.
- [ ] Confirm the next scheduled run posts a Slack message to the channel `SLACK_WEBHOOK_URL` points at (or trigger manually with `send_slack_notification=true`).
- [ ] Spot-check that the GHCR images are publicly readable — if not, add a `docker/login-action` step (and `packages: read` permission) to the workflow.
