### PR TITLE
Pin external GitHub actions to specific commit SHAs

### DIFF
--- a/.github/scripts/check_action_pins.py
+++ b/.github/scripts/check_action_pins.py
@@ -19,6 +19,7 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 def find_violations() -> list[tuple[Path, int, str]]:
+    """Return `(path, lineno, ref)` for each unpinned external `uses:` reference."""
     violations: list[tuple[Path, int, str]] = []
     for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
         for lineno, line in enumerate(path.read_text().splitlines(), start=1):
@@ -38,6 +39,7 @@ def find_violations() -> list[tuple[Path, int, str]]:
 
 
 def main() -> int:
+    """Print any violations to stderr and return a non-zero exit code if found."""
     violations = find_violations()
     if not violations:
         return 0

--- a/.github/scripts/check_action_pins.py
+++ b/.github/scripts/check_action_pins.py
@@ -1,0 +1,59 @@
+"""Fail if any external GitHub Action under `.github/workflows/` is not pinned to a 40-char commit SHA.
+
+Mitigates supply-chain attacks where a third party re-points a mutable tag (e.g. `v4`)
+at a malicious commit. Internal references (`./.github/workflows/...`) are allowed
+since they live in this repo.
+
+Run via pre-commit. Exits non-zero on any unpinned external `uses:` line.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github/workflows")
+USES_RE = re.compile(r'^\s*(?:-\s+)?uses:\s+["\']?(?P<ref>[^"\'\s#]+)["\']?')
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def find_violations() -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            m = USES_RE.match(line)
+            if not m:
+                continue
+            ref = m.group("ref")
+            if ref.startswith("./"):
+                continue
+            if "@" not in ref:
+                violations.append((path, lineno, ref))
+                continue
+            _, _, version = ref.partition("@")
+            if not SHA_RE.match(version):
+                violations.append((path, lineno, ref))
+    return violations
+
+
+def main() -> int:
+    violations = find_violations()
+    if not violations:
+        return 0
+    print("Unpinned GitHub Action references found:", file=sys.stderr)
+    for path, lineno, ref in violations:
+        print(f"  {path}:{lineno}: {ref}", file=sys.stderr)
+    print(
+        "\nPin each external `uses:` to a 40-char commit SHA with a version "
+        "comment, e.g.:\n"
+        "  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2\n"
+        "Tip: `pinact run` (https://github.com/suzuki-shunsuke/pinact) "
+        "resolves tags to SHAs automatically.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -77,10 +77,10 @@ jobs:
           echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-text-to-code/${{ matrix.name }}
           tags: |
@@ -100,7 +100,7 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.tag_latest }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -116,7 +116,7 @@ jobs:
             "huggingface_token=${{ secrets.HF_TOKEN }}"
 
       - name: Configure APHL AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
         with:
           aws-access-key-id: ${{ secrets.APHL_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.APHL_AWS_SECRET_ACCESS_KEY }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Login to APHL ECR
         id: aphl-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
       - name: Push tags to APHL ECR
         env:

--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -27,16 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: 1.14.7
           terraform_wrapper: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
         with:
           role-to-assume: ${{ secrets.TERRAFORM_ROLE_ARN }}
           role-session-name: githubBootstrapWorkflow

--- a/.github/workflows/check_code_vulnerabilities.yml
+++ b/.github/workflows/check_code_vulnerabilities.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: "pyproject.toml"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/check_types.yml
+++ b/.github/workflows/check_types.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: "pyproject.toml"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: 'pyproject.toml'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -39,7 +39,7 @@ jobs:
           uv run coverage xml -o coverage.xml
 
       - name: Upload combined coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,16 +36,16 @@ jobs:
       TF_VAR_debug_iam_principals: ${{ secrets.DEBUG_IAM_PRINCIPALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: 1.14.7
           terraform_wrapper: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
         with:
           role-to-assume: ${{ secrets.TERRAFORM_ROLE_ARN }}
           role-session-name: githubDeploymentWorkflow
@@ -71,7 +71,7 @@ jobs:
       - name: Login to Amazon ECR
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
       - name: Get ECR repository URLs
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
@@ -87,11 +87,11 @@ jobs:
 
       - name: Set up Buildx
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push Index Docker image
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile.index
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build and push TTC Docker image
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile.ttc
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build and push Augmentation Docker image
         if: ${{ inputs.apply && !inputs.destroy || (github.event_name == 'push' && github.ref_name == 'main') }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile.augmentation

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -34,7 +34,7 @@ jobs:
       is_release: ${{ steps.detect.outputs.is_release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -124,7 +124,7 @@ jobs:
           echo "RELEASE_URL=$html_url" >> "$GITHUB_ENV"
 
       - name: Post release to Slack
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Make repo owner lowercase
         id: repo
@@ -108,14 +108,14 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: steps.check.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: "trivy-${{ matrix.image }}-results.sarif"
           category: "vulnerability-scan-${{ matrix.image }}"
 
       - name: Upload JSON results as artifact
         if: steps.check.outputs.exists == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-results-${{ matrix.image }}
           path: trivy-${{ matrix.image }}-results.json
@@ -158,16 +158,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download scan results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: trivy-results-*
           merge-multiple: true
 
       - name: Send Slack notification
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/.github/workflows/slack_notifier_merged.yml
+++ b/.github/workflows/slack_notifier_merged.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Send GitHub trigger payload to Slack
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/slack_notifier_open_pulls.yml
+++ b/.github/workflows/slack_notifier_open_pulls.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Check out the repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: List open pull requests
       env:
@@ -38,7 +38,7 @@ jobs:
         fi
 
     - name: Post to Slack
-      uses: slackapi/slack-github-action@v3.0.3
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       if: ${{ env.SHOULD_POST_TO_SLACK == 'true' }}
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack_notifier_review.yml
+++ b/.github/workflows/slack_notifier_review.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Send GitHub trigger payload to Slack
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,12 @@ repos:
     rev: v0.9.3
     hooks:
       - id: taplo-format
+
+  - repo: local
+    hooks:
+      - id: check-action-pins
+        name: Check GitHub Actions are SHA-pinned
+        entry: python3 .github/scripts/check_action_pins.py
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Pins every external GitHub Action referenced in `.github/workflows/` to a 40-char commit SHA (with a `# vX.Y.Z` version comment) to mitigate supply-chain attacks where a third party re-points a mutable tag at a malicious commit.

Before this PR, 44 of 47 external `uses:` references were tag-pinned; only `aquasecurity/trivy-action` was already SHA-pinned.

## Changes

- Pinned 45 external action references across 13 workflow files. Each was bumped to the latest stable release within its current major (e.g. `actions/checkout@v6` → `v6.0.2`) before pinning. The `# vX.Y.Z` comment is the format Dependabot recognizes, so it will continue to surface minor/patch bumps.
- `aquasecurity/trivy-action` was already pinned to v0.36.0
- Added a local pre-commit hook (`check-action-pins`, backed by `.github/scripts/check_action_pins.py`) that scans `.github/workflows/*.y(a)ml` and fails commits introducing any unpinned external `uses:` reference. Used a self-contained ~40-line Python script.
- No changes to `.github/dependabot.yml` as it already monitors `github-actions` weekly.

Potential follow-up:

- Several actions have newer majors available (`actions/download-artifact` v5–v8, `actions/github-script` v8–v9, `astral-sh/setup-uv` v8). Decided to save major bumps for separate PRs.

## Test plan

- [ ] CI passes on this PR (exercises `check_lint.yml`, `check_unit_tests.yml`, `check_types.yml`, `check_code_vulnerabilities.yml`, `docker-image-push.yml`).
- [ ] Manually trigger `scan.yml` via `gh workflow run scan.yml` (or wait for the schedule) and confirm Trivy + CodeQL + Slack notifier jobs all complete.
- [ ] After merge, confirm `deploy.yaml` runs cleanly on the next deploy.
- [ ] Confirm Dependabot opens its next weekly PR against the new SHA-pinned references and includes the version comment in the diff.
- [ ] Confirm the new pre-commit hook blocks a deliberately unpinned `uses:` line
