### PR TITLE
refactor: Move some log statements closer to relevant code

### DIFF
--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -349,19 +349,9 @@ def _process_schematron_errors(
 
         text_candidates = processor.get_text_candidates(error.error_context, data_field)
 
-        logger.info(
-            "Evaluating candidates and selecting relevant text for each error in the eICR",
-            status="processing",
-        )
-
         selected_candidate = evaluator.select_relevant_text(text_candidates, data_field)
 
         error_with_candidate = error.model_copy(update={"candidate": selected_candidate})
-
-        logger.info(
-            "Embedding the relevant text strings for each error in the eICR",
-            status="processing",
-        )
 
         if selected_candidate is None:
             unmatched_error = error_with_candidate.model_dump()

--- a/packages/text-to-code/src/text_to_code/services/embedder.py
+++ b/packages/text-to-code/src/text_to_code/services/embedder.py
@@ -1,7 +1,11 @@
+import logging
+
 from sentence_transformers import SentenceTransformer
 from torch import Tensor
 
 from text_to_code.models.registry import TTC_RETRIEVER
+
+logger = logging.getLogger(__name__)
 
 _RETRIEVER = SentenceTransformer(TTC_RETRIEVER)
 
@@ -15,4 +19,8 @@ def embed(text: str) -> Tensor:
     :param text: Text string to embed.
     :returns: Tensor representation of input text.
     """
+    logger.info(
+        "Embedding the text string.",
+        extra={"status": "processing"},
+    )
     return _RETRIEVER.encode(text)

--- a/packages/text-to-code/src/text_to_code/services/evaluator.py
+++ b/packages/text-to-code/src/text_to_code/services/evaluator.py
@@ -1,3 +1,5 @@
+import logging
+
 from shared_models import DataField
 from text_to_code.models.evaluator import (
     EVALUATION_REGISTRY,
@@ -8,6 +10,8 @@ from text_to_code.models.evaluator import (
 )
 
 from ..models.eicr import Candidate, LabXPaths
+
+logger = logging.getLogger(__name__)
 
 
 def _classify_translation_system(
@@ -99,6 +103,10 @@ def select_relevant_text(candidates: list[Candidate], field_type: DataField) -> 
     :param criteria: The evaluation criteria defining priority order and translation behavior.
     :returns: The selected Candidate, or None if no candidate is viable.
     """
+    logger.info(
+        "Evaluating candidates and selecting relevant text",
+        extra={"status": "processing"},
+    )
     criteria = _get_evaluation_criteria_for_data_field(field_type)
     for priority in criteria.ordered_priorities():
         best_candidate = _resolve_best_for_xpath(


### PR DESCRIPTION
## Description

There are  several log statements in the TTC lambda function that could be moved into their relevant modules:
- `"Evaluating candidates and selecting relevant text for each error in the eICR"` can be moved into the embedder
- `"Evaluating candidates and selecting relevant text"` can be moved into the evaluator.

## Related Issues

Closes # n/a

## Additional Notes

This was something I ended up doing for [PR 570](https://github.com/CDCgov/dibbs-text-to-code/pull/570) to reduce the size of the `_process_schematron_errors` function. However it can be easily moved into its own PR.