### PR TITLE
Skip floating vX.Y / vX tags on APHL ECR push

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -126,20 +126,30 @@ jobs:
         id: aphl-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Push every tag to APHL ECR
+      - name: Push tags to APHL ECR
         env:
           OWNER: ${{ steps.repo.outputs.owner }}
           NAME: ${{ matrix.name }}
           APHL_ECR: ${{ secrets.APHL_ECR_REPOSITORY_URL }}
           META_JSON: ${{ steps.meta.outputs.json }}
+          MINOR_TAG: ${{ inputs.minor_tag }}
+          MAJOR_TAG: ${{ inputs.major_tag }}
         run: |
           set -euo pipefail
-          # Re-tag and push every tag the metadata action produced. Iterating
-          # over the metadata output keeps GHCR and APHL ECR exactly in sync;
-          # both registries receive the same set of (v0.2.0, v0.2, v0, latest)
-          # on releases, or (latest, main) on dev pushes.
+          # Re-tag and push tags the metadata action produced. APHL ECR has
+          # tag immutability enabled on everything except :latest, so we skip
+          # the floating vX.Y and vX tags (which would need to be re-pointed
+          # on each release). GHCR still receives the full set.
           for tag in $(jq -r '.tags[]' <<< "$META_JSON"); do
             bare="${tag##*:}"
+            if [ -n "$MINOR_TAG" ] && [ "$bare" = "$MINOR_TAG" ]; then
+              echo "Skipping floating tag ${bare} for APHL ECR (immutable)"
+              continue
+            fi
+            if [ -n "$MAJOR_TAG" ] && [ "$bare" = "$MAJOR_TAG" ]; then
+              echo "Skipping floating tag ${bare} for APHL ECR (immutable)"
+              continue
+            fi
             GHCR_IMAGE="ghcr.io/${OWNER}/dibbs-text-to-code/${NAME}:${bare}"
             ECR_IMAGE="${APHL_ECR}/${NAME}:${bare}"
             echo "Pushing ${ECR_IMAGE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,12 @@ name: release
 
 # Triggered on every push to `main`. Detects whether the merge commit bumps
 # the `version` field in the root `pyproject.toml`. If yes, tags the merge
-# commit, builds all three Lambda images, pushes them to GHCR and APHL ECR
-# with vX.Y.Z / vX.Y / vX / latest tags, publishes a GitHub Release with
-# auto-generated PR notes, and posts the link to Slack.
+# commit, builds all three Lambda images, pushes them to GHCR with
+# vX.Y.Z / vX.Y / vX / latest tags and to APHL ECR with vX.Y.Z / latest
+# only (APHL ECR has tag immutability enabled on everything but :latest, so
+# the floating vX.Y and vX tags would fail to re-point on each release).
+# Publishes a GitHub Release with auto-generated PR notes and posts the
+# link to Slack.
 #
 # The full release happens in a single workflow run; we do not rely on the
 # tag-push trigger (GITHUB_TOKEN-created tags do not fan out to other

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,12 +19,16 @@ release link to Slack.
 4. The `release` workflow runs automatically on the merge commit:
    - tags the merge commit as `vX.Y.Z`
    - builds all three Lambda images for `linux/amd64`
-   - pushes `vX.Y.Z`, `vX.Y`, `vX`, and `latest` tags to both GHCR and APHL ECR
+   - pushes `vX.Y.Z`, `vX.Y`, `vX`, and `latest` tags to GHCR
+   - pushes `vX.Y.Z` and `latest` to APHL ECR (APHL ECR has tag
+     immutability enabled on everything but `latest`, so the floating
+     `vX.Y` / `vX` tags can't be re-pointed there)
    - publishes a GitHub Release named `vX.Y.Z` with auto-generated notes
    - posts the release link to Slack
 
-The `vX.Y` and `vX` tags float to the latest release within that line; the
-`vX.Y.Z` tag is immutable.
+On GHCR, the `vX.Y` and `vX` tags float to the latest release within that
+line; the `vX.Y.Z` tag is immutable. On APHL ECR every tag except
+`latest` is immutable.
 
 ### Hotfix
 
@@ -38,8 +42,10 @@ After merging a release PR, confirm:
 - [ ] **Actions tab**: the `release` workflow run on the merge commit is green.
 - [ ] **Tags**: `git fetch --tags && git tag -l "vX.Y.Z"` shows the new tag.
 - [ ] **GitHub Releases**: `vX.Y.Z` is published (not draft) with PR-list notes.
-- [ ] **APHL ECR**: each of `index`, `ttc`, `augmentation` has `vX.Y.Z`,
-      `vX.Y`, `vX`, and `latest` tags.
+- [ ] **APHL ECR**: each of `index`, `ttc`, `augmentation` has `vX.Y.Z`
+      and `latest` tags.
+- [ ] **GHCR**: each image additionally has `vX.Y` and `vX` floating tags
+      pointing at this release.
 - [ ] **Slack**: the release-notifications channel received the release link.
 
 ## Failure modes


### PR DESCRIPTION
## Summary

- The v0.2.1 release workflow failed pushing to APHL ECR with `The image tag 'v0.2' already exists ... and cannot be overwritten because the tag is immutable`. APHL ECR has tag immutability enabled on every tag except `:latest`, so re-pointing the floating `vX.Y` and `vX` tags fails on every release after the first.
- Update the reusable build/push workflow to skip the `minor_tag` and `major_tag` values when iterating over the metadata-action tag list for the APHL push. GHCR still receives the full `vX.Y.Z` / `vX.Y` / `vX` / `latest` set.
- Update `docs/releases.md` and the `release.yml` header comment to reflect that APHL ECR only ever has `vX.Y.Z` and `latest` for each image.

Note: the v0.2.1 git tag was created and the GitHub Release was not (`release` job depends on `build`). After this lands we'll need to either dispatch the build manually or roll forward to v0.2.2 — happy to follow up with whichever approach we pick.

## Test plan

- [ ] CI green on this PR
- [ ] On the next release, confirm: GHCR has `vX.Y.Z`/`vX.Y`/`vX`/`latest`; APHL ECR has only `vX.Y.Z` and `latest`; no immutability error in the workflow logs