### PR TITLE
fix: augmenter passes through only on newly-introduced validation errors

### DIFF
--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_augmentation_metadata.json
@@ -1,6 +1,6 @@
 {
-  "augmented_eicr_id": "2.16.840.1.113883.3.432.0.16.1.100.779.2",
-  "error": "[{\"error_id\": \"ttc-labResultValue-noCode\", \"location\": \"/Q{urn:hl7-org:v3}ClinicalDocument[1]/Q{urn:hl7-org:v3}component[1]/Q{urn:hl7-org:v3}structuredBody[1]/Q{urn:hl7-org:v3}component[8]/Q{urn:hl7-org:v3}section[1]/Q{urn:hl7-org:v3}entry[1]/Q{urn:hl7-org:v3}organizer[1]/Q{urn:hl7-org:v3}component[1]/Q{urn:hl7-org:v3}observation[1]\"}]",
+  "augmented_eicr_id": "d44dc1c6-8a0c-5236-906e-12f6475589ec",
+  "error": null,
   "nonstandard_codes": [
     {
       "field_type": "Lab Test Name Resulted",
@@ -18,6 +18,6 @@
     }
   ],
   "original_eicr_id": "2.16.840.1.113883.3.432.0.16.1.100.779.2",
-  "passthrough": true,
-  "passthrough_reason": "augmentation_validation_failure"
+  "passthrough": false,
+  "passthrough_reason": null
 }

--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_augmented_eicr.xml
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_augmented_eicr.xml
@@ -1,42 +1,34 @@
-<ClinicalDocument xmlns="urn:hl7-org:v3"
-    xmlns:sdtc="urn:hl7-org:sdtc"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <realmCode code="US" />
-    <typeId extension="POCD_HD000040"
-        root="2.16.840.1.113883.1.3" />
+<?xml version='1.0' encoding='utf-8'?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3"/>
     <!-- [C-CDA R1.1] US Realm Header -->
-    <templateId root="2.16.840.1.113883.10.20.22.1.1" />
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
     <!-- [C-CDA R2.1] US Realm Header (V3) -->
-    <templateId extension="2015-08-01"
-        root="2.16.840.1.113883.10.20.22.1.1" />
+    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.1.1"/>
     <!-- [eICR R2 STU1.1] Initial Public Health Case Report Document (eICR) (V2) -->
-    <templateId extension="2016-12-01"
-        root="2.16.840.1.113883.10.20.15.2" />
-    <id extension="72975"
-        root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
-    <code code="55751-2"
-        codeSystem="2.16.840.1.113883.6.1"
-        codeSystemName="LOINC"
-        displayName="Public Health Case Report" />
+    <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2"/>
+    <!--DATA AUGMENTATION: eICR Data Augmentation Header -->
+    <templateId root="2.16.840.1.113883.10.20.15.2.1.3" extension="2025-11-01"/>
+    <!--DATA AUGMENTATION: new-document-id -->
+    <id root="d44dc1c6-8a0c-5236-906e-12f6475589ec" assigningAuthorityName="text-to-code"/>
+    <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Public Health Case Report"/>
     <title>Initial Public Health Case Report</title>
-    <effectiveTime value="202405181818-0500" />
-    <confidentialityCode code="N"
-        codeSystem="2.16.840.1.113883.5.25" />
-    <languageCode code="en" />
-    <setId extension="C0-B20240516115522456"
-        root="2.16.840.1.113883.3.432.0.16.1.100.779.2.10" />
-    <versionNumber value="4" />
+    <!--DATA AUGMENTATION: time of data augmentation operation -->
+    <effectiveTime value="20260213152757"/>
+    <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+    <languageCode code="en"/>
+    <!--DATA AUGMENTATION: new-document-setId -->
+    <setId root="2683d208-bbec-5d37-8886-3b46fb5ec908"/>
+    <!--DATA AUGMENTATION: new-document-versionNumber -->
+    <versionNumber value="4"/>
     <recordTarget>
         <patientRole>
             <!-- Patient Identifiers-->
-            <id extension="CC00033551"
-                root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
-            <id extension="C0-202212142-0000031070"
-                root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
-            <id extension="d57a0e72-2da8-5425-9157-c87d410a5682"
-                root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
-            <id extension="XXX-XX-8036"
-                root="2.16.840.1.113883.4.1" />
+            <id extension="CC00033551" root="2.16.840.1.113883.3.432.0.16.1.100.779.2"/>
+            <id extension="C0-202212142-0000031070" root="2.16.840.1.113883.3.432.0.16.1.100.779.2"/>
+            <id extension="d57a0e72-2da8-5425-9157-c87d410a5682" root="2.16.840.1.113883.3.432.0.16.1.100.779.2"/>
+            <id extension="XXX-XX-8036" root="2.16.840.1.113883.4.1"/>
             <!-- Patient Address -->
             <addr use="HP">
                 <streetAddressLine>999 N Green</streetAddressLine>
@@ -46,8 +38,8 @@
                 <country>USA</country>
             </addr>
             <!-- Patient Telephone/Contact Details -->
-            <telecom value="tel:+1(999)999-5987" />
-            <telecom value="mailto:emailAddress@GMAIL.COM" />
+            <telecom value="tel:+1(999)999-5987"/>
+            <telecom value="mailto:emailAddress@GMAIL.COM"/>
             <patient>
                 <!-- Patient Name -->
                 <name use="L">
@@ -55,57 +47,48 @@
                     <given>First</given>
                 </name>
                 <!-- Administrative Gender -->
-                <administrativeGenderCode code="M"
-                    codeSystem="2.16.840.1.113883.5.1"
-                    codeSystemName="AdministrativeGender"
-                    displayName="Male" />
+                <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" displayName="Male"/>
                 <!-- Birthdate -->
-                <birthTime value="19560330" />
+                <birthTime value="19560330"/>
                 <!-- Deceased Indicator -->
-                <sdtc:deceasedInd value="false" />
+                <sdtc:deceasedInd value="false"/>
                 <!-- Marital Status -->
-                <maritalStatusCode nullFlavor="UNK" />
+                <maritalStatusCode nullFlavor="UNK"/>
                 <!-- Religious Affiliation -->
-                <religiousAffiliationCode nullFlavor="UNK" />
+                <religiousAffiliationCode nullFlavor="UNK"/>
                 <!-- Patient Race -->
-                <raceCode code="2106-3"
-                    codeSystem="2.16.840.1.113883.6.238"
-                    codeSystemName="Race and Ethnicity - CDC"
-                    displayName="White" />
+                <raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race and Ethnicity - CDC" displayName="White"/>
                 <!-- Patient Ethnicity -->
-                <ethnicGroupCode code="2186-5"
-                    codeSystem="2.16.840.1.113883.6.238"
-                    codeSystemName="Race and Ethnicity - CDC"
-                    displayName="Not Hispanic or Latino" />
+                <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race and Ethnicity - CDC" displayName="Not Hispanic or Latino"/>
                 <!-- Detailed Ethnicity -->
-                <sdtc:ethnicGroupCode nullFlavor="UNK" />
+                <sdtc:ethnicGroupCode nullFlavor="UNK"/>
                 <!-- Place of birth -->
                 <birthplace>
                     <place>
                         <addr>
-                            <streetAddressLine nullFlavor="UNK" />
-                            <city nullFlavor="UNK" />
-                            <state nullFlavor="UNK" />
-                            <postalCode nullFlavor="UNK" />
+                            <streetAddressLine nullFlavor="UNK"/>
+                            <city nullFlavor="UNK"/>
+                            <state nullFlavor="UNK"/>
+                            <postalCode nullFlavor="UNK"/>
                         </addr>
                     </place>
                 </birthplace>
                 <languageCommunication>
-                    <languageCode nullFlavor="UNK" />
+                    <languageCode nullFlavor="UNK"/>
                     <!-- "Patient's preferred language" -->
-                    <preferenceInd value="true" />
+                    <preferenceInd value="true"/>
                 </languageCommunication>
             </patient>
             <!-- Provider Organization -->
             <providerOrganization>
-                <id nullFlavor="UNK" />
-                <name nullFlavor="UNK" />
-                <telecom nullFlavor="UNK" />
+                <id nullFlavor="UNK"/>
+                <name nullFlavor="UNK"/>
+                <telecom nullFlavor="UNK"/>
                 <addr>
-                    <streetAddressLine nullFlavor="UNK" />
-                    <city nullFlavor="UNK" />
-                    <state nullFlavor="UNK" />
-                    <postalCode nullFlavor="UNK" />
+                    <streetAddressLine nullFlavor="UNK"/>
+                    <city nullFlavor="UNK"/>
+                    <state nullFlavor="UNK"/>
+                    <postalCode nullFlavor="UNK"/>
                 </addr>
             </providerOrganization>
         </patientRole>
@@ -116,9 +99,9 @@ author and author timestamp be asserted in the document header. From there, auth
     to contained sections and contained
 entries, unless explicitly overridden.-->
     <author>
-        <time value="20240518181913-0500" />
+        <time value="20240518181913-0500"/>
         <assignedAuthor>
-            <id root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
+            <id root="2.16.840.1.113883.3.432.0.16.1.100.779.2"/>
             <addr use="WP">
                 <streetAddressLine>999 N 4th Street</streetAddressLine>
                 <city>Burlington</city>
@@ -126,17 +109,15 @@ entries, unless explicitly overridden.-->
                 <postalCode>66839</postalCode>
                 <country>US</country>
             </addr>
-            <telecom use="WP"
-                value="tel:+1(999)999-2121" />
+            <telecom use="WP" value="tel:+1(999)999-2121"/>
             <assignedAuthoringDevice>
                 <manufacturerModelName>CHS.LIVEN</manufacturerModelName>
                 <softwareName>NWN.LIVEN</softwareName>
             </assignedAuthoringDevice>
             <representedOrganization>
-                <id root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
+                <id root="2.16.840.1.113883.3.432.0.16.1.100.779.2"/>
                 <name>CHS Medical Clinics</name>
-                <telecom use="WP"
-                    value="tel:+1(999)999-2121" />
+                <telecom use="WP" value="tel:+1(999)999-2121"/>
                 <addr use="WP">
                     <streetAddressLine>999 N 4th Street</streetAddressLine>
                     <city>Burlington</city>
@@ -153,10 +134,9 @@ the care of the document. -->
     <custodian>
         <assignedCustodian>
             <representedCustodianOrganization>
-                <id root="2.16.840.1.113883.3.432.0.16.1.100.779.2" />
+                <id root="2.16.840.1.113883.3.432.0.16.1.100.779.2"/>
                 <name>CHS Medical Clinics</name>
-                <telecom use="WP"
-                    value="tel:+1(999)999-2121" />
+                <telecom use="WP" value="tel:+1(999)999-2121"/>
                 <addr use="WP">
                     <streetAddressLine>999 N 4th Street</streetAddressLine>
                     <city>Burlington</city>
@@ -174,12 +154,12 @@ the care of the document. -->
                 <originalText>Wife</originalText>
             </code>
             <addr>
-                <streetAddressLine nullFlavor="UNK" />
-                <city nullFlavor="UNK" />
-                <state nullFlavor="UNK" />
-                <postalCode nullFlavor="UNK" />
+                <streetAddressLine nullFlavor="UNK"/>
+                <city nullFlavor="UNK"/>
+                <state nullFlavor="UNK"/>
+                <postalCode nullFlavor="UNK"/>
             </addr>
-            <telecom value="tel:+1(785)614-1495" />
+            <telecom value="tel:+1(785)614-1495"/>
             <associatedPerson>
                 <name>
                     <family>Last</family>
@@ -193,7 +173,7 @@ the care of the document. -->
         <!-- Indicates the start and end date of the relationship between the contact and the
         patient. -->
         <time>
-            <low value="202405161117-0500" />
+            <low value="202405161117-0500"/>
         </time>
         <associatedEntity classCode="PRS">
             <code nullFlavor="NA">
@@ -205,8 +185,8 @@ the care of the document. -->
                 <state>KS</state>
                 <postalCode>66783</postalCode>
             </addr>
