### PR TITLE
fix: removing passthrough from metadata and switching to passthrough_reason

### DIFF
--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_covid/eicr_covid_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_covid/eicr_covid_augmentation_metadata.json
@@ -18,6 +18,5 @@
     }
   ],
   "original_eicr_id": "10c13861-86a8-4a9a-aec6-b615921178df",
-  "passthrough": false,
   "passthrough_reason": null
 }

--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_empty/eicr_empty_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_empty/eicr_empty_augmentation_metadata.json
@@ -3,6 +3,5 @@
   "error": null,
   "nonstandard_codes": [],
   "original_eicr_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
-  "passthrough": true,
   "passthrough_reason": "no_relevant_schematron_errors"
 }

--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_test/eicr_test_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_test/eicr_test_augmentation_metadata.json
@@ -18,6 +18,5 @@
     }
   ],
   "original_eicr_id": "c8516bdc-8bb2-40aa-8dae-20a77546488f",
-  "passthrough": false,
   "passthrough_reason": null
 }

--- a/e2e/snapshots/test_e2e/test_upload_and_process/patient_alliance/patient_alliance_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/patient_alliance/patient_alliance_augmentation_metadata.json
@@ -3,6 +3,5 @@
   "error": "Unable to find tag in eICR document for XPath: /ClinicalDocument/setId",
   "nonstandard_codes": [],
   "original_eicr_id": "1.2.840.113619.21.1.139060385287897942.5.3^1899729054011780",
-  "passthrough": true,
   "passthrough_reason": "augmentation_exception"
 }

--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_augmentation_metadata.json
@@ -18,6 +18,5 @@
     }
   ],
   "original_eicr_id": "2.16.840.1.113883.3.432.0.16.1.100.779.2",
-  "passthrough": false,
   "passthrough_reason": null
 }

--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample9/sample9_augmentation_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample9/sample9_augmentation_metadata.json
@@ -3,6 +3,5 @@
   "error": null,
   "nonstandard_codes": [],
   "original_eicr_id": "1.2.840.114350.1.13.370.2.7.8.688883.608381234",
-  "passthrough": true,
   "passthrough_reason": "no_relevant_schematron_errors"
 }

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -524,7 +524,7 @@ class TestEndToEndSimulated:
 
         actual_validation_results = validate_eicr(augmented_eicr)
 
-        if augmentation_metadata.passthrough:
+        if augmentation_metadata.passthrough_reason is not None:
             original_eicr = self._read_s3_object(
                 aws,
                 f"{TTC_INPUT_PREFIX}{TEST_PERSISTENCE_ID}",
@@ -544,10 +544,8 @@ class TestEndToEndSimulated:
                 PassthroughReason.AUGMENTATION_EXCEPTION,
                 PassthroughReason.AUGMENTATION_VALIDATION_FAILURE,
             ]:
-                assert ttc_output.passthrough is True
                 assert ttc_output.passthrough_reason == passthrough_reason
         else:
