### PR TITLE
Add coverage shortcut for unit tests

### DIFF
--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -11,3 +11,7 @@ e2e *ARGS:
 [doc("Run all tests, forwarding optional arguments to pytest")]
 all *ARGS:
     uv run pytest {{ ARGS }}
+
+[doc("Run tests with coverage, specifcying the package to measure coverage for")]
+coverage *ARGS:
+    uv run pytest {{ ARGS }} --cov={{ARGS}} --cov-report=term-missing

--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -12,6 +12,6 @@ e2e *ARGS:
 all *ARGS:
     uv run pytest {{ ARGS }}
 
-[doc("Run tests with coverage, specifcying the package to measure coverage for")]
+[doc("Run tests with coverage, specifying the package to measure coverage for")]
 coverage *ARGS:
     uv run pytest {{ ARGS }} --cov={{ARGS}} --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ To update snapshots:
 just test all --snapshot-update
 ```
 
+To check coverage for a specific package or test suite:
+
+```sh
+just test coverage packages/augmentation-lambda
+```
+
 ### e2e Tests:
 
 To run e2e tests, use the following command:


### PR DESCRIPTION
## Description

The `uv run pytest  --cov=packages --cov-report=term-missing` optional args are just finnicky enough that I thought it might be helpful to have a shortcut to check packages/ or a specific subfolder of packages/ for completeness in coverage. 

## Related Issues

Closes minor pet peeve

## Additional Notes

[Add any additional context or notes that reviewers should know about.]

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
