### PR TITLE
Drop gcc-c++ from Lambda images to remove HIGH CVEs

### DIFF
--- a/Dockerfile.augmentation
+++ b/Dockerfile.augmentation
@@ -7,11 +7,13 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 ARG ENVIRONMENT=prod
 ENV ENVIRONMENT=${ENVIRONMENT}
 
-# Update OS packages for CVE fixes, install build tools for compiling C++ extensions,
-# and drop the Runtime Interface Emulator (only used for local Lambda emulation).
+# Update OS packages for CVE fixes and drop the Runtime Interface Emulator
+# (only used for local Lambda emulation). All pip dependencies install from
+# prebuilt wheels, so no compiler toolchain is needed — keeping gcc-c++ out
+# of the image also keeps its build-time deps (kernel-headers, rust-toolset)
+# off the runtime layer, which is where the HIGH-severity CVEs come from.
 # --releasever=latest is required: AL2023 base images pin to a snapshot release.
 RUN microdnf update -y --releasever=latest \
-    && microdnf install -y --releasever=latest gcc-c++ make \
     && microdnf clean all \
     && rm -f /usr/local/bin/aws-lambda-rie
 

--- a/Dockerfile.index
+++ b/Dockerfile.index
@@ -10,16 +10,21 @@ ENV ENVIRONMENT=${ENVIRONMENT}
 # Initialize the index_lambda directory
 RUN mkdir -p "${LAMBDA_TASK_ROOT}/src/index_lambda"
 
-# Update OS packages for CVE fixes, install build tools for compiling C++ extensions,
-# and drop the Runtime Interface Emulator (only used for local Lambda emulation).
+# Update OS packages for CVE fixes and drop the Runtime Interface Emulator
+# (only used for local Lambda emulation). All pip dependencies install from
+# prebuilt wheels, so no compiler toolchain is needed — keeping gcc-c++ out
+# of the image also keeps its build-time deps (kernel-headers, rust-toolset)
+# off the runtime layer, which is where the HIGH-severity CVEs come from.
 # --releasever=latest is required: AL2023 base images pin to a snapshot release.
 RUN microdnf update -y --releasever=latest \
-    && microdnf install -y --releasever=latest gcc-c++ make \
     && microdnf clean all \
     && rm -f /usr/local/bin/aws-lambda-rie
 
 # Copy over just the pyproject.toml file and install the dependencies doing this
 # before copying the rest of the code allows for caching of the dependencies
+COPY ./packages/shared-models ${LAMBDA_TASK_ROOT}/shared-models
+RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/shared-models"
+
 COPY ./packages/utils ${LAMBDA_TASK_ROOT}/utils
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/utils"
 

--- a/Dockerfile.ttc
+++ b/Dockerfile.ttc
@@ -3,11 +3,13 @@ FROM public.ecr.aws/lambda/python:3.12
 LABEL org.opencontainers.image.source=https://github.com/CDCgov/dibbs-text-to-code
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-# Update OS packages for CVE fixes, install build tools for compiling C++ extensions,
-# and drop the Runtime Interface Emulator (only used for local Lambda emulation).
+# Update OS packages for CVE fixes and drop the Runtime Interface Emulator
+# (only used for local Lambda emulation). All pip dependencies install from
+# prebuilt wheels, so no compiler toolchain is needed — keeping gcc-c++ out
+# of the image also keeps its build-time deps (kernel-headers, rust-toolset)
+# off the runtime layer, which is where the HIGH-severity CVEs come from.
 # --releasever=latest is required: AL2023 base images pin to a snapshot release.
 RUN microdnf update -y --releasever=latest \
-    && microdnf install -y --releasever=latest gcc-c++ make \
     && microdnf clean all \
     && rm -f /usr/local/bin/aws-lambda-rie
 
@@ -46,9 +48,6 @@ RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code"
 COPY ./packages/text-to-code-lambda ${LAMBDA_TASK_ROOT}/text-to-code-lambda
 RUN pip install --no-cache-dir "${LAMBDA_TASK_ROOT}/text-to-code-lambda" \
     && pip install --no-cache-dir --upgrade "urllib3>=2.7.0"
-
-# Remove build tools no longer needed at runtime
-RUN rpm -e --nodeps gcc-c++ gcc cpp make && microdnf clean all && rm -rf /var/cache/*
 
 # Clean up package source copies
 RUN rm -rf ${LAMBDA_TASK_ROOT}/shared-models ${LAMBDA_TASK_ROOT}/utils ${LAMBDA_TASK_ROOT}/lambda-handler ${LAMBDA_TASK_ROOT}/text-to-code ${LAMBDA_TASK_ROOT}/text-to-code-lambda


### PR DESCRIPTION
## Summary

- Drops `microdnf install gcc-c++ make` from all three Lambda Dockerfiles. The C++ toolchain was never needed at runtime — every pip dependency (torch, lxml, pydantic-core, grpcio, opensearch-protobufs, etc.) installs from a prebuilt wheel on Python 3.12 / AL2023. Removing it eliminates the two HIGH CVEs that were riding along as transitive build deps:
  - `kernel6.18-headers` — CVE-2026-46300 ("Fragnesia" / Dirty Frag in ESP/XFRM)
  - `rust-toolset-srpm-macros` — CVE-2026-6654 (thin-vec UAF)
- Also drops the now-redundant post-install `rpm -e --nodeps gcc-c++ gcc cpp make` cleanup from `Dockerfile.ttc`.
- Adds `shared-models` install to `Dockerfile.index` — `lambda-handler` imports it but it was never installed, so the index handler failed to import before this change.

After the fix, `trivy image --severity HIGH,CRITICAL --ignore-unfixed` reports zero findings on all three rebuilt images.

## Remaining AWS Inspector HIGH findings (not addressed)

Inspector still reports 3 HIGH findings against `ttc-lambda:latest`, all with `fixedInVersion: NotAvailable`:

- `transformers` 5.9.0 — CVE-2025-14929 (X-CLIP checkpoint deserialization RCE)
- `torch` 2.9.1+cpu — CVE-2026-4538 (`torch.export.load` on untrusted `.pt2`; upstream PR #176791 was closed unmerged)
- `joblib` 1.5.3 — CVE-2024-34997 (confirmed false positive by joblib maintainers in joblib#1588)

All three require attacker-controlled deserialized input. This Lambda only loads pre-baked NCHS retriever/reranker models from `/opt/` and never accepts pickles/checkpoints from request input, so none are exploitable here. Tracked for re-scan once upstream fixes land.

## Test plan

- [ ] `docker build -f Dockerfile.index -t ttc-index .` succeeds
- [ ] `docker build -f Dockerfile.augmentation -t ttc-aug .` succeeds
- [ ] `docker build -f Dockerfile.ttc -t ttc-main --secret id=huggingface_token,env=HF_TOKEN .` succeeds
- [ ] `trivy image --severity HIGH,CRITICAL --ignore-unfixed` reports 0 findings on each image
- [ ] Index Lambda handler imports cleanly: `python -c "from index_lambda.lambda_function import handler"`
- [ ] CI build-and-push workflow passes