-            <telecom value="tel:+1(999)999-2312" />
-            <telecom value="mailto:bFirst@coffeyhealth.org" />
+            <telecom value="tel:+1(999)999-2312"/>
+            <telecom value="mailto:bFirst@coffeyhealth.org"/>
             <associatedPerson>
                 <name>
                     <suffix qualifier="AC">MD</suffix>
@@ -221,25 +201,18 @@ the care of the document. -->
         <!-- The encompassingEncounter element records the specific encounter the document is
         detailing-->
         <encompassingEncounter>
-            <id root="17313cfa-8731-5dbe-bc52-e296d82d0860" />
-            <id extension="Z00000173103"
-                root="2.16.840.1.113883.3.432.0.16.1.100.779.2.10" />
-            <code code="AMB"
-                codeSystem="2.16.840.1.113883.5.4"
-                codeSystemName="HL7 ActEncounterCode"
-                displayName="ambulatory" />
+            <id root="17313cfa-8731-5dbe-bc52-e296d82d0860"/>
+            <id extension="Z00000173103" root="2.16.840.1.113883.3.432.0.16.1.100.779.2.10"/>
+            <code code="AMB" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7 ActEncounterCode" displayName="ambulatory"/>
             <effectiveTime>
-                <low value="20240516111753-0500" />
-                <high value="202405161150-0500" />
+                <low value="20240516111753-0500"/>
+                <high value="202405161150-0500"/>
             </effectiveTime>
-            <dischargeDispositionCode nullFlavor="UNK" />
+            <dischargeDispositionCode nullFlavor="UNK"/>
             <location>
                 <healthCareFacility>
-                    <id root="5f3873e0-76bd-56d7-97ea-891a733fa4ea" />
-                    <code code="FMC"
-                        codeSystem="2.16.840.1.113883.5.111"
-                        codeSystemName="RoleCode"
-                        displayName="Family medicine clinic" />
+                    <id root="5f3873e0-76bd-56d7-97ea-891a733fa4ea"/>
+                    <code code="FMC" codeSystem="2.16.840.1.113883.5.111" codeSystemName="RoleCode" displayName="Family medicine clinic"/>
                     <location>
                         <addr>
                             <streetAddressLine>999 E Madison</streetAddressLine>
@@ -250,8 +223,7 @@ the care of the document. -->
                     </location>
                     <serviceProviderOrganization>
                         <name>CHS Medical Clinics</name>
-                        <telecom use="WP"
-                            value="tel:+1(999)999-2121" />
+                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                         <addr use="WP">
                             <streetAddressLine>999 N 4th Street</streetAddressLine>
                             <city>Burlington</city>
@@ -269,19 +241,13 @@ the care of the document. -->
             <!-- Care Team CG21Apg5-->
             <component>
                 <section>
-                    <templateId extension="2022-06-01"
-                        root="2.16.840.1.113883.10.20.22.2.500" />
-                    <templateId extension="2019-07-01"
-                        root="2.16.840.1.113883.10.20.22.2.500" />
-                    <code code="85847-2"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="Care team" />
+                    <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.2.500"/>
+                    <templateId extension="2019-07-01" root="2.16.840.1.113883.10.20.22.2.500"/>
+                    <code code="85847-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care team"/>
                     <title>Care Teams</title>
                     <text>
-                        <content ID="careTeamName-1"
-                            styleCode="Bold">Patient Care Team</content>
-                        <br />
+                        <content ID="careTeamName-1" styleCode="Bold">Patient Care Team</content>
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -299,14 +265,13 @@ the care of the document. -->
                                     <td>First M Last , MD</td>
                                     <td>Primary Care Provider</td>
                                     <td>Active</td>
-                                    <td />
+                                    <td/>
                                 </tr>
                             </tbody>
                         </table>
-                        <paragraph />
-                        <content ID="careTeamName-2"
-                            styleCode="Bold">Visit Care Team</content>
-                        <br />
+                        <paragraph/>
+                        <content ID="careTeamName-2" styleCode="Bold">Visit Care Team</content>
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -325,41 +290,33 @@ the care of the document. -->
                                     <td>Primary Care Provider, Attending Provider, Referring
                                         Provider</td>
                                     <td>Active</td>
-                                    <td>Start: May 16th, 2024<br />End: May 16th, 2024</td>
+                                    <td>Start: May 16th, 2024<br/>End: May 16th, 2024</td>
                                 </tr>
                             </tbody>
                         </table>
                     </text>
                     <entry>
-                        <organizer classCode="CLUSTER"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.500" />
-                            <templateId extension="2019-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.500" />
-                            <id root="3010ccc2-194e-5186-9e8b-eb17ed636cae" />
-                            <code code="86744-0"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="Care Team">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.500"/>
+                            <templateId extension="2019-08-01" root="2.16.840.1.113883.10.20.22.4.500"/>
+                            <id root="3010ccc2-194e-5186-9e8b-eb17ed636cae"/>
+                            <code code="86744-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team">
                                 <originalText>
-                                    <reference value="#careTeamName-1" />
+                                    <reference value="#careTeamName-1"/>
                                 </originalText>
                             </code>
-                            <statusCode code="active" />
+                            <statusCode code="active"/>
                             <effectiveTime>
-                                <low nullFlavor="UNK" />
+                                <low nullFlavor="UNK"/>
                             </effectiveTime>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20230116142325-0600" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20230116142325-0600"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -367,49 +324,39 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <!-- Care Team Members -->
                             <component>
-                                <act classCode="PCPR"
-                                    moodCode="EVN">
-                                    <templateId extension="2022-06-01"
-                                        root="2.16.840.1.113883.10.20.22.4.500.1" />
-                                    <templateId extension="2019-07-01"
-                                        root="2.16.840.1.113883.10.20.22.4.500.1" />
-                                    <id root="61a836b3-79da-52ad-92bf-5198177c51cd" />
-                                    <code code="85847-2"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Care Team Information" />
-                                    <statusCode code="active" />
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.500.1"/>
+                                    <templateId extension="2019-07-01" root="2.16.840.1.113883.10.20.22.4.500.1"/>
+                                    <id root="61a836b3-79da-52ad-92bf-5198177c51cd"/>
+                                    <code code="85847-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team Information"/>
+                                    <statusCode code="active"/>
                                     <effectiveTime>
-                                        <low nullFlavor="UNK" />
+                                        <low nullFlavor="UNK"/>
                                     </effectiveTime>
                                     <performer typeCode="PRF">
                                         <sdtc:functionCode nullFlavor="UNK">
                                             <originalText>Primary Care Provider</originalText>
                                         </sdtc:functionCode>
                                         <assignedEntity>
-                                            <id root="61a836b3-79da-52ad-92bf-5198177c51cd" />
+                                            <id root="61a836b3-79da-52ad-92bf-5198177c51cd"/>
                                             <addr>
                                                 <streetAddressLine>999 E Madison</streetAddressLine>
                                                 <city>YATES CENTER</city>
                                                 <state>KS</state>
                                                 <postalCode>66783</postalCode>
                                             </addr>
-                                            <telecom value="mailto:bFirst@coffeyhealth.org" />
-                                            <telecom use="WP"
-                                                value="tel:+1(999)999-2312" />
+                                            <telecom value="mailto:bFirst@coffeyhealth.org"/>
+                                            <telecom use="WP" value="tel:+1(999)999-2312"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>First</family>
@@ -423,35 +370,27 @@ the care of the document. -->
                         </organizer>
                     </entry>
                     <entry>
-                        <organizer classCode="CLUSTER"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.500" />
-                            <templateId extension="2019-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.500" />
-                            <id root="f84bce2a-5fa3-53f1-8499-66cf5212f245" />
-                            <code code="86744-0"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="Care Team">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.500"/>
+                            <templateId extension="2019-08-01" root="2.16.840.1.113883.10.20.22.4.500"/>
+                            <id root="f84bce2a-5fa3-53f1-8499-66cf5212f245"/>
+                            <code code="86744-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team">
                                 <originalText>
-                                    <reference value="#careTeamName-2" />
+                                    <reference value="#careTeamName-2"/>
                                 </originalText>
                             </code>
-                            <statusCode code="inactive" />
+                            <statusCode code="inactive"/>
                             <effectiveTime>
-                                <low nullFlavor="UNK" />
+                                <low nullFlavor="UNK"/>
                             </effectiveTime>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516111741-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516111741-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -459,41 +398,31 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <!-- Care Team Encounter -->
                             <component>
-                                <encounter classCode="ENC"
-                                    moodCode="EVN">
-                                    <id root="17313cfa-8731-5dbe-bc52-e296d82d0860" />
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id root="17313cfa-8731-5dbe-bc52-e296d82d0860"/>
                                 </encounter>
                             </component>
                             <!-- Care Team Members -->
                             <component>
-                                <act classCode="PCPR"
-                                    moodCode="EVN">
-                                    <templateId extension="2022-06-01"
-                                        root="2.16.840.1.113883.10.20.22.4.500.1" />
-                                    <templateId extension="2019-07-01"
-                                        root="2.16.840.1.113883.10.20.22.4.500.1" />
-                                    <id root="61a836b3-79da-52ad-92bf-5198177c51cd" />
-                                    <code code="85847-2"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Care Team Information" />
-                                    <statusCode code="active" />
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.500.1"/>
+                                    <templateId extension="2019-07-01" root="2.16.840.1.113883.10.20.22.4.500.1"/>
+                                    <id root="61a836b3-79da-52ad-92bf-5198177c51cd"/>
+                                    <code code="85847-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team Information"/>
+                                    <statusCode code="active"/>
                                     <effectiveTime>
-                                        <low value="202405161117-0500" />
-                                        <high value="202405161650-0500" />
+                                        <low value="202405161117-0500"/>
+                                        <high value="202405161650-0500"/>
                                     </effectiveTime>
                                     <performer typeCode="PRF">
                                         <sdtc:functionCode nullFlavor="UNK">
@@ -501,16 +430,15 @@ the care of the document. -->
                                                 Referring Provider</originalText>
                                         </sdtc:functionCode>
                                         <assignedEntity>
-                                            <id root="61a836b3-79da-52ad-92bf-5198177c51cd" />
+                                            <id root="61a836b3-79da-52ad-92bf-5198177c51cd"/>
                                             <addr>
                                                 <streetAddressLine>999 E Madison</streetAddressLine>
                                                 <city>YATES CENTER</city>
                                                 <state>KS</state>
                                                 <postalCode>66783</postalCode>
                                             </addr>
-                                            <telecom value="mailto:bFirst@coffeyhealth.org" />
-                                            <telecom use="WP"
-                                                value="tel:+1(999)999-2312" />
+                                            <telecom value="mailto:bFirst@coffeyhealth.org"/>
+                                            <telecom use="WP" value="tel:+1(999)999-2312"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>First</family>
@@ -528,11 +456,8 @@ the care of the document. -->
             <!-- Reason for Visit Section eCR IGpg 106 -->
             <component>
                 <section>
-                    <templateId root="2.16.840.1.113883.10.20.22.2.12" />
-                    <code code="29299-5"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="Reason for Visit" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.12"/>
+                    <code code="29299-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Reason for Visit"/>
                     <title>Reason for Visit</title>
                     <text>
                         <table>
@@ -549,11 +474,8 @@ the care of the document. -->
             <!-- History of Present Illness Section IGpg310 -->
             <component>
                 <section>
-                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
-                    <code code="10164-2"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="History Of Present Illness" />
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History Of Present Illness"/>
                     <title>History of Present Illness</title>
                     <text>
                         <table>
@@ -566,14 +488,14 @@ the care of the document. -->
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>Details: <br />First is here today for complaint of illness.
-                                        He has been sick since Tuesday night with cough and <br />runny
+                                    <td>Details: <br/>First is here today for complaint of illness.
+                                        He has been sick since Tuesday night with cough and <br/>runny
                                         nose. No fever. No sick contacts. Not too wheezy at this
-                                        point. He is using an inhaler. <br />Only coughing up a
+                                        point. He is using an inhaler. <br/>Only coughing up a
                                         little sputum. He is not short of breath. He has some body
