### PR TITLE
Create result cache service

### DIFF
--- a/packages/text-to-code/src/text_to_code/models/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/models/result_cache.py
@@ -1,0 +1,67 @@
+from datetime import UTC
+from datetime import datetime
+
+from pydantic import Field
+
+from shared_models import FrozenBaseModel
+
+
+class OpenSearchResultCacheSource(FrozenBaseModel):
+    """Represents a term-standardization mapping returned from the OpenSearch Result Cache Index."""
+
+    cache_key: str = Field(
+        description="The computed hash key mapping candidate text + data field to this known hit."
+    )
+    text: str = Field(description="The input candidate text this Cache Result is associated with.")
+    data_field: str = Field(
+        description="The data field from which the candidate text was retrieved during initial "
+        "processing of this cache hit."
+    )
+    loinc_code: str = Field(description="The serialized Code object for this cached input.")
+    search_score: float = Field(
+        description="The cosine similarity score calculated for this standardization during "
+        "initial processing of this input."
+    )
+    reranker_score: float = Field(
+        description="The cross-encoder score calculated for this standardization during initial "
+        "processing of this input."
+    )
+    cached_at: str = Field(
+        default=datetime.now(UTC).isoformat(),
+        description="The timestamp at which this input was cached.",
+    )
+
+
+class OpenSearchGetResponse(FrozenBaseModel):
+    """Represents the response body returned by an ID-indexed GET request to the OpenSearch API."""
+
+    index: str = Field(description="The name of the index containing the document.", alias="_index")
+    id: str = Field(description="The document's unique identifier.", alias="_id")
+    version: int = Field(
+        description="The document's version number, incremented each time the document is updated",
+        alias="_version",
+    )
+    seq_no: int = Field(
+        description="The sequence number assigned to the document for the indexing operation. "
+        "Used to ensure an older version doesn't overwrite a newer version.",
+        alias="_seq_no",
+    )
+    primary_term: int = Field(
+        description="The primary term assigned to the document for the indexing operation. "
+        "Used with `seq_no` for optimistic concurrency control.",
+        alias="_primary_term",
+    )
+    found: bool = Field(
+        description="Indicates whether the document exists (`True` if it was found) in the "
+        "searched index. For searches against the `result-cache` index, the 'document' will be "
+        "a cache-key pair whose source data contains the known standardized LOINC code."
+    )
+    routing: str = Field(
+        description="The routing value used to determine which shard stores the document. "
+        "Only included if a routing value was specified when the document was indexed.",
+        alias="_routing",
+    )
+    source: OpenSearchResultCacheSource = Field(description="The cached result for the input.")
+    fields: dict[str, list] = Field(
+        description="Stored field values of the mappings.", alias="_fields"
+    )

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -114,7 +114,7 @@ def put_new_cached_result(
         cache_key=cache_key,
         text=candidate_input,
         data_field=data_field,
-        loinc_code=json.dumps(loinc_code),
+        loinc_code=json.dumps(loinc_code.__dict__),
         search_score=search_score,
         reranker_score=reranker_score,
         cached_at=datetime.now(UTC).isoformat(),

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -76,9 +76,9 @@ def get_cached_result(
     :param index: The namespace of the Index to check.
     :param os_doc_id: The OpenSearch document `_id` parameter to check for.
     """
-    response: OpenSearchGetResponse = opensearch_client.get(index=index, id=os_doc_id)
+    response = opensearch_client.get(index=index, id=os_doc_id)
     if response and response["found"]:
-        return response.source
+        return response["source"]
     return None
 
 

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -77,7 +77,7 @@ def get_cached_result(
     :param os_doc_id: The OpenSearch document `_id` parameter to check for.
     """
     response: OpenSearchGetResponse = opensearch_client.get(index=index, id=os_doc_id)
-    if response and response.found:
+    if response and response["found"]:
         return response.source
     return None
 

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -1,0 +1,121 @@
+import json
+from datetime import UTC
+from datetime import datetime
+from hashlib import sha256
+
+from opensearchpy import OpenSearch
+from pydantic import Field
+
+from shared_models import Code
+from shared_models import FrozenBaseModel
+
+
+class OpenSearchResultCacheSource(FrozenBaseModel):
+    """Represents a term-standardization mapping returned from the OpenSearch Result Cache Index."""
+
+    cache_key: str = Field(
+        description="The computed hash key mapping candidate text + data field to this known hit."
+    )
+    text: str = Field(description="The input candidate text this Cache Result is associated with.")
+    data_field: str = Field(
+        description="The data field from which the candidate text was retrieved during initial "
+        "processing of this cache hit."
+    )
+    loinc_code: str = Field(description="The serialized Code object for this cached input.")
+    search_score: float = Field(
+        description="The cosine similarity score calculated for this standardization during "
+        "initial processing of this input."
+    )
+    reranker_score: float = Field(
+        description="The cross-encoder score calculated for this standardization during initial "
+        "processing of this input."
+    )
+    cached_at: str = Field(description="The timestamp at which this input was cached.")
+
+
+class OpenSearchGetResponse(FrozenBaseModel):
+    """Represents the response body returned by an ID-indexed GET request to the OpenSearch API."""
+
+    index: str = Field(description="The name of the index containing the document.", alias="_index")
+    id: str = Field(description="The document's unique identifier.", alias="_id")
+    version: int = Field(
+        description="The document's version number, incremented each time the document is updated",
+        alias="_version",
+    )
+    seq_no: int = Field(
+        description="The sequence number assigned to the document for the indexing operation. "
+        "Used to ensure an older version doesn't overwrite a newer version.",
+        alias="_seq_no",
+    )
+    primary_term: int = Field(
+        description="The primary term assigned to the document for the indexing operation. "
+        "Used with `seq_no` for optimistic concurrency control.",
+        alias="_primary_term",
+    )
+    found: bool = Field(
+        description="Indicates whether the document exists (`True` if it was found)."
+    )
+    routing: str = Field(
+        description="The routing value used to determine which shard stores the document. "
+        "Only included if a routing value was specified when the document was indexed.",
+        alias="_routing",
+    )
+    source: OpenSearchResultCacheSource = Field(description="The cached result for the input.")
+    fields: dict[str, list] = Field(
+        description="Stored field values of the mappings.", alias="_fields"
+    )
+
+
+def get_cached_result(
+    opensearch_client: OpenSearch, index: str, os_doc_id: str
+) -> OpenSearchResultCacheSource | None:
+    """Queries an OpenSearch Index by document ID.
+
+    :param opensearch_client: An instantiated client meant for communicating with
+      the TTC OpenSearch instance.
+    :param index: The namespace of the Index to check.
+    :param os_doc_id: The OpenSearch document `_id` parameter to check for.
+    """
+    response: OpenSearchGetResponse = opensearch_client.get(index=index, id=os_doc_id)
+    if response and response.found:
+        return response.source
+    return None
+
+
+def put_new_cached_result(
+    opensearch_client: OpenSearch,
+    index: str,
+    candidate_input: str,
+    data_field: str,
+    loinc_code: Code,
+    search_score: float,
+    reranker_score: float,
+) -> bool:
+    """Stores a hit for a new nonstandard input in the Result Cache index in OpenSearch.
+
+    :param opensearch_client: An instantiated client for communicating with OpenSearch.
+    :param index: The index name to store the cache hit in.
+    :param candidate_input: The candidate text extracted from a schematron error that
+      was used as the input for OpenSearch semantic similarity.
+    :param data_field: The data field associated with the candidate text in the eICR.
+    :param loinc_code: A LOINC code object representing the nonstandard input's correct
+      standardization, including display name and numeric code.
+    :param search_score: The cosine similarity score returned by OpenSearch during
+      embedding comparisons.
+    :param reranker_score: The cross-encoder score calculated by the reranker during
+      final decision making on this input.
+    :returns: A boolean indicating whether the new cache hit was successfully added to
+      the OpenSearch index.
+    """
+    cache_key = sha256(candidate_input.strip().lower() + "|" + data_field).hexdigest()
+    new_cache_hit: OpenSearchResultCacheSource = OpenSearchResultCacheSource(
+        cache_key=cache_key,
+        text=candidate_input,
+        data_field=data_field,
+        loinc_code=json.dumps(loinc_code),
+        search_score=search_score,
+        reranker_score=reranker_score,
+        cached_at=datetime.now(UTC).isoformat(),
+    )
+    put_response = opensearch_client.index(index=index, id=cache_key, body=new_cache_hit)
+    return put_response["result"] == "created"

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -26,7 +26,7 @@ def get_cached_result(
     return None
 
 
-def put_new_cached_result(
+def put_new_cached_result(  # noqa: PLR0913
     opensearch_client: OpenSearch,
     index: str,
     candidate_input: str,

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -1,69 +1,10 @@
 import json
-from datetime import UTC
-from datetime import datetime
 from hashlib import sha256
 
 from opensearchpy import OpenSearch
-from pydantic import Field
 
 from shared_models import Code
-from shared_models import FrozenBaseModel
-
-
-class OpenSearchResultCacheSource(FrozenBaseModel):
-    """Represents a term-standardization mapping returned from the OpenSearch Result Cache Index."""
-
-    cache_key: str = Field(
-        description="The computed hash key mapping candidate text + data field to this known hit."
-    )
-    text: str = Field(description="The input candidate text this Cache Result is associated with.")
-    data_field: str = Field(
-        description="The data field from which the candidate text was retrieved during initial "
-        "processing of this cache hit."
-    )
-    loinc_code: str = Field(description="The serialized Code object for this cached input.")
-    search_score: float = Field(
-        description="The cosine similarity score calculated for this standardization during "
-        "initial processing of this input."
-    )
-    reranker_score: float = Field(
-        description="The cross-encoder score calculated for this standardization during initial "
-        "processing of this input."
-    )
-    cached_at: str = Field(description="The timestamp at which this input was cached.")
-
-
-class OpenSearchGetResponse(FrozenBaseModel):
-    """Represents the response body returned by an ID-indexed GET request to the OpenSearch API."""
-
-    index: str = Field(description="The name of the index containing the document.", alias="_index")
-    id: str = Field(description="The document's unique identifier.", alias="_id")
-    version: int = Field(
-        description="The document's version number, incremented each time the document is updated",
-        alias="_version",
-    )
-    seq_no: int = Field(
-        description="The sequence number assigned to the document for the indexing operation. "
-        "Used to ensure an older version doesn't overwrite a newer version.",
-        alias="_seq_no",
-    )
-    primary_term: int = Field(
-        description="The primary term assigned to the document for the indexing operation. "
-        "Used with `seq_no` for optimistic concurrency control.",
-        alias="_primary_term",
-    )
-    found: bool = Field(
-        description="Indicates whether the document exists (`True` if it was found)."
-    )
-    routing: str = Field(
-        description="The routing value used to determine which shard stores the document. "
-        "Only included if a routing value was specified when the document was indexed.",
-        alias="_routing",
-    )
-    source: OpenSearchResultCacheSource = Field(description="The cached result for the input.")
-    fields: dict[str, list] = Field(
-        description="Stored field values of the mappings.", alias="_fields"
-    )
+from text_to_code.models.result_cache import OpenSearchResultCacheSource
 
 
 def get_cached_result(
@@ -123,7 +64,6 @@ def put_new_cached_result(
         loinc_code=json.dumps(loinc_code.__dict__),
         search_score=search_score,
         reranker_score=reranker_score,
-        cached_at=datetime.now(UTC).isoformat(),
     )
     put_response = opensearch_client.index(index=index, id=cache_key, body=new_cache_hit)
     return put_response["result"] == "created"

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -71,6 +71,9 @@ def get_cached_result(
 ) -> OpenSearchResultCacheSource | None:
     """Queries an OpenSearch Index by document ID.
 
+    Full details of the OpenSearch API's GET Response body can be found at
+    https://docs.opensearch.org/latest/api-reference/document-apis/get-documents/#response-body-fields
+
     :param opensearch_client: An instantiated client meant for communicating with
       the TTC OpenSearch instance.
     :param index: The namespace of the Index to check.
@@ -92,6 +95,9 @@ def put_new_cached_result(
     reranker_score: float,
 ) -> bool:
     """Stores a hit for a new nonstandard input in the Result Cache index in OpenSearch.
+
+    Full API documentation for the `.index()` method can be found at
+    https://docs.opensearch.org/latest/api-reference/document-apis/index-document/.
 
     :param opensearch_client: An instantiated client for communicating with OpenSearch.
     :param index: The index name to store the cache hit in.

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -107,7 +107,9 @@ def put_new_cached_result(
     :returns: A boolean indicating whether the new cache hit was successfully added to
       the OpenSearch index.
     """
-    cache_key = sha256(candidate_input.strip().lower() + "|" + data_field).hexdigest()
+    cache_key = sha256(
+        (candidate_input.strip().lower() + "|" + data_field).encode("utf-8")
+    ).hexdigest()
     new_cache_hit: OpenSearchResultCacheSource = OpenSearchResultCacheSource(
         cache_key=cache_key,
         text=candidate_input,

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from shared_models import Code
 from text_to_code.services.result_cache import get_cached_result
@@ -8,10 +8,9 @@ RESULT_CACHE_INDEX_NAME = "test-result-cache"
 
 
 class TestResultCacheAPIs:
-    @patch("text_to_code.services.result_cache.opensearch")
-    def test_get(self, mock_opensearch_client):
-        mock_client = mock_opensearch_client.return_value
-        mock_client.get.return_value = {
+    def test_get(self):
+        mock_opensearch_client = MagicMock()
+        mock_opensearch_client.get.return_value = {
             "index": RESULT_CACHE_INDEX_NAME,
             "id": "13579246680",
             "version": "1.0.0",
@@ -37,7 +36,9 @@ class TestResultCacheAPIs:
             "fields": {},
         }
 
-        cached_result = get_cached_result(mock_client, RESULT_CACHE_INDEX_NAME, "1357924680")
+        cached_result = get_cached_result(
+            mock_opensearch_client, RESULT_CACHE_INDEX_NAME, "1357924680"
+        )
 
         assert cached_result is not None
         assert cached_result.cache_key == "1357924680"

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -65,8 +65,7 @@ class TestResultCacheAPIs:
             mock_opensearch_client, RESULT_CACHE_INDEX_NAME, "1357924680"
         )
 
-        assert cached_result is not None
-        assert not cached_result["found"]
+        assert cached_result is None
 
     def test_put_cache_hit_success(self):
         """Tests the Result Cache service's PUT function when the result is created."""

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -41,5 +41,5 @@ class TestResultCacheAPIs:
         )
 
         assert cached_result is not None
-        assert cached_result.cache_key == "1357924680"
-        assert cached_result.text == "Screening urine fentanyl detection"
+        assert cached_result["cache_key"] == "1357924680"
+        assert cached_result["text"] == "Screening urine fentanyl detection"

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -3,12 +3,14 @@ from unittest.mock import MagicMock
 
 from shared_models import Code
 from text_to_code.services.result_cache import get_cached_result
+from text_to_code.services.result_cache import put_new_cached_result
 
 RESULT_CACHE_INDEX_NAME = "test-result-cache"
 
 
 class TestResultCacheAPIs:
-    def test_get(self):
+    def test_get_success(self):
+        """Tests the Result Cache's GET functionality when the document is present."""
         mock_opensearch_client = MagicMock()
         mock_opensearch_client.get.return_value = {
             "index": RESULT_CACHE_INDEX_NAME,
@@ -21,7 +23,7 @@ class TestResultCacheAPIs:
             "source": {
                 "cache_key": "1357924680",
                 "text": "Screening urine fentanyl detection",
-                "data_field": "field",
+                "data_field": "Lab Test Name Ordered",
                 "loinc_code": json.dumps(
                     Code(
                         code_system="2.16.840.1.113883.6.1",
@@ -43,3 +45,54 @@ class TestResultCacheAPIs:
         assert cached_result is not None
         assert cached_result["cache_key"] == "1357924680"
         assert cached_result["text"] == "Screening urine fentanyl detection"
+
+    def test_get_miss(self):
+        """Tests the Result Cache's GET functionality when the document is absent."""
+        mock_opensearch_client = MagicMock()
+        mock_opensearch_client.get.return_value = {
+            "index": RESULT_CACHE_INDEX_NAME,
+            "id": "",
+            "version": "",
+            "seq_no": "",
+            "primary_term": "",
+            "found": False,
+            "routing": "",
+            "source": {},
+            "fields": {},
+        }
+
+        cached_result = get_cached_result(
+            mock_opensearch_client, RESULT_CACHE_INDEX_NAME, "1357924680"
+        )
+
+        assert cached_result is not None
+        assert not cached_result["found"]
+
+    def test_put_cache_hit_success(self):
+        """Tests the Result Cache service's PUT function when the result is created."""
+        mock_opensearch_client = MagicMock()
+        mock_opensearch_client.index.return_value = {
+            "_index": RESULT_CACHE_INDEX_NAME,
+            "_id": "a652c34ac12",
+            "_version": "1.0.0",
+            "result": "created",
+        }
+
+        standard_loinc_code = Code(
+            code="6299-2",
+            code_system="2.16.840.1.113883.6.1",
+            code_system_name="LOINC",
+            display_name="Urea nitrogen [Mass/volume] in Blood",
+        )
+
+        cache_result_created = put_new_cached_result(
+            mock_opensearch_client,
+            RESULT_CACHE_INDEX_NAME,
+            "blood urea nitrogen (BUN)",
+            "Lab Test Name Resulted",
+            standard_loinc_code,
+            0.97771,
+            0.8624,
+        )
+
+        assert cache_result_created

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from shared_models import Code
 from text_to_code.services.result_cache import get_cached_result
@@ -6,11 +7,11 @@ from text_to_code.services.result_cache import get_cached_result
 RESULT_CACHE_INDEX_NAME = "test-result-cache"
 
 
-def patch_opensearch_client(monkeypatch):
-    mock_client = object()
-
-    def mock_get() -> dict:
-        return {
+class TestResultCacheAPIs:
+    @patch("text_to_code.services.result_cache.opensearch")
+    def test_get(self, mock_opensearch_client):
+        mock_client = mock_opensearch_client.return_value
+        mock_client.get.return_value = {
             "index": RESULT_CACHE_INDEX_NAME,
             "id": "13579246680",
             "version": "1.0.0",
@@ -36,16 +37,8 @@ def patch_opensearch_client(monkeypatch):
             "fields": {},
         }
 
-    monkeypatch.setattr(mock_client, "get", mock_get)
-    return mock_client
+        cached_result = get_cached_result(mock_client, RESULT_CACHE_INDEX_NAME, "1357924680")
 
-
-class TestResultCacheAPIs:
-    def test_get(self, monkeypatch):
-        mock_client = patch_opensearch_client(monkeypatch)
-        cached_result = get_cached_result(
-            mock_client, RESULT_CACHE_INDEX_NAME, os_doc_id="1357924680"
-        )
         assert cached_result is not None
         assert cached_result.cache_key == "1357924680"
         assert cached_result.text == "Screening urine fentanyl detection"

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -27,7 +27,7 @@ class TestResultCacheAPIs:
                         code_system="2.16.840.1.113883.6.1",
                         code_system_name="LOINC",
                         display_name="fentaNYL [Presence] in Urine by Screen method",
-                    )
+                    ).__dict__
                 ),
                 "search_score": 0.9563,
                 "reranker_score": 0.6789,

--- a/packages/text-to-code/tests/unit/test_result_cache.py
+++ b/packages/text-to-code/tests/unit/test_result_cache.py
@@ -1,0 +1,51 @@
+import json
+
+from shared_models import Code
+from text_to_code.services.result_cache import get_cached_result
+
+RESULT_CACHE_INDEX_NAME = "test-result-cache"
+
+
+def patch_opensearch_client(monkeypatch):
+    mock_client = object()
+
+    def mock_get() -> dict:
+        return {
+            "index": RESULT_CACHE_INDEX_NAME,
+            "id": "13579246680",
+            "version": "1.0.0",
+            "seq_no": "2",
+            "primary_term": "3",
+            "found": True,
+            "routing": "",
+            "source": {
+                "cache_key": "1357924680",
+                "text": "Screening urine fentanyl detection",
+                "data_field": "field",
+                "loinc_code": json.dumps(
+                    Code(
+                        code_system="2.16.840.1.113883.6.1",
+                        code_system_name="LOINC",
+                        display_name="fentaNYL [Presence] in Urine by Screen method",
+                    )
+                ),
+                "search_score": 0.9563,
+                "reranker_score": 0.6789,
+                "cached_at": "2026-05-15T18:14:45.020655+00:00",
+            },
+            "fields": {},
+        }
+
+    monkeypatch.setattr(mock_client, "get", mock_get)
+    return mock_client
+
+
+class TestResultCacheAPIs:
+    def test_get(self, monkeypatch):
+        mock_client = patch_opensearch_client(monkeypatch)
+        cached_result = get_cached_result(
+            mock_client, RESULT_CACHE_INDEX_NAME, os_doc_id="1357924680"
+        )
+        assert cached_result is not None
+        assert cached_result.cache_key == "1357924680"
+        assert cached_result.text == "Screening urine fentanyl detection"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,11 @@ select = [
   "W",    # pycodestyle warning
 ]
 ignore = [
-  "D100",   # undocumented-public-module
-  "E501",   # line-too-long - Handled by formatter
-  "RET504", # unnecessary-assign
-  "S314",   # recommend `defusedxml` over `xml` and `lxml`
+  "D100",    # undocumented-public-module
+  "E501",    # line-too-long - Handled by formatter
+  "PLR0913", # too many arguments in function definition
+  "RET504",  # unnecessary-assign
+  "S314",    # recommend `defusedxml` over `xml` and `lxml`
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,10 @@ select = [
   "W",    # pycodestyle warning
 ]
 ignore = [
-  "D100",    # undocumented-public-module
-  "E501",    # line-too-long - Handled by formatter
-  "PLR0913", # too many arguments in function definition
-  "RET504",  # unnecessary-assign
-  "S314",    # recommend `defusedxml` over `xml` and `lxml`
+  "D100",   # undocumented-public-module
+  "E501",   # line-too-long - Handled by formatter
+  "RET504", # unnecessary-assign
+  "S314",   # recommend `defusedxml` over `xml` and `lxml`
 ]
 
 [tool.ruff.lint.flake8-annotations]


### PR DESCRIPTION
## Description

This PR creates the result cache service within text-to-code and builds out its GET and PUT functionality for storing and retrieving cached results within open search. I opted to make this its own PR before integrating with e2e since there's a new service being created, and this helps keep each individual PR review small.

## Related Issues

Related to a task in #533 