-            assert augmentation_metadata.passthrough in [None, False]
             assert augmented_eicr != ""
 
             augmented_observations: list[etree._Element] = augmented_root.xpath(

--- a/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
+++ b/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
@@ -116,7 +116,7 @@ def _process_record(record: SQSRecord) -> None:
         _save_augmentation_outputs(persistence_id, output, bucket_name)
         logger.info(
             "Augmentation processing completed",
-            status="passthrough" if output.metadata.passthrough else "success",
+            status="passthrough" if output.metadata.passthrough_reason is not None else "success",
             passthrough_reason=output.metadata.passthrough_reason,
         )
 
@@ -205,7 +205,7 @@ def _build_augmentation_output(
         elif extension:
             original_eicr_id = extension
 
-    if augmenter_input.passthrough:
+    if augmenter_input.passthrough_reason is not None:
         return _build_original_eicr_output(
             persistence_id=persistence_id,
             original_eicr_id=original_eicr_id,
@@ -287,7 +287,6 @@ def _build_original_eicr_output(  # noqa: PLR0913
         augmented_eicr_id=original_eicr_id,
         nonstandard_codes=nonstandard_codes,
         error=error,
-        passthrough=True,
         passthrough_reason=passthrough_reason,
     )
 
@@ -382,7 +381,6 @@ def _save_augmentation_outputs(
         bucket_name=bucket_name,
         s3_key=augmented_eicr_key,
         status="success",
-        passthrough=output.metadata.passthrough,
         passthrough_reason=output.metadata.passthrough_reason,
     )
 
@@ -397,6 +395,5 @@ def _save_augmentation_outputs(
         bucket_name=bucket_name,
         s3_key=augmentation_metadata_key,
         status="success",
-        passthrough=output.metadata.passthrough,
         passthrough_reason=output.metadata.passthrough_reason,
     )

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_success/handler_writes_outputs_metadata.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_success/handler_writes_outputs_metadata.json
@@ -18,6 +18,5 @@
     }
   ],
   "original_eicr_id": "c8516bdc-8bb2-40aa-8dae-20a77546488f",
-  "passthrough": false,
   "passthrough_reason": null
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_augmentation_fails/augmentation_fails.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_augmentation_fails/augmentation_fails.json
@@ -3,6 +3,5 @@
   "error": "augmentation boom",
   "nonstandard_codes": [],
   "original_eicr_id": "c8516bdc-8bb2-40aa-8dae-20a77546488f",
-  "passthrough": true,
   "passthrough_reason": "augmentation_exception"
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_ttc_output_has_passthrough_reason/ttc_passthrough.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_ttc_output_has_passthrough_reason/ttc_passthrough.json
@@ -3,6 +3,5 @@
   "error": null,
   "nonstandard_codes": [],
   "original_eicr_id": "c8516bdc-8bb2-40aa-8dae-20a77546488f",
-  "passthrough": true,
-  "passthrough_reason": null
+  "passthrough_reason": "no_code_matches"
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_ttc_output_is_passthrough/ttc_passthrough.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_ttc_output_is_passthrough/ttc_passthrough.json
@@ -3,6 +3,5 @@
   "error": null,
   "nonstandard_codes": [],
   "original_eicr_id": "c8516bdc-8bb2-40aa-8dae-20a77546488f",
-  "passthrough": true,
   "passthrough_reason": "no_code_matches"
 }

--- a/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
+++ b/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
@@ -184,11 +184,6 @@ class TestHandler:
     def test_handler_writes_augmented_eicr_when_ttc_output_passthrough_reason_is_missing(
         self, example_sqs_event, mock_aws_setup, mock_lambda_context
     ) -> None:
