### PR TITLE
Release v0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dibbs-text-to-code-root"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = [
   { name = "Brady Fausett", email = "bradyfausett@skylight.digital" },

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ requires-dist = [
 
 [[package]]
 name = "dibbs-text-to-code-root"
-version = "0.2.3"
+version = "0.2.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bumps the root package version from `0.2.3` to `0.2.4`. Per `docs/releases.md`, merging to `main` triggers the release workflow to tag `v0.2.4`, build/publish the three Lambda images (`index`, `ttc`, `augmentation`) to GHCR and APHL ECR, and post the release to Slack.

## Changes since v0.2.3

- #652 — fix: removing passthrough from metadata and switching to `passthrough_reason`
- #654 — fix: Updating starlette to close vulnerability
- #619 — Add synchronous demo API and browser frontend for Text-to-Code
- #643 — build(deps): bump actions/checkout from 6.0.3 to 7.0.0