### PR TITLE
Release: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dibbs-text-to-code-root"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = [
   { name = "Brady Fausett", email = "bradyfausett@skylight.digital" },

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ requires-dist = [
 
 [[package]]
 name = "dibbs-text-to-code-root"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Follow-up to #558. Bumps the root `pyproject.toml` version from `0.1.0` to `0.2.0` to trigger the new release workflow and cut the first versioned release.

## Test plan

- [ ] On merge, confirm `v0.2.0` tag exists on origin pointing at the merge commit
- [ ] GHCR + APHL ECR each have `index` / `ttc` / `augmentation` with `:v0.2.0`, `:v0.2`, `:v0`, `:latest`
- [ ] GitHub Releases page shows `v0.2.0` published with auto-generated PR notes
- [ ] Slack receives the release link
- [ ] `docker-image-push.yml` `build` job is skipped on the release commit