-                                        aches. No diarrhea. <br /> His psa last month 0.05 with dr
+                                        aches. No diarrhea. <br/> His psa last month 0.05 with dr
                                         hashmi. </td>
-                                    <td>Last First<br />Name Health System</td>
+                                    <td>Last First<br/>Name Health System</td>
                                     <td>May 16th, 2024 11:18am</td>
                                 </tr>
                             </tbody>
@@ -584,17 +506,13 @@ the care of the document. -->
             <!-- Social History Section (V3) IGpg404 -->
             <component>
                 <section>
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.17" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.17" />
-                    <code code="29762-2"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="Social History" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social History"/>
                     <title>Social History</title>
                     <text>
                         <content styleCode="Bold">Smoking Status</content>
-                        <br />
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -607,15 +525,15 @@ the care of the document. -->
                             <tbody>
                                 <tr>
                                     <td ID="smoking-1">Never smoked tobacco (finding)</td>
-                                    <td />
-                                    <td />
+                                    <td/>
+                                    <td/>
                                     <td>May 16th, 2024 11:28am</td>
                                 </tr>
                             </tbody>
                         </table>
-                        <br />
+                        <br/>
                         <content styleCode="Bold">Observation Status</content>
-                        <br />
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -665,41 +583,30 @@ the care of the document. -->
                     </text>
                     <!-- Smoking Status - Meaningful Use (V2) IGpg834 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2014-06-09"
-                                root="2.16.840.1.113883.10.20.22.4.78" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.78" />
-                            <id root="86954c55-b235-4892-b597-29bf790f5cd8" />
-                            <code code="72166-2"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="Tobacco smoking status NHIS" />
-                            <statusCode code="completed" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <id root="86954c55-b235-4892-b597-29bf790f5cd8"/>
+                            <code code="72166-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Tobacco smoking status NHIS"/>
+                            <statusCode code="completed"/>
                             <!-- The effectiveTime reflects when the current smoking status was
                             observed. -->
-                            <effectiveTime value="202405161128-0500" />
+                            <effectiveTime value="202405161128-0500"/>
                             <!-- The value represents the patient's smoking status currently
                             observed. -->
-                            <value code="266919005"
-                                codeSystem="2.16.840.1.113883.6.96"
-                                codeSystemName="SNOMED CT"
-                                displayName="Never smoked tobacco (finding)"
-                                xsi:type="CD">
+                            <value code="266919005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Never smoked tobacco (finding)" xsi:type="CD">
                                 <originalText>
-                                    <reference value="#smoking-1" />
+                                    <reference value="#smoking-1"/>
                                 </originalText>
                             </value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516112813-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516112813-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -707,14 +614,11 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -722,55 +626,44 @@ the care of the document. -->
                     </entry>
                     <!-- Tobacco Use (V2) IGpg865 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId root="2.16.840.1.113883.10.20.22.4.85" />
-                            <templateId extension="2014-06-09"
-                                root="2.16.840.1.113883.10.20.22.4.85" />
-                            <id nullFlavor="NA" />
-                            <code code="11367-0"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="History of tobacco use" />
-                            <statusCode code="completed" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <id nullFlavor="NA"/>
+                            <code code="11367-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of tobacco use"/>
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low nullFlavor="UNK" />
+                                <low nullFlavor="UNK"/>
                             </effectiveTime>
-                            <value nullFlavor="UNK"
-                                xsi:type="CD" />
+                            <value nullFlavor="UNK" xsi:type="CD"/>
                         </observation>
                     </entry>
                     <!-- Social History Observation IGpg838 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
-                            <id nullFlavor="NA" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <id nullFlavor="NA"/>
                             <code nullFlavor="UNK">
                                 <originalText>
-                                    <reference value="#obs-1" />
+                                    <reference value="#obs-1"/>
                                 </originalText>
-                                <translation nullFlavor="UNK" />
+                                <translation nullFlavor="UNK"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low value="20240516112813-0500" />
+                                <low value="20240516112813-0500"/>
                             </effectiveTime>
                             <value xsi:type="ST">No</value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516112813-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516112813-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -778,14 +671,11 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -793,35 +683,30 @@ the care of the document. -->
                     </entry>
                     <!-- Social History Observation IGpg838 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
-                            <id nullFlavor="NA" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <id nullFlavor="NA"/>
                             <code nullFlavor="UNK">
                                 <originalText>
-                                    <reference value="#obs-2" />
+                                    <reference value="#obs-2"/>
                                 </originalText>
-                                <translation nullFlavor="UNK" />
+                                <translation nullFlavor="UNK"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low value="20240516112813-0500" />
+                                <low value="20240516112813-0500"/>
                             </effectiveTime>
                             <value xsi:type="ST">house</value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516112813-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516112813-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -829,14 +714,11 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -844,35 +726,30 @@ the care of the document. -->
                     </entry>
                     <!-- Social History Observation IGpg838 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
-                            <id nullFlavor="NA" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <id nullFlavor="NA"/>
                             <code nullFlavor="UNK">
                                 <originalText>
-                                    <reference value="#obs-3" />
+                                    <reference value="#obs-3"/>
                                 </originalText>
-                                <translation nullFlavor="UNK" />
+                                <translation nullFlavor="UNK"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low value="20240516112813-0500" />
+                                <low value="20240516112813-0500"/>
                             </effectiveTime>
                             <value xsi:type="ST">spouse</value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516112813-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516112813-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -880,14 +757,11 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -895,35 +769,30 @@ the care of the document. -->
                     </entry>
                     <!-- Social History Observation IGpg838 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
-                            <id nullFlavor="NA" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <id nullFlavor="NA"/>
                             <code nullFlavor="UNK">
                                 <originalText>
-                                    <reference value="#obs-4" />
+                                    <reference value="#obs-4"/>
                                 </originalText>
-                                <translation nullFlavor="UNK" />
+                                <translation nullFlavor="UNK"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low value="20240516112813-0500" />
+                                <low value="20240516112813-0500"/>
                             </effectiveTime>
                             <value xsi:type="ST">Yes</value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516112813-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516112813-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -931,14 +800,11 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -946,35 +812,30 @@ the care of the document. -->
                     </entry>
                     <!-- Social History Observation IGpg838 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.38" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.38" />
-                            <id nullFlavor="NA" />
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <id nullFlavor="NA"/>
                             <code nullFlavor="UNK">
                                 <originalText>
-                                    <reference value="#obs-5" />
+                                    <reference value="#obs-5"/>
                                 </originalText>
-                                <translation nullFlavor="UNK" />
+                                <translation nullFlavor="UNK"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low value="20240516112813-0500" />
+                                <low value="20240516112813-0500"/>
                             </effectiveTime>
                             <value xsi:type="ST">retired</value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516112813-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516112813-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>Last</family>
@@ -982,14 +843,11 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -997,44 +855,30 @@ the care of the document. -->
                     </entry>
                     <!-- Sex Observation CDA21CG41pg123 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2023-06-28"
-                                root="2.16.840.1.113883.10.20.22.4.507" />
-                            <code code="46098-0"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="Sex" />
-                            <statusCode code="completed" />
-                            <effectiveTime value="202405181818-0500" />
-                            <value code="248153007"
-                                codeSystem="2.16.840.1.113883.6.96"
-                                codeSystemName="SNOMED CT"
-                                displayName="Male (finding)"
-                                xsi:type="CD">
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2023-06-28" root="2.16.840.1.113883.10.20.22.4.507"/>
+                            <code code="46098-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202405181818-0500"/>
+                            <value code="248153007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Male (finding)" xsi:type="CD">
                                 <originalText>
-                                    <reference value="#sexobs" />
+                                    <reference value="#sexobs"/>
                                 </originalText>
                             </value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="202405161154-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="202405161154-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -1042,46 +886,31 @@ the care of the document. -->
                     </entry>
                     <!-- Birth Sex Observation CDA21CGIGpg85 -->
                     <entry>
-                        <observation classCode="OBS"
-                            moodCode="EVN">
-                            <templateId extension="2023-05-01"
-                                root="2.16.840.1.113883.10.20.22.4.200" />
-                            <templateId extension="2016-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.200" />
-                            <code code="76689-9"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="Sex Assigned At Birth" />
-                            <statusCode code="completed" />
-                            <effectiveTime value="19560330" />
-                            <value code="M"
-                                codeSystem="2.16.840.1.113883.5.1"
-                                codeSystemName="AdministrativeGender"
-                                displayName="Male"
-                                xsi:type="CD">
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId extension="2023-05-01" root="2.16.840.1.113883.10.20.22.4.200"/>
+                            <templateId extension="2016-06-01" root="2.16.840.1.113883.10.20.22.4.200"/>
+                            <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sex Assigned At Birth"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="19560330"/>
+                            <value code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" displayName="Male" xsi:type="CD">
                                 <originalText>
-                                    <reference value="#birthsex" />
+                                    <reference value="#birthsex"/>
                                 </originalText>
                             </value>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="202405161154-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="202405161154-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
