### PR TITLE
Release v0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dibbs-text-to-code-root"
-version = "0.2.1"
+version = "0.2.2"
 description = ""
 authors = [
   { name = "Brady Fausett", email = "bradyfausett@skylight.digital" },

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ requires-dist = [
 
 [[package]]
 name = "dibbs-text-to-code-root"
-version = "0.2.1"
+version = "0.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bumps the root package version from `0.2.1` to `0.2.2`. Per `docs/releases.md`, merging to `main` triggers the release workflow to tag `v0.2.2`, build/publish the three Lambda images (`index`, `ttc`, `augmentation`) to GHCR and APHL ECR, and post the release to Slack.

## Changes since v0.2.1

- #624 — Update Schematron Model and Processor to use new/updated Schematron Error Messages from APHL
- #618 — Adding opensearch test to lambda-handler
- #617 — Revert "Remove Marcelle from CODEOWNERS"
- #609 — fix: Bypass Docker layer cache when rebuilding for OS patches
- #608 — refactor: Remove augmentation ABC
- #607 — refactor: ruff data curation
- #605 — Add coverage shortcut for unit tests
- #599 — Increasing data-curation coverage
- #598 — feat!: Remove configuration from Augmentation
- #594 — Add Schematron validation to aws_e2e.sh
- #593 — SPIKE: Embedding variability
- #592 — typing in data curation folder and rest of repo
- #590 — Add Embedding Vectors to Embedding Records for LOINC Updates
- #588 — Pin external GitHub actions to specific commit SHAs
- #580 — Extending ty checks to most of packages/ folder
- #578 — refactor: Move some log statements closer to relevant code
- #577 — Skip floating vX.Y / vX tags on APHL ECR push
- #570 — feat!: Refactor TTC lambda function and condense saved models.
- #569 — Rob/adding evaluator coverage test
- #568 — Extending schematron validation in e2e tests

(Dependabot bumps omitted; full notes are auto-generated on the GitHub Release.)

Note: #570 and #598 are marked `feat!:` (breaking). If those warrant a minor bump instead, this can be re-cut as `0.3.0`.

## Test plan

- [x] CI green on this PR
- [x] After merge: `release` workflow run on the merge commit is green
- [ ] `git fetch --tags && git tag -l "v0.2.2"` shows the new tag
- [ ] GitHub Release `v0.2.2` published with PR-list notes
- [ ] APHL ECR has `v0.2.2` and `latest` tags for `index`, `ttc`, `augmentation`
- [ ] Slack release-notifications channel received the release link