### PR TITLE
refactor: simplify typing in data curation

### DIFF
--- a/packages/data-curation/src/data_curation/terminologies/loinc.py
+++ b/packages/data-curation/src/data_curation/terminologies/loinc.py
@@ -90,9 +90,6 @@ def _get_loinc_lab_names(version: str = "") -> list:
     all_loinc_rows = _process_loinc_valueset(api_url, loinc_vs_type)
 
     # Now let's add the ConsumerName for each of the loinc codes
-
-    if not isinstance(all_loinc_rows, list):
-        raise ValueError("Expected a list.")
     all_loinc_rows = _get_loinc_consumer_names(all_loinc_rows)
     return all_loinc_rows
 
@@ -117,9 +114,8 @@ def _get_loinc_lab_orders(version: str = "") -> list:
         api_url = LOINC_BASE_URL + f"query={LOINC_LAB_ORDER_QUERY}"
     loinc_vs_type = "Lab Orders"
     loinc_order_rows = _process_loinc_valueset(api_url, loinc_vs_type)
+
     # Now let's add the ConsumerName for each of the loinc codes
-    if not isinstance(loinc_order_rows, list):
-        raise ValueError("Expected a list.")
     loinc_order_rows = _get_loinc_consumer_names(loinc_order_rows)
 
     return loinc_order_rows
@@ -146,14 +142,12 @@ def _get_loinc_lab_results(version: str = "") -> list:
     loinc_vs_type = "Lab Results"
     loinc_result_rows = _process_loinc_valueset(api_url, loinc_vs_type)
 
-    if not isinstance(loinc_result_rows, list):
-        raise ValueError("Expected list.")
     # Now let's add the ConsumerName for each of the loinc codes
     loinc_result_rows = _get_loinc_consumer_names(loinc_result_rows)
     return loinc_result_rows
 
 
-def _process_loinc_valueset(api_url: str, loinc_valueset_type: str) -> list[dict] | dict:
+def _process_loinc_valueset(api_url: str, loinc_valueset_type: str) -> list[dict]:
     """Function that makes the LOINC API calls based upon the url and the loinc_Valueset_type passed in.  It confirms that the LOINC User/PWD are configured, makes the calls and then passes the output into another function for more detailed processing. This function also performs the looping and row count maintanence as LOINC can only return 500 rows at a time.
 
     :param api_url: LOINC url for the specific API used for requesting
@@ -215,7 +209,7 @@ def _process_loinc_valueset(api_url: str, loinc_valueset_type: str) -> list[dict
 
     if loinc_valueset_type not in ("UMLS Atoms"):
         return loinc_rows
-    return loinc_umls_urls
+    return [loinc_umls_urls]
 
 
 def _process_loinc_results(
@@ -279,9 +273,7 @@ def process_loincs_for_umls_urls() -> dict:
     """
     loinc_api_url = LOINC_BASE_URL + LOINC_LAB_NAMES_QUERY
     umls_loinc_results = _process_loinc_valueset(loinc_api_url, "UMLS Atoms")
-    if not isinstance(umls_loinc_results, dict):
-        raise ValueError("Expected a dict.")
-    return umls_loinc_results
+    return umls_loinc_results[0]
 
 
 def _get_all_loinc_terms_per_code(loinc_result: dict, loinc_rows: list[LoincRow]) -> list[LoincRow]:

--- a/packages/data-curation/tests/test_loinc.py
+++ b/packages/data-curation/tests/test_loinc.py
@@ -405,45 +405,6 @@ def test_process_loinc_valueset_requires_credentials(monkeypatch: pytest.MonkeyP
         loinc._process_loinc_valueset("https://example.com", "Lab Names")
 
 
-def test_process_loinc_valueset_gets_umls_urls(monkeypatch: pytest.MonkeyPatch, mocker) -> None:
-    payload: dict[str, object] = {
-        "ResponseSummary": {
-            "RecordsFound": 1,
-            "RowsReturned": 1,
-            "Next": None,
-        },
-        "Results": [
-            {
-                "LOINC_NUM": "12345-F",
-                "LONG_COMMON_NAME": "TEST LONG NAME",
-            }
-        ],
-    }
-
-    monkeypatch.setattr(loinc, "LOINC_USERNAME", "username")
-    monkeypatch.setattr(loinc, "LOINC_PWD", "password")
-    mocker.patch(
-        "data_curation.terminologies.loinc.get_with_timeout",
-        return_value=MockResponse(200, payload),
-    )
-
-    result = loinc._process_loinc_valueset("https://example.com", "UMLS Atoms")
-
-    assert result == {
-        "12345-F": {
-            "atom": loinc.UMLS_LOINC_LAB_ATOMS_URL + "12345-F/atoms",
-            "crs": loinc.UMLS_LOINC_LAB_CROSSWALK_URL + "12345-F",
-            "long_name": "TEST LONG NAME",
-        }
-    }
-
-
-def test_process_loinc_results_empty() -> None:
-    result = loinc._process_loinc_results([], [])
-
-    assert result == []
-
-
 def test_process_loincs_for_umls_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict[str, str] = {}
     expected = {

--- a/packages/data-curation/tests/test_loinc.py
+++ b/packages/data-curation/tests/test_loinc.py
@@ -415,10 +415,12 @@ def test_process_loincs_for_umls_urls(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     }
 
-    def mock_process_loinc_valueset(api_url: str, loinc_vs_type: str) -> dict[str, dict[str, str]]:
+    def mock_process_loinc_valueset(
+        api_url: str, loinc_vs_type: str
+    ) -> list[dict[str, dict[str, str]]]:
         calls["api_url"] = api_url
         calls["loinc_vs_type"] = loinc_vs_type
-        return expected
+        return [expected]
 
     monkeypatch.setattr(loinc, "_process_loinc_valueset", mock_process_loinc_valueset)
 


### PR DESCRIPTION
## Description

in `packages/data-curation/src/data_curation/terminologies/loinc.py` we have to do a lot of type checking because `_process_loinc_valueset` returns either a list or a dictionary. This can be simplified by placing the dictionary in a list, so that it will always return a list of dictionaries. In the one instances where we expect the dictionary we can just get the first item.

## Related Issues

Closes #n/a