-        original_eicr = lambda_handler.get_file_content_from_s3(
-            bucket_name=S3_BUCKET,
-            object_key=f"TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
-        )
-
         ttc_output = TTCAugmenterInput.model_validate(
             json.loads(
                 lambda_handler.get_file_content_from_s3(
@@ -221,7 +216,6 @@ class TestHandler:
             bucket_name=S3_BUCKET,
             object_key=f"{AUGMENTED_EICR_PREFIX}{TEST_PERSISTENCE_ID}",
         )
-        assert augmented_eicr != original_eicr
 
         metadata_raw = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
@@ -233,6 +227,9 @@ class TestHandler:
         assert metadata["augmented_eicr_id"] != metadata["original_eicr_id"]
         assert metadata["augmented_eicr_id"] != TEST_PERSISTENCE_ID
         assert metadata["passthrough_reason"] is None
+
+        actual_validation_results = validate_eicr(augmented_eicr)
+        assert actual_validation_results == []
 
     def test_handler_writes_original_eicr_when_augmentation_fails(
         self, example_sqs_event, mock_aws_setup, mocker, mock_lambda_context, snapshot

--- a/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
+++ b/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
@@ -113,7 +113,6 @@ class TestHandler:
         assert metadata["augmented_eicr_id"] == EXPECTED_AUGMENTED_EICR_ID
         assert metadata["augmented_eicr_id"] != metadata["original_eicr_id"]
         assert metadata["augmented_eicr_id"] != TEST_PERSISTENCE_ID
-        assert metadata["passthrough"] is False
         assert metadata["passthrough_reason"] is None
         snapshot.assert_match(
             _serialize_snapshot_value(metadata),
@@ -124,7 +123,7 @@ class TestHandler:
         actual_validation_results = validate_eicr(augmented_eicr)
         assert actual_validation_results == []  # Empty list means no errors.
 
-    def test_handler_writes_original_eicr_when_ttc_output_is_passthrough(
+    def test_handler_writes_original_eicr_when_ttc_output_has_passthrough_reason(
         self, example_sqs_event, mock_aws_setup, mocker, mock_lambda_context, snapshot
     ) -> None:
         original_eicr = lambda_handler.get_file_content_from_s3(
@@ -142,7 +141,6 @@ class TestHandler:
         ).model_copy(
             update={
                 "original_eicr_id": CdaInstanceIdentifier(root=EXPECTED_ORIGINAL_EICR_ID),
-                "passthrough": True,
                 "passthrough_reason": PassthroughReason.NO_CODE_MATCHES,
             }
         )
@@ -177,15 +175,14 @@ class TestHandler:
         assert metadata["augmented_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
         assert metadata["original_eicr_id"] != TEST_PERSISTENCE_ID
         assert metadata["augmented_eicr_id"] != TEST_PERSISTENCE_ID
-        assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.NO_CODE_MATCHES
         snapshot.assert_match(
             _serialize_snapshot_value(metadata),
             "ttc_passthrough.json",
         )
 
-    def test_handler_writes_original_eicr_when_ttc_output_passthrough_reason_is_missing(
-        self, example_sqs_event, mock_aws_setup, mocker, mock_lambda_context, snapshot
+    def test_handler_writes_augmented_eicr_when_ttc_output_passthrough_reason_is_missing(
+        self, example_sqs_event, mock_aws_setup, mock_lambda_context
     ) -> None:
         original_eicr = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
@@ -202,7 +199,6 @@ class TestHandler:
         ).model_copy(
             update={
                 "original_eicr_id": CdaInstanceIdentifier(root=EXPECTED_ORIGINAL_EICR_ID),
-                "passthrough": True,
                 "passthrough_reason": None,
             }
         )
@@ -215,20 +211,17 @@ class TestHandler:
             Body=json.dumps(ttc_output_json).encode("utf-8"),
         )
 
-        augmenter_mock = mocker.patch("augmentation_lambda.lambda_function.EICRAugmenter")
-
         result = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
         assert result["statusCode"] == SUCCESS_CODE
         assert result["message"] == "Augmentation processed successfully!"
         assert result["num_success_eicrs"] == 1
-        augmenter_mock.assert_not_called()
 
         augmented_eicr = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
             object_key=f"{AUGMENTED_EICR_PREFIX}{TEST_PERSISTENCE_ID}",
         )
-        assert augmented_eicr == original_eicr
+        assert augmented_eicr != original_eicr
 
         metadata_raw = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
@@ -236,15 +229,10 @@ class TestHandler:
         )
         metadata = json.loads(metadata_raw)
         assert metadata["original_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
-        assert metadata["augmented_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
-        assert metadata["original_eicr_id"] != TEST_PERSISTENCE_ID
+        assert metadata["augmented_eicr_id"] == EXPECTED_AUGMENTED_EICR_ID
+        assert metadata["augmented_eicr_id"] != metadata["original_eicr_id"]
         assert metadata["augmented_eicr_id"] != TEST_PERSISTENCE_ID
-        assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] is None
-        snapshot.assert_match(
-            _serialize_snapshot_value(metadata),
-            "passthrough_reason_missing.json",
-        )
 
     def test_handler_writes_original_eicr_when_augmentation_fails(
         self, example_sqs_event, mock_aws_setup, mocker, mock_lambda_context, snapshot
@@ -285,7 +273,6 @@ class TestHandler:
         assert metadata["original_eicr_id"] != TEST_PERSISTENCE_ID
         assert metadata["augmented_eicr_id"] != TEST_PERSISTENCE_ID
         assert metadata["error"] == "augmentation boom"
-        assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.AUGMENTATION_EXCEPTION
         snapshot.assert_match(
             _serialize_snapshot_value(metadata),
@@ -307,7 +294,6 @@ class TestHandler:
             )
         )
         ttc_output.pop("original_eicr_id", None)
-        ttc_output["passthrough"] = False
         ttc_output["passthrough_reason"] = None
 
         mock_aws_setup.put_object(
@@ -342,7 +328,6 @@ class TestHandler:
         assert metadata["original_eicr_id"] == TEST_PERSISTENCE_ID
         assert metadata["augmented_eicr_id"] == TEST_PERSISTENCE_ID
         assert metadata["error"] == "constructor boom"
-        assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.AUGMENTATION_EXCEPTION
 
     def test_handler_writes_original_eicr_when_augmented_eicr_validation_throws(
@@ -384,7 +369,6 @@ class TestHandler:
         assert metadata["original_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
         assert metadata["augmented_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
         assert metadata["error"] == "validation boom"
-        assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.AUGMENTATION_VALIDATION_FAILURE
 
     def test_handler_writes_original_eicr_when_augmentation_introduces_new_validation_error(
@@ -438,7 +422,6 @@ class TestHandler:
         assert metadata["augmented_eicr_id"] == EXPECTED_ORIGINAL_EICR_ID
         # Only the newly-introduced error is recorded, not the pre-existing one.
         assert metadata["error"] == json.dumps([new_error.model_dump()])
-        assert metadata["passthrough"] is True
         assert metadata["passthrough_reason"] == PassthroughReason.AUGMENTATION_VALIDATION_FAILURE
 
     def test_handler_emits_augmented_eicr_when_validation_errors_are_preexisting(
@@ -485,10 +468,9 @@ class TestHandler:
 
         assert metadata["augmented_eicr_id"] == EXPECTED_AUGMENTED_EICR_ID
         assert metadata["error"] is None
-        assert metadata["passthrough"] is False
         assert metadata["passthrough_reason"] is None
 
-    def test_build_augmentation_output_uses_root_and_extension_for_passthrough_original_eicr_id(
+    def test_build_augmentation_output_uses_root_and_extension_when_passthrough_reason_is_present(
         self, mocker
     ) -> None:
         augmenter_mock = mocker.patch("augmentation_lambda.lambda_function.EICRAugmenter")
@@ -501,7 +483,6 @@ class TestHandler:
                     root=EXPECTED_ORIGINAL_EICR_ID,
                     extension="extension-1",
                 ),
-                passthrough=True,
                 passthrough_reason=PassthroughReason.NO_CODE_MATCHES,
             ),
         )
@@ -511,10 +492,9 @@ class TestHandler:
         assert output.augmented_eicr == "<ClinicalDocument />"
         assert output.metadata.original_eicr_id == f"{EXPECTED_ORIGINAL_EICR_ID}^extension-1"
         assert output.metadata.augmented_eicr_id == f"{EXPECTED_ORIGINAL_EICR_ID}^extension-1"
-        assert output.metadata.passthrough is True
         assert output.metadata.passthrough_reason == PassthroughReason.NO_CODE_MATCHES
 
-    def test_build_augmentation_output_uses_extension_for_passthrough_original_eicr_id(
+    def test_build_augmentation_output_uses_extension_when_passthrough_reason_is_present(
         self, mocker
     ) -> None:
         augmenter_mock = mocker.patch("augmentation_lambda.lambda_function.EICRAugmenter")
@@ -524,7 +504,6 @@ class TestHandler:
             augmenter_input=TTCAugmenterInput(
                 persistence_id=TEST_PERSISTENCE_ID,
                 original_eicr_id=CdaInstanceIdentifier(extension="extension-only"),
-                passthrough=True,
                 passthrough_reason=PassthroughReason.NO_CODE_MATCHES,
             ),
         )
@@ -534,7 +513,6 @@ class TestHandler:
         assert output.augmented_eicr == "<ClinicalDocument />"
         assert output.metadata.original_eicr_id == "extension-only"
         assert output.metadata.augmented_eicr_id == "extension-only"
-        assert output.metadata.passthrough is True
         assert output.metadata.passthrough_reason == PassthroughReason.NO_CODE_MATCHES
 
     def test_build_original_eicr_output_sets_metadata_ids_to_original_eicr_id(self) -> None:
@@ -553,7 +531,6 @@ class TestHandler:
             "augmented_eicr_id": EXPECTED_ORIGINAL_EICR_ID,
             "nonstandard_codes": [],
             "error": None,
-            "passthrough": True,
             "passthrough_reason": PassthroughReason.NO_CODE_MATCHES.value,
         }
 

--- a/packages/augmentation/src/augmentation/models/application.py
+++ b/packages/augmentation/src/augmentation/models/application.py
@@ -37,7 +37,6 @@ class Metadata(FrozenBaseModel):
     nonstandard_codes: list[NonstandardCodeInstanceMetadata]
     """List of the nonstandard codes TTC attempted to resolve."""
     error: str | None = None
-    passthrough: bool = False
     passthrough_reason: PassthroughReason | None = None
 
 

--- a/packages/shared-models/src/shared_models/__init__.py
+++ b/packages/shared-models/src/shared_models/__init__.py
@@ -71,5 +71,4 @@ class TTCAugmenterInput(FrozenBaseModel):
     persistence_id: str
     original_eicr_id: CdaInstanceIdentifier | None = None
     nonstandard_codes: list[NonstandardCodeInstance] = []
-    passthrough: bool = False
     passthrough_reason: PassthroughReason | None = None

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -123,7 +123,6 @@ def _write_ttc_exception_passthrough_output(record: SQSRecord, error: Exception)
         persistence_id = lambda_handler.get_persistence_id(object_key, TTC_INPUT_PREFIX)
         ttc_metadata = Metadata(
             persistence_id=persistence_id,
-            passthrough=True,
             passthrough_reason=PassthroughReason.TTC_EXCEPTION,
             error=str(error),
             model_info=TTCModelInfo(
@@ -133,7 +132,6 @@ def _write_ttc_exception_passthrough_output(record: SQSRecord, error: Exception)
         )
         ttc_output = TTCAugmenterInput(
             persistence_id=persistence_id,
-            passthrough=True,
             passthrough_reason=PassthroughReason.TTC_EXCEPTION,
         )
 
@@ -443,14 +441,12 @@ def _process_record_pipeline(
         persistence_id=persistence_id,
         original_eicr_id=eicr_metadata.eicr_id,
         nonstandard_codes=nonstandard_code_replacements,
-        passthrough=passthrough_reason is not None,
         passthrough_reason=passthrough_reason,
     )
     ttc_metadata = Metadata(
         persistence_id=persistence_id,
         eicr_metadata=eicr_metadata,
         ttc_schematron_issues=ttc_schematron_issues_details,
-        passthrough=passthrough_reason is not None,
         passthrough_reason=passthrough_reason,
         model_info=TTCModelInfo(
             retriever=RETRIEVER_MODEL_INFO,

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/models/metadata.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/models/metadata.py
@@ -35,7 +35,6 @@ class Metadata(FrozenBaseModel):
     eicr_metadata: EICRMetadata | None = None
     ttc_schematron_issues: list[TTCSchematronIssueDetail] | None = None
     processed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    passthrough: bool | None = None
     passthrough_reason: PassthroughReason | None = None
     error: str | None = None
     model_info: TTCModelInfo | None = None

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/no_opensearch_hits_none_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/no_opensearch_hits_none_metadata_output.json
@@ -24,7 +24,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": true,
   "passthrough_reason": "no_code_matches",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/no_opensearch_hits_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_adds_unmatched_error_when_selected_candidate_has_no_opensearch_hits/no_opensearch_hits_ttc_output.json
@@ -7,7 +7,6 @@
     "null_flavor": null,
     "root": "c8516bdc-8bb2-40aa-8dae-20a77546488f"
   },
-  "passthrough": true,
   "passthrough_reason": "no_code_matches",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_continues_when_selected_candidate_is_none/continues_selected_candidate_none_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_continues_when_selected_candidate_is_none/continues_selected_candidate_none_metadata_output.json
@@ -24,7 +24,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": true,
   "passthrough_reason": "no_code_matches",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_continues_when_selected_candidate_is_none/continues_selected_candidate_none_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_continues_when_selected_candidate_is_none/continues_selected_candidate_none_ttc_output.json
@@ -7,7 +7,6 @@
     "null_flavor": null,
     "root": "c8516bdc-8bb2-40aa-8dae-20a77546488f"
   },
-  "passthrough": true,
   "passthrough_reason": "no_code_matches",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_malformed_eicr_with_no_schematron_issues/malformed_eicr_with_no_schematron_issues_ttc_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_malformed_eicr_with_no_schematron_issues/malformed_eicr_with_no_schematron_issues_ttc_metadata_output.json
@@ -18,7 +18,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": true,
   "passthrough_reason": "no_relevant_schematron_errors",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_malformed_eicr_with_no_schematron_issues/malformed_eicr_with_no_schematron_issues_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_malformed_eicr_with_no_schematron_issues/malformed_eicr_with_no_schematron_issues_ttc_output.json
@@ -1,7 +1,6 @@
 {
   "nonstandard_codes": [],
   "original_eicr_id": null,
-  "passthrough": true,
   "passthrough_reason": "no_relevant_schematron_errors",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_reranker_returns_empty/reranker_returns_empty_ttc_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_reranker_returns_empty/reranker_returns_empty_ttc_metadata_output.json
@@ -24,7 +24,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": true,
   "passthrough_reason": "no_code_matches",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_reranker_returns_empty/reranker_returns_empty_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_reranker_returns_empty/reranker_returns_empty_ttc_output.json
@@ -7,7 +7,6 @@
     "null_flavor": null,
     "root": "c8516bdc-8bb2-40aa-8dae-20a77546488f"
   },
-  "passthrough": true,
   "passthrough_reason": "no_code_matches",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_saves_metadata_when_no_relevant_schematron_fields/no_relevant_schematron_fields_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_saves_metadata_when_no_relevant_schematron_fields/no_relevant_schematron_fields_metadata_output.json
@@ -24,7 +24,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": true,
   "passthrough_reason": "no_relevant_schematron_errors",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_saves_metadata_when_no_relevant_schematron_fields/no_relevant_schematron_fields_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_saves_metadata_when_no_relevant_schematron_fields/no_relevant_schematron_fields_ttc_output.json
@@ -7,7 +7,6 @@
     "null_flavor": null,
     "root": "c8516bdc-8bb2-40aa-8dae-20a77546488f"
   },
-  "passthrough": true,
   "passthrough_reason": "no_relevant_schematron_errors",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_success/handler_success_ttc_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_success/handler_success_ttc_metadata_output.json
@@ -24,7 +24,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": false,
   "passthrough_reason": null,
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_success/handler_success_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_success/handler_success_ttc_output.json
@@ -21,7 +21,6 @@
     "null_flavor": null,
     "root": "c8516bdc-8bb2-40aa-8dae-20a77546488f"
   },
-  "passthrough": false,
   "passthrough_reason": null,
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_writes_ttc_exception_passthrough_output_when_record_exception_has_recoverable_persistence_id/record_exception_id_metadata_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_writes_ttc_exception_passthrough_output_when_record_exception_has_recoverable_persistence_id/record_exception_id_metadata_output.json
@@ -15,7 +15,6 @@
       "last_modified": "2026-03-30T14:12:37Z"
     }
   },
-  "passthrough": true,
   "passthrough_reason": "ttc_exception",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
   "processed_at": "2026-01-01T01:01:00Z",

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_writes_ttc_exception_passthrough_output_when_record_exception_has_recoverable_persistence_id/record_exception_id_ttc_output.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_writes_ttc_exception_passthrough_output_when_record_exception_has_recoverable_persistence_id/record_exception_id_ttc_output.json
@@ -1,7 +1,6 @@
 {
   "nonstandard_codes": [],
   "original_eicr_id": null,
-  "passthrough": true,
   "passthrough_reason": "ttc_exception",
   "persistence_id": "2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234"
 }


### PR DESCRIPTION
## Description

Removes `passthrough` from code and metadata output. `passthrough_reason` being not null as the method to determine whether the eICR is passthrough.

## Related Issues

Closes #628 

## Additional Notes

[Add any additional context or notes that reviewers should know about.]

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