@@ -1093,17 +922,13 @@ the care of the document. -->
                 <section>
                     <!-- Problem Section (entries required) (V3) [section: identifier
                     urn:hl7ii:2.16.840.1.113883.10.20.22.2.5.1:2015-08-01 IGpg371-->
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.5.1" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
-                    <code code="11450-4"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="PROBLEM LIST" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="PROBLEM LIST"/>
                     <title>Problems</title>
                     <text>
                         <content styleCode="Bold">Active Problems</content>
-                        <br />
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -1115,18 +940,18 @@ the care of the document. -->
                             <tbody>
                                 <tr>
                                     <td ID="problem-1">Acute bacterial bronchitis</td>
-                                    <td />
+                                    <td/>
                                     <td>Active</td>
                                 </tr>
                                 <tr>
                                     <td ID="problem-3">Asthma</td>
-                                    <td />
+                                    <td/>
                                     <td>Active</td>
                                 </tr>
                             </tbody>
                         </table>
                         <content styleCode="Bold">Inactive/Resolved Problems</content>
-                        <br />
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -1138,7 +963,7 @@ the care of the document. -->
                             <tbody>
                                 <tr>
                                     <td ID="problem-2">COPD (chronic obstructive pulmonary disease)</td>
-                                    <td />
+                                    <td/>
                                     <td>Resolved</td>
                                 </tr>
                             </tbody>
@@ -1147,81 +972,54 @@ the care of the document. -->
                     <entry typeCode="DRIV">
                         <!-- Problem Concern Act (V3) [act: identifier
                         urn:hl7ii:2.16.840.1.113883.10.20.22.4.3:2015-08-01 IGpg732 -->
-                        <act classCode="ACT"
-                            moodCode="EVN">
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.3" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
-                            <id root="1cbdd0cd-47d0-458c-5099-98c900747bf8" />
-                            <code code="CONC"
-                                codeSystem="2.16.840.1.113883.5.6"
-                                codeSystemName="HL7 ActClass"
-                                displayName="Concern" />
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <id root="1cbdd0cd-47d0-458c-5099-98c900747bf8"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="HL7 ActClass" displayName="Concern"/>
                             <!-- The statusCode represents the need to continue tracking the problem -->
                             <!-- This is of ongoing concern to the provider -->
-                            <statusCode code="active" />
+                            <statusCode code="active"/>
                             <!-- "The low value represents when the problem was first recorded in
                             the patient's chart" -->
                             <effectiveTime>
-                                <low value="20231026144703-0500" />
+                                <low value="20231026144703-0500"/>
                             </effectiveTime>
                             <entryRelationship typeCode="SUBJ">
                                 <!-- Problem observation (V3) observation: identifier
                                 urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01 IGpg737-->
-                                <observation classCode="OBS"
-                                    moodCode="EVN"
-                                    negationInd="false">
-                                    <templateId extension="2022-06-01"
-                                        root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <templateId extension="2015-08-01"
-                                        root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <id root="623f4167-f352-45bf-9d96-a998307aab3a" />
-                                    <code code="55607006"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED-CT"
-                                        displayName="Problem">
+                                <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                                    <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="623f4167-f352-45bf-9d96-a998307aab3a"/>
+                                    <code code="55607006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Problem">
                                         <!-- a.	This code SHALL contain at least one [1..*]
                                         translation, which SHOULD be selected from ValueSet Problem
                                         Type (LOINC)-->
-                                        <translation code="75326-9"
-                                            codeSystem="2.16.840.1.113883.6.1"
-                                            codeSystemName="LOINC"
-                                            displayName="Problem" />
+                                        <translation code="75326-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem"/>
                                     </code>
                                     <!-- The statusCode reflects the status of the observation
                                     itself -->
-                                    <statusCode code="completed" />
+                                    <statusCode code="completed"/>
                                     <effectiveTime>
-                                        <low nullFlavor="UNK" />
+                                        <low nullFlavor="UNK"/>
                                     </effectiveTime>
-                                    <value code="233598009"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED CT"
-                                        displayName="Acute bacterial bronchitis"
-                                        xsi:type="CD">
+                                    <value code="233598009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Acute bacterial bronchitis" xsi:type="CD">
                                         <originalText>
-                                            <reference value="#problem-1" />
+                                            <reference value="#problem-1"/>
                                         </originalText>
-                                        <translation code="J20.8"
-                                            codeSystem="2.16.840.1.113883.6.90"
-                                            codeSystemName="ICD10"
-                                            displayName="Acute bacterial bronchitis" />
-                                        <translation code="466.0"
-                                            codeSystem="2.16.840.1.113883.6.103"
-                                            codeSystemName="ICD9"
-                                            displayName="Acute bacterial bronchitis" />
+                                        <translation code="J20.8" codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD10" displayName="Acute bacterial bronchitis"/>
+                                        <translation code="466.0" codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD9" displayName="Acute bacterial bronchitis"/>
                                     </value>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20231026144707-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20231026144707-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id extension="1386846475"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id extension="1386846475" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>VanAnne</family>
@@ -1229,14 +1027,11 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
@@ -1247,83 +1042,56 @@ the care of the document. -->
                     <entry typeCode="DRIV">
                         <!-- Problem Concern Act (V3) [act: identifier
                         urn:hl7ii:2.16.840.1.113883.10.20.22.4.3:2015-08-01 IGpg732 -->
-                        <act classCode="ACT"
-                            moodCode="EVN">
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.3" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
-                            <id root="a5c32e42-8d1d-4270-2b8f-eedb414a9b10" />
-                            <code code="CONC"
-                                codeSystem="2.16.840.1.113883.5.6"
-                                codeSystemName="HL7 ActClass"
-                                displayName="Concern" />
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <id root="a5c32e42-8d1d-4270-2b8f-eedb414a9b10"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="HL7 ActClass" displayName="Concern"/>
                             <!-- The statusCode represents the need to continue tracking the problem -->
                             <!-- This is of ongoing concern to the provider -->
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <!-- "The low value represents when the problem was first recorded in
                             the patient's chart" -->
                             <effectiveTime>
-                                <low value="20230418083559-0500" />
-                                <high nullFlavor="UNK" />
+                                <low value="20230418083559-0500"/>
+                                <high nullFlavor="UNK"/>
                             </effectiveTime>
                             <entryRelationship typeCode="SUBJ">
                                 <!-- Problem observation (V3) observation: identifier
                                 urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01 IGpg737-->
-                                <observation classCode="OBS"
-                                    moodCode="EVN"
-                                    negationInd="false">
-                                    <templateId extension="2022-06-01"
-                                        root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <templateId extension="2015-08-01"
-                                        root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <id root="31406afa-1278-49ad-bfa5-82a4f1e8cad2" />
-                                    <code code="55607006"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED-CT"
-                                        displayName="Problem">
+                                <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                                    <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="31406afa-1278-49ad-bfa5-82a4f1e8cad2"/>
+                                    <code code="55607006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Problem">
                                         <!-- a.	This code SHALL contain at least one [1..*]
                                         translation, which SHOULD be selected from ValueSet Problem
                                         Type (LOINC)-->
-                                        <translation code="75326-9"
-                                            codeSystem="2.16.840.1.113883.6.1"
-                                            codeSystemName="LOINC"
-                                            displayName="Problem" />
+                                        <translation code="75326-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem"/>
                                     </code>
                                     <!-- The statusCode reflects the status of the observation
                                     itself -->
-                                    <statusCode code="completed" />
+                                    <statusCode code="completed"/>
                                     <effectiveTime>
-                                        <low nullFlavor="UNK" />
-                                        <high nullFlavor="UNK" />
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
                                     </effectiveTime>
-                                    <value code="13645005"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED CT"
-                                        displayName="Chronic obstructive pulmonary disease"
-                                        xsi:type="CD">
+                                    <value code="13645005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Chronic obstructive pulmonary disease" xsi:type="CD">
                                         <originalText>
-                                            <reference value="#problem-2" />
+                                            <reference value="#problem-2"/>
                                         </originalText>
-                                        <translation code="J44.9"
-                                            codeSystem="2.16.840.1.113883.6.90"
-                                            codeSystemName="ICD10"
-                                            displayName="Chronic obstructive pulmonary disease" />
-                                        <translation code="496"
-                                            codeSystem="2.16.840.1.113883.6.103"
-                                            codeSystemName="ICD9"
-                                            displayName="Chronic obstructive pulmonary disease" />
+                                        <translation code="J44.9" codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD10" displayName="Chronic obstructive pulmonary disease"/>
+                                        <translation code="496" codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD9" displayName="Chronic obstructive pulmonary disease"/>
                                     </value>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20231026165600-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20231026165600-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id extension="1386846475"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id extension="1386846475" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>VanAnne</family>
@@ -1331,14 +1099,11 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
@@ -1349,81 +1114,54 @@ the care of the document. -->
                     <entry typeCode="DRIV">
                         <!-- Problem Concern Act (V3) [act: identifier
                         urn:hl7ii:2.16.840.1.113883.10.20.22.4.3:2015-08-01 IGpg732 -->
-                        <act classCode="ACT"
-                            moodCode="EVN">
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.3" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.3" />
-                            <id root="81747fa0-e43a-4b20-4ebd-e914652d353c" />
-                            <code code="CONC"
-                                codeSystem="2.16.840.1.113883.5.6"
-                                codeSystemName="HL7 ActClass"
-                                displayName="Concern" />
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <id root="81747fa0-e43a-4b20-4ebd-e914652d353c"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="HL7 ActClass" displayName="Concern"/>
                             <!-- The statusCode represents the need to continue tracking the problem -->
                             <!-- This is of ongoing concern to the provider -->
-                            <statusCode code="active" />
+                            <statusCode code="active"/>
                             <!-- "The low value represents when the problem was first recorded in
                             the patient's chart" -->
                             <effectiveTime>
-                                <low value="20230522113837-0500" />
+                                <low value="20230522113837-0500"/>
                             </effectiveTime>
                             <entryRelationship typeCode="SUBJ">
                                 <!-- Problem observation (V3) observation: identifier
                                 urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01 IGpg737-->
-                                <observation classCode="OBS"
-                                    moodCode="EVN"
-                                    negationInd="false">
-                                    <templateId extension="2022-06-01"
-                                        root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <templateId extension="2015-08-01"
-                                        root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" />
-                                    <id root="8dbec95e-be8e-4335-99b4-b16c5d8c1465" />
-                                    <code code="55607006"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED-CT"
-                                        displayName="Problem">
+                                <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                                    <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="8dbec95e-be8e-4335-99b4-b16c5d8c1465"/>
+                                    <code code="55607006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Problem">
                                         <!-- a.	This code SHALL contain at least one [1..*]
                                         translation, which SHOULD be selected from ValueSet Problem
                                         Type (LOINC)-->
-                                        <translation code="75326-9"
-                                            codeSystem="2.16.840.1.113883.6.1"
-                                            codeSystemName="LOINC"
-                                            displayName="Problem" />
+                                        <translation code="75326-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem"/>
                                     </code>
                                     <!-- The statusCode reflects the status of the observation
                                     itself -->
-                                    <statusCode code="completed" />
+                                    <statusCode code="completed"/>
                                     <effectiveTime>
-                                        <low nullFlavor="UNK" />
+                                        <low nullFlavor="UNK"/>
                                     </effectiveTime>
-                                    <value code="195967001"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED CT"
-                                        displayName="Asthma"
-                                        xsi:type="CD">
+                                    <value code="195967001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Asthma" xsi:type="CD">
                                         <originalText>
-                                            <reference value="#problem-3" />
+                                            <reference value="#problem-3"/>
                                         </originalText>
-                                        <translation code="J45.909"
-                                            codeSystem="2.16.840.1.113883.6.90"
-                                            codeSystemName="ICD10"
-                                            displayName="Asthma" />
-                                        <translation code="493.90"
-                                            codeSystem="2.16.840.1.113883.6.103"
-                                            codeSystemName="ICD9"
-                                            displayName="Asthma" />
+                                        <translation code="J45.909" codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD10" displayName="Asthma"/>
+                                        <translation code="493.90" codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD9" displayName="Asthma"/>
                                     </value>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20231026165623-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20231026165623-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id extension="1386846475"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id extension="1386846475" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>VanAnne</family>
@@ -1431,14 +1169,11 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
@@ -1451,14 +1186,10 @@ the care of the document. -->
             <!-- Immunizations section IGpg320 -->
             <component>
                 <section nullFlavor="NI">
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.2.1" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.2" />
-                    <code code="11369-6"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="History of immunizations" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2"/>
+                    <code code="11369-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of immunizations"/>
                     <title>Immunizations</title>
                     <text>No immunization information available</text>
                 </section>
@@ -1466,15 +1197,10 @@ the care of the document. -->
             <!-- Procedures Section (entries required) (V2) IGpg389-->
             <component>
                 <section>
-                    <templateId extension="2014-06-09"
-                        root="2.16.840.1.113883.10.20.22.2.7" />
-                    <templateId extension="2014-06-09"
-                        root="2.16.840.1.113883.10.20.22.2.7.1" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" />
-                    <code code="47519-4"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="PROCEDURES" />
+                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.7"/>
+                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="PROCEDURES"/>
                     <title>Procedures</title>
                     <text>
                         <table>
@@ -1501,34 +1227,26 @@ the care of the document. -->
                     </text>
                     <entry typeCode="DRIV">
                         <!-- Procedure Activity Procedure (V2) IGpg766-->
-                        <procedure classCode="PROC"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.14" />
-                            <templateId extension="2014-06-09"
-                                root="2.16.840.1.113883.10.20.22.4.14" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.14" />
-                            <id root="3eac56a9-7848-4895-5b81-1a1a14bdbd8a" />
-                            <code code="122433001"
-                                codeSystem="2.16.840.1.113883.6.96"
-                                codeSystemName="SNOMED CT"
-                                displayName="COVID-19 virus antigen detection">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <id root="3eac56a9-7848-4895-5b81-1a1a14bdbd8a"/>
+                            <code code="122433001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="COVID-19 virus antigen detection">
                                 <originalText>
-                                    <reference value="#procedure-1" />
+                                    <reference value="#procedure-1"/>
                                 </originalText>
                             </code>
-                            <statusCode code="completed" />
-                            <effectiveTime value="20240516" />
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20240516"/>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="202405161647-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="202405161647-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id extension="1649404625"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id extension="1649404625" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>First</family>
@@ -1536,27 +1254,24 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <!-- Service Delivery Location IGpg 336-->
                             <participant typeCode="LOC">
                                 <participantRole classCode="SDLOC">
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.32" />
-                                    <code nullFlavor="UNK" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <code nullFlavor="UNK"/>
                                     <addr>
-                                        <streetAddressLine nullFlavor="UNK" />
-                                        <city nullFlavor="UNK" />
-                                        <state nullFlavor="UNK" />
-                                        <postalCode nullFlavor="UNK" />
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
                                     </addr>
                                 </participantRole>
                             </participant>
@@ -1564,31 +1279,26 @@ the care of the document. -->
                     </entry>
                     <entry typeCode="DRIV">
                         <!-- Procedure Activity Procedure (V2) IGpg766-->
-                        <procedure classCode="PROC"
-                            moodCode="EVN">
-                            <templateId extension="2022-06-01"
-                                root="2.16.840.1.113883.10.20.22.4.14" />
-                            <templateId extension="2014-06-09"
-                                root="2.16.840.1.113883.10.20.22.4.14" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.14" />
-                            <id root="37ffc93e-4edb-46aa-679b-90fc121c86ae" />
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <id root="37ffc93e-4edb-46aa-679b-90fc121c86ae"/>
                             <code nullFlavor="UNK">
                                 <originalText>
-                                    <reference value="#procedure-2" />
+                                    <reference value="#procedure-2"/>
                                 </originalText>
                             </code>
-                            <statusCode code="completed" />
-                            <effectiveTime value="20240516" />
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20240516"/>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516120907-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516120907-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id extension="1649404625"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id extension="1649404625" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>First</family>
@@ -1596,27 +1306,24 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <!-- Service Delivery Location IGpg 336-->
                             <participant typeCode="LOC">
                                 <participantRole classCode="SDLOC">
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.32" />
-                                    <code nullFlavor="UNK" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <code nullFlavor="UNK"/>
                                     <addr>
-                                        <streetAddressLine nullFlavor="UNK" />
-                                        <city nullFlavor="UNK" />
-                                        <state nullFlavor="UNK" />
-                                        <postalCode nullFlavor="UNK" />
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
                                     </addr>
                                 </participantRole>
                             </participant>
@@ -1627,17 +1334,13 @@ the care of the document. -->
             <!--   Section (entries required) (V3) IGpg 398 -->
             <component>
                 <section>
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.3.1" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" />
-                    <code code="30954-2"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="RELEVANT DIAGNOSTIC TESTS AND/OR LABORATORY DATA" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="RELEVANT DIAGNOSTIC TESTS AND/OR LABORATORY DATA"/>
                     <title>Relevant Diagnostic Tests and/or Laboratory Data</title>
                     <text>
                         <content styleCode="Bold">Microbiology Results</content>
-                        <br />
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -1654,47 +1357,42 @@ the care of the document. -->
                                 <tr>
                                     <td ID="result-M11">Influenza A &amp; B Antigen</td>
                                     <td>Nasopharyngeal, Other</td>
-                                    <td />
+                                    <td/>
                                     <td>May 16th, 2024 11:54am</td>
                                     <td>May 16th, 2024 12:09pm</td>
-                                    <td />
-                                    <td />
+                                    <td/>
+                                    <td/>
                                 </tr>
                                 <tr>
                                     <td ID="result-M21">SARS-CoV-2 Antigen (Rapid)</td>
                                     <td>Nares</td>
-                                    <td />
+                                    <td/>
                                     <td>May 16th, 2024 2:16pm</td>
                                     <td>May 16th, 2024 4:47pm</td>
-                                    <td />
-                                    <td>Name County Main Lab<br />CLIA#17D0450734<br />999 N. 4th
-                                        St.<br />Burlington KS 66839</td>
+                                    <td/>
+                                    <td>Name County Main Lab<br/>CLIA#17D0450734<br/>999 N. 4th
+                                        St.<br/>Burlington KS 66839</td>
                                 </tr>
                             </tbody>
                         </table>
                     </text>
                     <entry typeCode="DRIV">
                         <!-- Result Organizer (V3) IGpg797 -->
-                        <organizer classCode="BATTERY"
-                            moodCode="EVN">
-                            <templateId extension="2023-05-01"
-                                root="2.16.840.1.113883.10.20.22.4.1" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.1" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.1" />
-                            <id root="145c3d93-f482-4e51-e38f-4121b1a7f1d9" />
-                            <code nullFlavor="UNK" />
-                            <statusCode code="completed" />
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId extension="2023-05-01" root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <id root="145c3d93-f482-4e51-e38f-4121b1a7f1d9"/>
+                            <code nullFlavor="UNK"/>
+                            <statusCode code="completed"/>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="20240516120907-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="20240516120907-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id extension="1649404625"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id extension="1649404625" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>First</family>
@@ -1702,68 +1400,71 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <component>
                                 <!--  Result observation IGpg792 -->
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2023-05-01"
-                                        root="2.16.840.1.113883.10.20.22.4.2" />
-                                    <templateId extension="2015-08-01"
-                                        root="2.16.840.1.113883.10.20.22.4.2" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
-                                    <id root="e4f583c1-a125-409c-bf20-4a144a898bc2" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2023-05-01" root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <id root="e4f583c1-a125-409c-bf20-4a144a898bc2"/>
+                                    <!--DATA AUGMENTATION: This data has been augmented with a standard LOINC code -->
+                                    <!--DATA AUGMENTATION: The data in the code and code/originalText data elements is the original data -->
                                     <code nullFlavor="UNK">
                                         <originalText>
-                                            <reference value="#result-M11" />
+                                            <reference value="#result-M11"/>
                                         </originalText>
+                                        <!--DATA AUGMENTATION: The data in the translation is the augmented data -->
+                                        <translation code="82041-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" DisplayName="Weed Allerg Mix3 IgE Qn" originalText="Influenza A &amp; B Antigen"/>
                                     </code>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="202405161154-0500" />
-                                    <value nullFlavor="UNK"
-                                        xsi:type="ST" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202405161154-0500"/>
+                                    <value nullFlavor="UNK" xsi:type="ST"/>
+                                    <author>
+                                        <!--DATA AUGMENTATION: functionCode specifies type of change 'code-text-to-code' which signifies that the code in this observation has been augmented with a code derived from the text in the code element -->
+                                        <functionCode code="code-text-to-code" codeSystem="2.16.840.1.113883.10.20.15.2.7.1" codeSystemName="eCRDataAugmentation"/>
+                                        <!--DATA AUGMENTATION: time of data augmentation operation -->
+                                        <effectiveTime value="20260213152757"/>
+                                        <assignedAuthor>
+                                            <!--DATA AUGMENTATION: set to nullFlavor 'NA' -->
+                                            <id nullFlavor="NA"/>
+                                            <!--DATA AUGMENTATION: set to nullFlavor 'NA' -->
+                                            <addr nullFlavor="NA"/>
+                                            <!--DATA AUGMENTATION: set to nullFlavor 'NA' -->
+                                            <telecom nullFlavor="NA"/>
+                                            <!--DATA AUGMENTATION: set to 'Data Augmentation Tool' -->
+                                            <assignedAuthoringDevice>
+                                                <!--DATA AUGMENTATION: assignedAuthoringDevice/softwareName specifies that this document has been transformed using the Text-to-Code data augmentation tool -->
+                                                <softwareName code="text-to-code" codeSystem="2.16.840.1.113883.10.20.15.2.7.1" codeSystemName="eCRDataAugmentation" displayName="Text-to-Code"/>
+                                            </assignedAuthoringDevice>
+                                        </assignedAuthor>
+                                    </author>
                                 </observation>
                             </component>
                         </organizer>
                     </entry>
                     <entry typeCode="DRIV">
                         <!-- Result Organizer (V3) IGpg797 -->
-                        <organizer classCode="BATTERY"
-                            moodCode="EVN">
-                            <templateId extension="2023-05-01"
-                                root="2.16.840.1.113883.10.20.22.4.1" />
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.1" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.1" />
-                            <id root="c16f8600-4d41-454a-b6a3-2a50fb327e68" />
-                            <code code="94558-4"
-                                codeSystem="2.16.840.1.113883.6.1"
-                                codeSystemName="LOINC"
-                                displayName="COVID-19 virus antigen detection">
-                                <translation code="87426"
-                                    codeSystem="2.16.840.1.113883.6.12"
-                                    codeSystemName="CPT-4"
-                                    displayName="COVID-19 virus antigen detection" />
-                                <translation code="122433001"
-                                    codeSystem="2.16.840.1.113883.6.96"
-                                    codeSystemName="SNOMED CT"
-                                    displayName="COVID-19 virus antigen detection" />
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId extension="2023-05-01" root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <id root="c16f8600-4d41-454a-b6a3-2a50fb327e68"/>
+                            <code code="94558-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="COVID-19 virus antigen detection">
+                                <translation code="87426" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" displayName="COVID-19 virus antigen detection"/>
+                                <translation code="122433001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="COVID-19 virus antigen detection"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <performer>
                                 <assignedEntity>
-                                    <id extension="CLIA#17D0450734"
-                                        root="2.16.840.1.113883.4.7" />
+                                    <id extension="CLIA#17D0450734" root="2.16.840.1.113883.4.7"/>
                                     <representedOrganization>
                                         <name>Name County Main Lab</name>
                                         <addr>
@@ -1777,14 +1478,12 @@ the care of the document. -->
                             </performer>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="202405161647-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="202405161647-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id extension="1649404625"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id extension="1649404625" root="2.16.840.1.113883.4.6"/>
                                     <assignedPerson>
                                         <name>
                                             <family>First</family>
@@ -1792,56 +1491,34 @@ the care of the document. -->
                                         </name>
                                     </assignedPerson>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <component>
                                 <!--  Result observation IGpg792 -->
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2023-05-01"
-                                        root="2.16.840.1.113883.10.20.22.4.2" />
-                                    <templateId extension="2015-08-01"
-                                        root="2.16.840.1.113883.10.20.22.4.2" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2023-05-01" root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
                                     <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Result
                                     Observation eCR IGpg 196-->
-                                    <templateId extension="2016-12-01"
-                                        root="2.16.840.1.113883.10.20.15.2.3.2" />
-                                    <id root="d5bc163d-351c-4170-8467-418ee6204a58" />
-                                    <code code="94558-4"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="COVID-19 virus antigen detection"
-                                        sdtc:valueSet="2.16.840.1.114222.4.11.7508"
-                                        sdtc:valueSetVersion="2024-02-02">
+                                    <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.2"/>
+                                    <id root="d5bc163d-351c-4170-8467-418ee6204a58"/>
+                                    <code code="94558-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="COVID-19 virus antigen detection" sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="2024-02-02">
                                         <originalText>
-                                            <reference value="#result-M21" />
+                                            <reference value="#result-M21"/>
                                         </originalText>
-                                        <translation code="87426"
-                                            codeSystem="2.16.840.1.113883.6.12"
-                                            codeSystemName="CPT-4"
-                                            displayName="COVID-19 virus antigen detection" />
-                                        <translation code="122433001"
-                                            codeSystem="2.16.840.1.113883.6.96"
-                                            codeSystemName="SNOMED CT"
-                                            displayName="COVID-19 virus antigen detection" />
+                                        <translation code="87426" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" displayName="COVID-19 virus antigen detection"/>
+                                        <translation code="122433001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="COVID-19 virus antigen detection"/>
                                     </code>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="202405161416-0500" />
-                                    <value code="122433001"
-                                        codeSystem="2.16.840.1.113883.6.96"
-                                        codeSystemName="SNOMED CT"
-                                        displayName="COVID-19 virus antigen detection"
-                                        xsi:type="CD" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202405161416-0500"/>
+                                    <value code="122433001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="COVID-19 virus antigen detection" xsi:type="CD"/>
                                 </observation>
                             </component>
                         </organizer>
@@ -1851,13 +1528,9 @@ the care of the document. -->
             <!-- Vital Signs Section (entries required) (V3) IGpg412 -->
             <component>
                 <section>
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.4.1" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" />
-                    <code code="8716-3"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="VITAL SIGNS" />
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="VITAL SIGNS"/>
                     <title>Vital Signs</title>
                     <text>
                         <table>
@@ -1873,13 +1546,13 @@ the care of the document. -->
                                 <tr>
                                     <td>Height</td>
                                     <td ID="vitalSign-1.1">64 [in_i]</td>
-                                    <td />
+                                    <td/>
                                     <td>May 16th, 2024 11:20am</td>
                                 </tr>
                                 <tr>
                                     <td>Weight</td>
                                     <td ID="vitalSign-1.2">150.00 [lb_av]</td>
-                                    <td />
+                                    <td/>
                                     <td>May 16th, 2024 11:20am</td>
                                 </tr>
                                 <tr>
@@ -1915,7 +1588,7 @@ the care of the document. -->
                                 <tr>
                                     <td>BMI (Body Mass Index)</td>
                                     <td ID="vitalSign-1.8">25.7 kg/m2</td>
-                                    <td />
+                                    <td/>
                                     <td>May 16th, 2024 11:20am</td>
                                 </tr>
                             </tbody>
@@ -1923,56 +1596,39 @@ the care of the document. -->
                     </text>
                     <!-- ** Vital signs organizer (V3) ** IGpg873-->
                     <entry typeCode="DRIV">
-                        <organizer classCode="CLUSTER"
-                            moodCode="EVN">
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.26" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.26" />
-                            <id root="26a6221a-366b-4bf6-a860-238899c5d9ea" />
-                            <code code="46680005"
-                                codeSystem="2.16.840.1.113883.6.96"
-                                codeSystemName="SNOMED CT"
-                                displayName="Vital signs">
-                                <translation code="74728-7"
-                                    codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"
-                                    displayName="Vital signs" />
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <id root="26a6221a-366b-4bf6-a860-238899c5d9ea"/>
+                            <code code="46680005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Vital signs">
+                                <translation code="74728-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Vital signs"/>
                             </code>
-                            <statusCode code="completed" />
+                            <statusCode code="completed"/>
                             <effectiveTime>
-                                <low value="20240516111753-0500" />
-                                <high value="202405161150-0500" />
+                                <low value="20240516111753-0500"/>
+                                <high value="202405161150-0500"/>
                             </effectiveTime>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="beecbd85-8e54-4e0d-7bb9-d8e5b14caa65" />
-                                    <code code="8302-2"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Height" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="beecbd85-8e54-4e0d-7bb9-d8e5b14caa65"/>
+                                    <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Height"/>
                                     <text>
-                                        <reference value="#vitalSign-1.1" />
+                                        <reference value="#vitalSign-1.1"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="[in_i]"
-                                        value="64"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="[in_i]" value="64" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -1980,14 +1636,11 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
@@ -1995,34 +1648,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="cf4179e2-7e2a-4acd-96b1-dc5ad00365a1" />
-                                    <code code="29463-7"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Weight" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="cf4179e2-7e2a-4acd-96b1-dc5ad00365a1"/>
+                                    <code code="29463-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Weight"/>
                                     <text>
-                                        <reference value="#vitalSign-1.2" />
+                                        <reference value="#vitalSign-1.2"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="[lb_av]"
-                                        value="150.00"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="[lb_av]" value="150.00" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2030,14 +1674,11 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
@@ -2045,34 +1686,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="fe0691df-b68f-47aa-8bb8-ce3687d768fd" />
-                                    <code code="8310-5"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Body Temperature" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="fe0691df-b68f-47aa-8bb8-ce3687d768fd"/>
+                                    <code code="8310-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Body Temperature"/>
                                     <text>
-                                        <reference value="#vitalSign-1.3" />
+                                        <reference value="#vitalSign-1.3"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="[degF]"
-                                        value="97.8"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="[degF]" value="97.8" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2080,24 +1712,21 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
                                     <referenceRange>
                                         <observationRange>
                                             <text>
-                                                <reference value="#vitalSignRefRange-1.3" />
+                                                <reference value="#vitalSignRefRange-1.3"/>
                                             </text>
                                             <value xsi:type="ED">
-                                                <reference value="#vitalSignRefRange-1.3" />
+                                                <reference value="#vitalSignRefRange-1.3"/>
                                             </value>
                                         </observationRange>
                                     </referenceRange>
@@ -2105,34 +1734,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="2a94b4f6-57ed-4a23-e6b8-2aef73d0a641" />
-                                    <code code="8867-4"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Heart Rate" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="2a94b4f6-57ed-4a23-e6b8-2aef73d0a641"/>
+                                    <code code="8867-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Heart Rate"/>
                                     <text>
-                                        <reference value="#vitalSign-1.4" />
+                                        <reference value="#vitalSign-1.4"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="/min"
-                                        value="82"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="/min" value="82" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2140,24 +1760,21 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
                                     <referenceRange>
                                         <observationRange>
                                             <text>
-                                                <reference value="#vitalSignRefRange-1.4" />
+                                                <reference value="#vitalSignRefRange-1.4"/>
                                             </text>
                                             <value xsi:type="ED">
-                                                <reference value="#vitalSignRefRange-1.4" />
+                                                <reference value="#vitalSignRefRange-1.4"/>
                                             </value>
                                         </observationRange>
                                     </referenceRange>
@@ -2165,34 +1782,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="574b6c7a-adc6-4866-99a0-58b3bd4398bb" />
-                                    <code code="59408-5"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Oxygen saturation by Pulse oximetry" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="574b6c7a-adc6-4866-99a0-58b3bd4398bb"/>
+                                    <code code="59408-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Oxygen saturation by Pulse oximetry"/>
                                     <text>
-                                        <reference value="#vitalSign-1.5" />
+                                        <reference value="#vitalSign-1.5"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="%"
-                                        value="98"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="%" value="98" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2200,24 +1808,21 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
                                     <referenceRange>
                                         <observationRange>
                                             <text>
-                                                <reference value="#vitalSignRefRange-1.5" />
+                                                <reference value="#vitalSignRefRange-1.5"/>
                                             </text>
                                             <value xsi:type="ED">
-                                                <reference value="#vitalSignRefRange-1.5" />
+                                                <reference value="#vitalSignRefRange-1.5"/>
                                             </value>
                                         </observationRange>
                                     </referenceRange>
@@ -2225,34 +1830,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="cba309f8-1901-4508-979f-37394c3630e4" />
-                                    <code code="8480-6"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="BP Systolic" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="cba309f8-1901-4508-979f-37394c3630e4"/>
+                                    <code code="8480-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BP Systolic"/>
                                     <text>
-                                        <reference value="#vitalSign-1.6" />
+                                        <reference value="#vitalSign-1.6"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="mm[Hg]"
-                                        value="122"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="mm[Hg]" value="122" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2260,24 +1856,21 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
                                     <referenceRange>
                                         <observationRange>
                                             <text>
-                                                <reference value="#vitalSignRefRange-1.6" />
+                                                <reference value="#vitalSignRefRange-1.6"/>
                                             </text>
                                             <value xsi:type="ED">
-                                                <reference value="#vitalSignRefRange-1.6" />
+                                                <reference value="#vitalSignRefRange-1.6"/>
                                             </value>
                                         </observationRange>
                                     </referenceRange>
@@ -2285,34 +1878,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="d6a703fb-4469-41f4-99a2-ac396252d69e" />
-                                    <code code="8462-4"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="BP Diastolic" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="d6a703fb-4469-41f4-99a2-ac396252d69e"/>
+                                    <code code="8462-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BP Diastolic"/>
                                     <text>
-                                        <reference value="#vitalSign-1.7" />
+                                        <reference value="#vitalSign-1.7"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="mm[Hg]"
-                                        value="59"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="mm[Hg]" value="59" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2320,24 +1904,21 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
                                     <referenceRange>
                                         <observationRange>
                                             <text>
-                                                <reference value="#vitalSignRefRange-1.7" />
+                                                <reference value="#vitalSignRefRange-1.7"/>
                                             </text>
                                             <value xsi:type="ED">
-                                                <reference value="#vitalSignRefRange-1.7" />
+                                                <reference value="#vitalSignRefRange-1.7"/>
                                             </value>
                                         </observationRange>
                                     </referenceRange>
@@ -2345,34 +1926,25 @@ the care of the document. -->
                             </component>
                             <!-- ** Vital sign observation (V2) IGpg869 -->
                             <component>
-                                <observation classCode="OBS"
-                                    moodCode="EVN">
-                                    <templateId extension="2014-06-09"
-                                        root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.27" />
-                                    <id root="6731dc7b-f1a2-40f3-b8aa-955bdb22b1b8" />
-                                    <code code="39156-5"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="BMI (Body Mass Index)" />
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <id root="6731dc7b-f1a2-40f3-b8aa-955bdb22b1b8"/>
+                                    <code code="39156-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="BMI (Body Mass Index)"/>
                                     <text>
-                                        <reference value="#vitalSign-1.8" />
+                                        <reference value="#vitalSign-1.8"/>
                                     </text>
-                                    <statusCode code="completed" />
-                                    <effectiveTime value="20240516112046-0500" />
-                                    <value unit="kg/m2"
-                                        value="25.7"
-                                        xsi:type="PQ" />
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20240516112046-0500"/>
+                                    <value unit="kg/m2" value="25.7" xsi:type="PQ"/>
                                     <author>
                                         <!-- Provenance - Author Participation -->
-                                        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                        <templateId extension="2019-10-01"
-                                            root="2.16.840.1.113883.10.20.22.5.6" />
-                                        <time value="20240516112046-0500" />
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                        <time value="20240516112046-0500"/>
                                         <assignedAuthor>
                                             <!-- NPI of Author -->
-                                            <id nullFlavor="UNK"
-                                                root="2.16.840.1.113883.4.6" />
+                                            <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                             <assignedPerson>
                                                 <name>
                                                     <family>Last</family>
@@ -2380,14 +1952,11 @@ the care of the document. -->
                                                 </name>
                                             </assignedPerson>
                                             <representedOrganization>
-                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.6" />
-                                                <id nullFlavor="UNK"
-                                                    root="2.16.840.1.113883.4.2" />
+                                                <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                                <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                                 <name>Name Health System</name>
-                                                <telecom use="WP"
-                                                    value="tel:+1(999)999-2121" />
+                                                <telecom use="WP" value="tel:+1(999)999-2121"/>
                                             </representedOrganization>
                                         </assignedAuthor>
                                     </author>
@@ -2400,13 +1969,9 @@ the care of the document. -->
             <!-- Medications Administered Section IGpg334 -->
             <component>
                 <section nullFlavor="NI">
-                    <templateId extension="2014-06-09"
-                        root="2.16.840.1.113883.10.20.22.2.38" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.38" />
-                    <code code="29549-3"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="MEDICATIONS ADMINISTERED" />
+                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="MEDICATIONS ADMINISTERED"/>
                     <title>Administered Medications</title>
                     <text>No administered medications information available</text>
                 </section>
@@ -2414,16 +1979,11 @@ the care of the document. -->
             <!-- Encounters Section IGpg287-->
             <component>
                 <section>
-                    <templateId root="2.16.840.1.113883.10.20.22.2.22" />
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.22" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
-                    <templateId extension="2015-08-01"
-                        root="2.16.840.1.113883.10.20.22.2.22.1" />
-                    <code code="46240-8"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="History of encounters" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22.1"/>
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.2.22.1"/>
+                    <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of encounters"/>
                     <title>Encounters</title>
                     <text>
                         <table>
@@ -2450,7 +2010,7 @@ the care of the document. -->
                                 </tr>
                             </tbody>
                         </table>
-                        <br />
+                        <br/>
                         <table>
                             <thead>
                                 <tr>
@@ -2462,7 +2022,7 @@ the care of the document. -->
                             <tbody>
                                 <tr>
                                     <td ID="diagnosis-1.0">Cough</td>
-                                    <td />
+                                    <td/>
                                     <td>May 16th, 2024 11:17am</td>
                                 </tr>
                             </tbody>
@@ -2470,62 +2030,50 @@ the care of the document. -->
                     </text>
                     <!-- Encounter Activity IGpg479-->
                     <entry typeCode="DRIV">
-                        <encounter classCode="ENC"
-                            moodCode="EVN">
-                            <templateId extension="2015-08-01"
-                                root="2.16.840.1.113883.10.20.22.4.49" />
-                            <templateId root="2.16.840.1.113883.10.20.22.4.49" />
-                            <id root="17313cfa-8731-5dbe-bc52-e296d82d0860" />
-                            <id extension="Z00000173103"
-                                root="2.16.840.1.113883.3.432.0.16.1.100.779.2.10" />
-                            <code code="AMB"
-                                codeSystem="2.16.840.1.113883.5.4"
-                                codeSystemName="HL7 ActEncounterCode"
-                                displayName="ambulatory">
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <id root="17313cfa-8731-5dbe-bc52-e296d82d0860"/>
+                            <id extension="Z00000173103" root="2.16.840.1.113883.3.432.0.16.1.100.779.2.10"/>
+                            <code code="AMB" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7 ActEncounterCode" displayName="ambulatory">
                                 <originalText>
-                                    <reference value="#encounter-1" />
+                                    <reference value="#encounter-1"/>
                                 </originalText>
                             </code>
                             <effectiveTime>
-                                <low value="20240516111753-0500" />
-                                <high value="202405161150-0500" />
+                                <low value="20240516111753-0500"/>
+                                <high value="202405161150-0500"/>
                             </effectiveTime>
                             <!-- Provider Detail -->
                             <performer>
                                 <assignedEntity>
                                     <!-- Provider NPI -->
-                                    <id extension="1649404625"
-                                        root="2.16.840.1.113883.4.6" />
-                                    <code nullFlavor="UNK" />
+                                    <id extension="1649404625" root="2.16.840.1.113883.4.6"/>
+                                    <code nullFlavor="UNK"/>
                                 </assignedEntity>
                             </performer>
                             <author>
                                 <!-- Provenance - Author Participation -->
-                                <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-                                <templateId extension="2019-10-01"
-                                    root="2.16.840.1.113883.10.20.22.5.6" />
-                                <time value="202405161150-0500" />
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <templateId extension="2019-10-01" root="2.16.840.1.113883.10.20.22.5.6"/>
+                                <time value="202405161150-0500"/>
                                 <assignedAuthor>
                                     <!-- NPI of Author -->
-                                    <id nullFlavor="UNK"
-                                        root="2.16.840.1.113883.4.6" />
+                                    <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
                                     <representedOrganization>
-                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.6" />
-                                        <id nullFlavor="UNK"
-                                            root="2.16.840.1.113883.4.2" />
+                                        <id root="2.16.840.1.113883.3.432.0.16.1.100.779"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.6"/>
+                                        <id nullFlavor="UNK" root="2.16.840.1.113883.4.2"/>
                                         <name>Name Health System</name>
-                                        <telecom use="WP"
-                                            value="tel:+1(999)999-2121" />
+                                        <telecom use="WP" value="tel:+1(999)999-2121"/>
                                     </representedOrganization>
                                 </assignedAuthor>
                             </author>
                             <!-- Service Location -->
                             <participant typeCode="LOC">
                                 <participantRole classCode="SDLOC">
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.32" />
-                                    <code nullFlavor="UNK" />
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <code nullFlavor="UNK"/>
                                     <addr>
                                         <streetAddressLine>999 E Madison</streetAddressLine>
                                         <city>YATES CENTER</city>
@@ -2539,55 +2087,31 @@ the care of the document. -->
                             </participant>
                             <!-- Encounter Diagnosis Section IGpg484 -->
                             <entryRelationship typeCode="SUBJ">
-                                <act classCode="ACT"
-                                    moodCode="EVN">
-                                    <templateId extension="2015-08-01"
-                                        root="2.16.840.1.113883.10.20.22.4.80" />
-                                    <templateId root="2.16.840.1.113883.10.20.22.4.80" />
-                                    <code code="29308-4"
-                                        codeSystem="2.16.840.1.113883.6.1"
-                                        codeSystemName="LOINC"
-                                        displayName="Diagnosis" />
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diagnosis"/>
                                     <!-- Problem Observation IGpg737 -->
                                     <entryRelationship typeCode="SUBJ">
-                                        <observation classCode="OBS"
-                                            moodCode="EVN"
-                                            negationInd="false">
-                                            <templateId root="2.16.840.1.113883.10.20.22.4.4" />
-                                            <templateId extension="2015-08-01"
-                                                root="2.16.840.1.113883.10.20.22.4.4" />
-                                            <id root="d0b233e7-6986-4cc0-ba34-6beaaec12ef5" />
-                                            <code code="64572001"
-                                                codeSystem="2.16.840.1.113883.6.96"
-                                                codeSystemName="SNOMED CT"
-                                                displayName="Condition">
-                                                <translation code="75323-6"
-                                                    codeSystem="2.16.840.1.113883.6.1"
-                                                    codeSystemName="LOINC"
-                                                    displayName="Condition" />
+                                        <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <id root="d0b233e7-6986-4cc0-ba34-6beaaec12ef5"/>
+                                            <code code="64572001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Condition">
+                                                <translation code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Condition"/>
                                             </code>
-                                            <statusCode code="completed" />
+                                            <statusCode code="completed"/>
                                             <!-- Diagnosis Effective Time -->
                                             <effectiveTime>
-                                                <low nullFlavor="UNK" />
+                                                <low nullFlavor="UNK"/>
                                             </effectiveTime>
                                             <!-- Diagnosis Codes -->
-                                            <value code="R05.9"
-                                                codeSystem="2.16.840.1.113883.6.90"
-                                                codeSystemName="ICD10"
-                                                displayName="Cough"
-                                                xsi:type="CD">
+                                            <value code="R05.9" codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD10" displayName="Cough" xsi:type="CD">
                                                 <originalText>
-                                                    <reference value="#diagnosis-1.0" />
+                                                    <reference value="#diagnosis-1.0"/>
                                                 </originalText>
-                                                <translation code="786.2"
-                                                    codeSystem="2.16.840.1.113883.6.103"
-                                                    codeSystemName="ICD9"
-                                                    displayName="Cough" />
-                                                <translation code="49727002"
-                                                    codeSystem="2.16.840.1.113883.6.96"
-                                                    codeSystemName="SNOMED CT"
-                                                    displayName="Cough" />
+                                                <translation code="786.2" codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD9" displayName="Cough"/>
+                                                <translation code="49727002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Cough"/>
                                             </value>
                                         </observation>
                                     </entryRelationship>
@@ -2599,11 +2123,8 @@ the care of the document. -->
             </component>
             <component>
                 <section>
-                    <templateId root="2.16.840.1.113883.10.20.22.2.8" />
-                    <code code="51848-0"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="ASSESSMENTS" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <code code="51848-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="ASSESSMENTS"/>
                     <title>Assessments</title>
                     <text>
                         <table>
@@ -2619,8 +2140,8 @@ the care of the document. -->
                             <tbody>
                                 <tr>
                                     <td>Cough</td>
-                                    <td />
-                                    <td />
+                                    <td/>
+                                    <td/>
                                     <td>noneactive</td>
                                     <td>May 16th, 2024 11:17am</td>
                                 </tr>
@@ -2632,20 +2153,16 @@ the care of the document. -->
             <!-- Plan of Treatment Section (V2) IGpg357 -->
             <component>
                 <section>
-                    <templateId extension="2014-06-09"
-                        root="2.16.840.1.113883.10.20.22.2.10" />
-                    <templateId root="2.16.840.1.113883.10.20.22.2.10" />
-                    <code code="18776-5"
-                        codeSystem="2.16.840.1.113883.6.1"
-                        codeSystemName="LOINC"
-                        displayName="Treatment plan" />
+                    <templateId extension="2014-06-09" root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Treatment plan"/>
                     <title>Plan of Treatment</title>
                     <text>
                         <table>
                             <tbody>
                                 <tr>
                                     <th>Author</th>
-                                    <td>Last First<br />Name Health System</td>
+                                    <td>Last First<br/>Name Health System</td>
                                 </tr>
                                 <tr>
                                     <th>Authored</th>
@@ -2653,43 +2170,68 @@ the care of the document. -->
                                 </tr>
                                 <tr>
                                     <td colspan="2">His flu swab was negative today. We will obtain
-                        a covid swab and notify him of results when <br />available. Reassurance at
-                        this point he is pretty clear on exam and this may just be the common <br />
+                        a covid swab and notify him of results when <br/>available. Reassurance at
+                        this point he is pretty clear on exam and this may just be the common <br/>
                         cold.
-<br />The information above is a summary, and not a full recitation,
-                        of the interaction. Not everything <br />can be documented. Sometimes
+<br/>The information above is a summary, and not a full recitation,
+                        of the interaction. Not everything <br/>can be documented. Sometimes
                         inadvertent omissions occur. </td>
                                 </tr>
                             </tbody>
                         </table>
-						<br />
-						<content
-                            styleCode="Bold">Future Tests</content>
-						<br /> Future scheduled test
-                        information is unavailable <br />
-						<content styleCode="Bold">Pending Tests</content>
-						<br />
-                        Pending diagnostic test information is unavailable <br />
-						<content
-                            styleCode="Bold">Future Visits</content>
-						<br /> Future appointment
-                        information is unavailable <br />
-						<content styleCode="Bold">Referrals to
+                        <br/>
+                        <content styleCode="Bold">Future Tests</content>
+                        <br/> Future scheduled test
+                        information is unavailable <br/>
+                        <content styleCode="Bold">Pending Tests</content>
+                        <br/>
+                        Pending diagnostic test information is unavailable <br/>
+                        <content styleCode="Bold">Future Visits</content>
+                        <br/> Future appointment
+                        information is unavailable <br/>
+                        <content styleCode="Bold">Referrals to
                         Other Providers</content>
-						<br /> Referral information is unavailable <br />
-						<content
-                            styleCode="Bold">Future Procedures</content>
-						<br /> Future procedure
-                        information is unavailable <br />
-						<content styleCode="Bold">Future
+                        <br/> Referral information is unavailable <br/>
+                        <content styleCode="Bold">Future Procedures</content>
+                        <br/> Future procedure
+                        information is unavailable <br/>
+                        <content styleCode="Bold">Future
                         Medications</content>
-						<br /> Future medication information is unavailable <br />
-						<content
-                            styleCode="Bold">Patient Instructions</content>
-						<br /> Patient
+                        <br/> Future medication information is unavailable <br/>
+                        <content styleCode="Bold">Patient Instructions</content>
+                        <br/> Patient
                         instructions are unavailable </text>
                 </section>
             </component>
         </structuredBody>
     </component>
+    <!--DATA AUGMENTATION: typeCode 'XFRM' -->
+    <relatedDocument typeCode="XFRM">
+        <parentDocument>
+            <!--DATA AUGMENTATION: ClinicalDocument/id of the document to replace -->
+            <!--DATA AUGMENTATION: original-document-id -->
+            <id extension="72975" root="2.16.840.1.113883.3.432.0.16.1.100.779.2" assigningAuthorityName="original-document"/>
+            <!--DATA AUGMENTATION: input-document-setId -->
+            <setId extension="C0-B20240516115522456" root="2.16.840.1.113883.3.432.0.16.1.100.779.2.10"/>
+            <!--DATA AUGMENTATION: input-document-versionNumber -->
+            <versionNumber value="4"/>
+        </parentDocument>
+    </relatedDocument>
+    <author>
+        <!--DATA AUGMENTATION: time of data augmentation operation -->
+        <effectiveTime value="20260213152757"/>
+        <assignedAuthor>
+            <!--DATA AUGMENTATION: set to nullFlavor 'NA' -->
+            <id nullFlavor="NA"/>
+            <!--DATA AUGMENTATION: set to nullFlavor 'NA' -->
+            <addr nullFlavor="NA"/>
+            <!--DATA AUGMENTATION: set to nullFlavor 'NA' -->
+            <telecom nullFlavor="NA"/>
+            <!--DATA AUGMENTATION: set to 'Data Augmentation Tool' -->
+            <assignedAuthoringDevice>
+                <!--DATA AUGMENTATION: assignedAuthoringDevice/softwareName specifies that this document has been transformed using the Text-to-Code data augmentation tool -->
+                <softwareName code="text-to-code" codeSystem="2.16.840.1.113883.10.20.15.2.7.1" codeSystemName="eCRDataAugmentation" displayName="Text-to-Code"/>
+            </assignedAuthoringDevice>
+        </assignedAuthor>
+    </author>
 </ClinicalDocument>

--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_validation_results.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_validation_results.json
@@ -1,9 +1,5 @@
 [
   {
-    "error_id": "ttc-labTestNameResulted-code-missing",
-    "location": "/Q{urn:hl7-org:v3}ClinicalDocument[1]/Q{urn:hl7-org:v3}component[1]/Q{urn:hl7-org:v3}structuredBody[1]/Q{urn:hl7-org:v3}component[8]/Q{urn:hl7-org:v3}section[1]/Q{urn:hl7-org:v3}entry[1]/Q{urn:hl7-org:v3}organizer[1]/Q{urn:hl7-org:v3}component[1]/Q{urn:hl7-org:v3}observation[1]"
-  },
-  {
     "error_id": "ttc-labResultValue-noCode",
     "location": "/Q{urn:hl7-org:v3}ClinicalDocument[1]/Q{urn:hl7-org:v3}component[1]/Q{urn:hl7-org:v3}structuredBody[1]/Q{urn:hl7-org:v3}component[8]/Q{urn:hl7-org:v3}section[1]/Q{urn:hl7-org:v3}entry[1]/Q{urn:hl7-org:v3}organizer[1]/Q{urn:hl7-org:v3}component[1]/Q{urn:hl7-org:v3}observation[1]"
   }

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -568,7 +568,13 @@ class TestEndToEndSimulated:
 
             _assert_augmented_eicr_retains_original_content(original_root, augmented_root, eicr_id)
 
-            assert actual_validation_results == [], actual_validation_results
+            # The augmenter only blocks output on errors it introduced, so the success path
+            # asserts no *new* findings versus the original eICR, not zero findings overall.
+            baseline_validation_results = validate_eicr(original_eicr)
+            new_validation_results = set(actual_validation_results) - set(
+                baseline_validation_results
+            )
+            assert new_validation_results == set(), new_validation_results
 
         snapshot.assert_match(
             json.dumps(

--- a/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
+++ b/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
@@ -121,6 +121,58 @@ def _process_record(record: SQSRecord) -> None:
         )
 
 
+def _introduced_validation_error(original_eicr: str, augmented_eicr: str) -> str | None:
+    """Return a JSON error string only if augmentation introduced new validation errors.
+
+    Augmentation adds ``<translation>`` children under ``<code>`` and never alters result
+    values or observation positions, so a finding that pre-existed in the original eICR has
+    an identical ``(error_id, location)`` in both validations and cancels out of the diff.
+    Pre-existing findings the augmenter does not own therefore do not block its output.
+
+    A clean augmented result cannot contain anything new, so the original is only
+    re-validated when the augmented eICR has findings to diff against. On a validation
+    exception the exception text is returned so the caller conservatively passes through.
+
+    :param original_eicr: The original (pre-augmentation) eICR XML string.
+    :param augmented_eicr: The augmented eICR XML string.
+    :return: A JSON-encoded list of the newly-introduced validation errors, the exception
+        text if validation raised, or ``None`` when augmentation introduced nothing.
+    """
+    try:
+        augmented_results = validate_eicr(augmented_eicr)
+        if not augmented_results:
+            return None
+        baseline_results = validate_eicr(original_eicr)
+        new_results = sorted(
+            set(augmented_results) - set(baseline_results),
+            key=lambda result: (result.error_id, result.location),
+        )
+    except Exception as e:
+        logger.exception(
+            "Augmentation validation failed; writing original eICR output",
+            status="passthrough",
+            passthrough_reason=PassthroughReason.AUGMENTATION_VALIDATION_FAILURE,
+        )
+        return str(e)
+
+    if new_results:
+        logger.warning(
+            "Augmentation introduced new validation errors; writing original eICR output",
+            status="passthrough",
+            passthrough_reason=PassthroughReason.AUGMENTATION_VALIDATION_FAILURE,
+            new_error_count=len(new_results),
+        )
+        return json.dumps([result.model_dump() for result in new_results])
+
+    logger.info(
+        "Augmented eICR has pre-existing validation findings not introduced by "
+        "augmentation; emitting augmented eICR",
+        status="success",
+        preexisting_error_count=len(augmented_results),
+    )
+    return None
+
+
 def _build_augmentation_output(
     persistence_id: str,
     original_eicr: str,
@@ -189,20 +241,7 @@ def _build_augmentation_output(
             passthrough_reason=PassthroughReason.AUGMENTATION_EXCEPTION,
         )
 
-    validation_error = None
-
-    try:
-        validation_results = validate_eicr(output.augmented_eicr)
-    except Exception as e:
-        logger.exception(
-            "Augmentation validation failed; writing original eICR output",
-            status="passthrough",
-            passthrough_reason=PassthroughReason.AUGMENTATION_VALIDATION_FAILURE,
-        )
-        validation_error = str(e)
-    else:
-        if validation_results:
-            validation_error = json.dumps([result.model_dump() for result in validation_results])
+    validation_error = _introduced_validation_error(original_eicr, output.augmented_eicr)
 
     if validation_error:
         return _build_original_eicr_output(

--- a/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
+++ b/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
@@ -17,6 +17,8 @@ AUGMENTED_EICR_PREFIX = os.environ["AUGMENTED_EICR_PREFIX"]
 AUGMENTATION_METADATA_PREFIX = os.environ["AUGMENTATION_METADATA_PREFIX"]
 TEST_PERSISTENCE_ID = os.environ["TEST_PERSISTENCE_ID"]
 SUCCESS_CODE = 200
+# The diff-based gate validates the augmented eICR, then the original as a baseline.
+EXPECTED_DIFF_VALIDATION_CALLS = 2
 EXPECTED_ORIGINAL_EICR_ID = "c8516bdc-8bb2-40aa-8dae-20a77546488f"
 EXPECTED_AUGMENTED_EICR_ID = "d44dc1c6-8a0c-5236-906e-12f6475589ec"
 
@@ -385,7 +387,7 @@ class TestHandler:
         assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.AUGMENTATION_VALIDATION_FAILURE
 
-    def test_handler_writes_original_eicr_when_augmented_eicr_fails_validation(
+    def test_handler_writes_original_eicr_when_augmentation_introduces_new_validation_error(
         self,
         example_sqs_event,
         mock_aws_setup,
@@ -396,16 +398,21 @@ class TestHandler:
             bucket_name=S3_BUCKET,
             object_key=f"TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
         )
-        validation_results = [
-            ValidationResult(
-                error_id="ttc-labResultValue-noCode",
-                location="/ClinicalDocument[1]",
-            )
-        ]
+        # A pre-existing result-value finding the augmenter does not own, and a new error
+        # only present after augmentation. Only the new one should block the output.
+        preexisting_error = ValidationResult(
+            error_id="ttc-labResultValue-PQNoInterp",
+            location="/ClinicalDocument[1]/component[1]/structuredBody[1]/component[6]",
+        )
+        new_error = ValidationResult(
+            error_id="ttc-labTestNameResulted-wrongCode",
+            location="/ClinicalDocument[1]/component[1]/structuredBody[1]/component[7]",
+        )
 
         validate_mock = mocker.patch(
             "augmentation_lambda.lambda_function.validate_eicr",
-            return_value=validation_results,
+            # First call validates the augmented eICR, second the original (baseline).
+            side_effect=[[new_error, preexisting_error], [preexisting_error]],
         )
 
         result = lambda_function.handler(example_sqs_event, mock_lambda_context)
@@ -413,7 +420,7 @@ class TestHandler:
         assert result["statusCode"] == SUCCESS_CODE
         assert result["message"] == "Augmentation processed successfully!"
         assert result["num_success_eicrs"] == 1
-        validate_mock.assert_called_once()
+        assert validate_mock.call_count == EXPECTED_DIFF_VALIDATION_CALLS
 
         augmented_eicr = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
@@ -429,11 +436,57 @@ class TestHandler:
 
         assert metadata["original_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
         assert metadata["augmented_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
-        assert metadata["error"] == json.dumps(
-            [result.model_dump() for result in validation_results]
-        )
+        # Only the newly-introduced error is recorded, not the pre-existing one.
+        assert metadata["error"] == json.dumps([new_error.model_dump()])
         assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.AUGMENTATION_VALIDATION_FAILURE
+
+    def test_handler_emits_augmented_eicr_when_validation_errors_are_preexisting(
+        self,
+        example_sqs_event,
+        mock_aws_setup,
+        mocker,
+        mock_lambda_context,
+    ) -> None:
+        original_eicr = lambda_handler.get_file_content_from_s3(
+            bucket_name=S3_BUCKET,
+            object_key=f"TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
+        )
+        # The same finding is present before and after augmentation: augmentation did not
+        # introduce it, so the augmented eICR must still be emitted (no passthrough).
+        preexisting_error = ValidationResult(
+            error_id="ttc-labResultValue-PQNoInterp",
+            location="/ClinicalDocument[1]/component[1]/structuredBody[1]/component[6]",
+        )
+
+        validate_mock = mocker.patch(
+            "augmentation_lambda.lambda_function.validate_eicr",
+            side_effect=[[preexisting_error], [preexisting_error]],
+        )
+
+        result = lambda_function.handler(example_sqs_event, mock_lambda_context)
+
+        assert result["statusCode"] == SUCCESS_CODE
+        assert result["message"] == "Augmentation processed successfully!"
+        assert result["num_success_eicrs"] == 1
+        assert validate_mock.call_count == EXPECTED_DIFF_VALIDATION_CALLS
+
+        augmented_eicr = lambda_handler.get_file_content_from_s3(
+            bucket_name=S3_BUCKET,
+            object_key=f"{AUGMENTED_EICR_PREFIX}{TEST_PERSISTENCE_ID}",
+        )
+        assert augmented_eicr != original_eicr
+
+        metadata_raw = lambda_handler.get_file_content_from_s3(
+            bucket_name=S3_BUCKET,
+            object_key=f"{AUGMENTATION_METADATA_PREFIX}{TEST_PERSISTENCE_ID}",
+        )
+        metadata = json.loads(metadata_raw)
+
+        assert metadata["augmented_eicr_id"] == EXPECTED_AUGMENTED_EICR_ID
+        assert metadata["error"] is None
+        assert metadata["passthrough"] is False
+        assert metadata["passthrough_reason"] is None
 
     def test_build_augmentation_output_uses_root_and_extension_for_passthrough_original_eicr_id(
         self, mocker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dibbs-text-to-code-root"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = [
   { name = "Brady Fausett", email = "bradyfausett@skylight.digital" },

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ requires-dist = [
 
 [[package]]
 name = "dibbs-text-to-code-root"
-version = "0.2.2"
+version = "0.2.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Problem

After augmenting an eICR, the augmentation lambda re-validated the result and treated **any** schematron finding as fatal, passing through the original (un-augmented) eICR. This blocked good augmentations whenever the input carried unrelated, pre-existing data-quality issues, most commonly lab **result values** that lack an interpretation code (`ttc-labResultValue-PQNoInterp` / `-STNoInterp`), which the augmenter never touches (it only adds lab-test-**name** `<translation>` elements).

In the latest APHL training rerun, persistence ID `2026/06/11/19d4812b…` was fully augmented (9 LOINC translations) but then discarded via `passthrough_reason: augmentation_validation_failure`, so RCKMS never received an augmented document. The blocking errors (28× `PQNoInterp`, 3× `STNoInterp`) were already present in the input eICR. Pre/post-anonymization validation both report an identical 48 result observations / 17 interpretation codes, so the gate would also block these in production, independent of anonymization.

## Fix

Switch to a **diff-based gate** (`_introduced_validation_error`): validate the original eICR as a baseline and pass through only when augmentation **introduces new** `(error_id, location)` findings. Pre-existing findings cancel out of the diff. A clean augmented result short-circuits the baseline call, so the common path still runs a single `validate_eicr`. Conservative passthrough on validation exceptions is preserved. The recorded `error` now lists only the newly-introduced findings.

## Testing

- `ruff` + `ty` clean.
- Unit (`augmentation-lambda`): updated the existing gate test to diff semantics and added `test_handler_emits_augmented_eicr_when_validation_errors_are_preexisting`.
- e2e: the `sample7` (`nullFlavorResultValues`) fixture correctly flips from passthrough to augmented; snapshots regenerated (`passthrough: true->false`, `error` cleared, translations added, only the pre-existing finding remains). The success-path assertion now checks "no new findings vs. original" rather than "zero findings".
- Reproduced on the real `19d4812b` eICR: old gate - passthrough (31 errors present); new gate emits the augmented eICR, augmentation fixing 8 `noCode` errors and introducing 0.

Bumps version to **v0.2.3** for release to APHL.