### PR TITLE
fix: Bypass Docker layer cache when rebuilding for OS patches

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -45,6 +45,15 @@ on:
         type: string
         required: false
         default: ""
+      no_cache:
+        description: >-
+          Build without layer cache. Required when the goal is picking up OS
+          package patches: the `microdnf update` layer is keyed on the base
+          image digest, so cached builds silently skip repo updates (e.g.
+          AL2023 security patches) published since the layer was first built.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -110,6 +119,7 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          no-cache: ${{ inputs.no_cache }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           secrets: |

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -18,6 +18,13 @@ on:
       version_tag:
         description: Optional Docker tag
         required: false
+      no_cache:
+        description: >-
+          Build without layer cache so OS package patches are picked up.
+          Disable only when rebuilding for a code change.
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -56,3 +63,7 @@ jobs:
       extra_tag: ${{ github.event.inputs.version_tag || '' }}
       tag_branch: true
       tag_latest: ${{ github.ref_name == 'main' }}
+      # The weekly rebuild exists to pick up base-image/OS patches, which a
+      # cached `microdnf update` layer silently skips — so bust the cache on
+      # schedule and (by default) on manual dispatch. Push builds stay cached.
+      no_cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.no_cache != 'false') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,9 @@ jobs:
       major_tag: ${{ needs.detect-release.outputs.major }}
       tag_latest: true
       tag_branch: false
+      # Versioned images are long-lived; never bake week-old cached OS layers
+      # into a release.
+      no_cache: true
 
   release:
     needs: [detect-release, build]


### PR DESCRIPTION
## Problem

The four open HIGH code-scanning alerts flag `libsolv 0.7.22-1.amzn2023.0.3` in the augmentation image, all fixed in `0.7.22-1.amzn2023.0.4`. `Dockerfile.augmentation` already runs `microdnf update -y --releasever=latest`, and the weekly rebuild exists precisely so these patches land, yet rebuilding (including a manual run today) didn't pick up the fix.

Root cause: the GHA BuildKit cache keys the `RUN microdnf update` layer on the base image digest + instruction text. Amazon published the patched libsolv to the AL2023 repos *without* a new `lambda/python:3.12` base image, so scheduled and manual rebuilds reused the stale cached layer and pushed a byte-identical image (build log shows `#13 RUN microdnf update ... CACHED`).

## Fix

- `_build-and-push.yml`: new `no_cache` input, passed to `docker/build-push-action` as `no-cache`. Cache is still *written* on no-cache builds, so subsequent cached builds inherit the freshly patched layers.
- `docker-image-push.yml`: bypass cache on the weekly schedule and on manual dispatch (new checkbox, default on — manual rebuilds are usually for patch pickup). Push-to-main builds keep using the cache for speed.
- `release.yml`: release builds always use `no-cache: true` so versioned, long-lived images never bake in stale cached OS layers.

Verified the patched package is reachable: `microdnf update --releasever=latest` in a fresh `public.ecr.aws/lambda/python:3.12` container upgrades libsolv to exactly `0.7.22-1.amzn2023.0.4`.

## After merging

Dispatch **Build and push images (dev)** (no-cache is now the dispatch default), then re-run **Scan GHCR Images for Vulnerabilities**. 