### PR TITLE
Release v0.2.5: fix Hugging Face Hub lookup crash on baked-in local model paths

### DIFF
--- a/packages/text-to-code/src/text_to_code/services/utils.py
+++ b/packages/text-to-code/src/text_to_code/services/utils.py
@@ -1,9 +1,14 @@
+import logging
+import os
+
 from huggingface_hub import errors, model_info
 
 from shared_models import DataField
 from text_to_code.models.labs import BaseLabField
 from text_to_code.models.model_info import ModelInfo
 from text_to_code.models.registry import EICR_REGISTRY
+
+logger = logging.getLogger(__name__)
 
 ConfigType = type[BaseLabField]
 
@@ -28,14 +33,34 @@ def get_config_for_data_field(data_field: DataField) -> BaseLabField:
 def get_model_info(model: str) -> ModelInfo:
     """Returns the model info for a given model.
 
-    :param model: The name of the model.
+    Models baked into the container image are referenced by a local filesystem
+    path (e.g. ``/opt/retriever_model``) rather than a Hugging Face repo id.
+    Such a path is not a valid repo id, and the Hub is unreachable from the
+    production VPC anyway, so for local paths we skip the Hub lookup and return
+    only the id. The remaining fields are populated from the Hub when the model
+    is a reachable repo id.
+
+    :param model: The Hugging Face repo id or local filesystem path of the model.
     :returns: The model info for the specified model.
     """
+    # Models baked into the image load from a local path, which is not a valid
+    # Hub repo id and cannot be looked up (the prod VPC has no internet access).
+    if os.path.isdir(model):
+        logger.info("Model '%s' is a local path; skipping Hugging Face Hub lookup.", model)
+        return ModelInfo(id=model, author=None, created_at=None, last_modified=None)
+
     try:
         full_info = model_info(model)
     # If the model doesn't exist or is inaccessible, model_info will return a 400 error
     except errors.RepositoryNotFoundError as e:
         raise ValueError(f"Model name '{model}' was not found") from e
+    # A value that is neither a local path nor a valid repo id must not crash
+    # module import; degrade gracefully to just the id.
+    except errors.HFValidationError:
+        logger.warning(
+            "Model '%s' is not a valid Hugging Face repo id; skipping Hub lookup.", model
+        )
+        return ModelInfo(id=model, author=None, created_at=None, last_modified=None)
 
     info = ModelInfo(
         id=full_info.id,

--- a/packages/text-to-code/tests/unit/test_utils.py
+++ b/packages/text-to-code/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from huggingface_hub import errors
 
 from shared_models import DataField
 from text_to_code.models import LabTestNameResulted
@@ -44,3 +45,31 @@ class TestGetModelInfo:
     def test_get_model_info_raises_for_nonexistent_model(self):
         with pytest.raises(Exception, match=r"Model name 'nonexistent-model' was not found"):
             get_model_info("nonexistent-model")
+
+    def test_get_model_info_skips_hub_lookup_for_local_path(self, tmp_path, mocker):
+        # Models baked into the container image are referenced by a local path
+        # (e.g. /opt/retriever_model), which is not a valid Hub repo id. This must
+        # not crash module import by hitting the Hub. Regression test for the prod
+        # outage where TTC_RETRIEVER=/opt/retriever_model raised HFValidationError.
+        spy = mocker.patch("text_to_code.services.utils.model_info")
+
+        info = get_model_info(str(tmp_path))
+
+        spy.assert_not_called()
+        assert info == ModelInfo(
+            id=str(tmp_path), author=None, created_at=None, last_modified=None
+        )
+
+    def test_get_model_info_degrades_for_invalid_repo_id(self, mocker):
+        # A value that is neither a local path nor a valid repo id should degrade
+        # to just the id rather than raise and crash startup.
+        mocker.patch(
+            "text_to_code.services.utils.model_info",
+            side_effect=errors.HFValidationError("bad repo id"),
+        )
+
+        info = get_model_info("/opt/retriever_model")
+
+        assert info == ModelInfo(
+            id="/opt/retriever_model", author=None, created_at=None, last_modified=None
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dibbs-text-to-code-root"
-version = "0.2.4"
+version = "0.2.5"
 description = ""
 authors = [
   { name = "Brady Fausett", email = "bradyfausett@skylight.digital" },

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ requires-dist = [
 
 [[package]]
 name = "dibbs-text-to-code-root"
-version = "0.2.4"
+version = "0.2.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Description

Hotfix for the production outage reported by APHL on 0.2.4: every eICR submitted to the TTC Lambda failed and went to the DLQ.

### Root cause

`get_model_info()` (added in #627) calls `huggingface_hub.model_info()` at **module import time** in `embedder.py` and `reranker.py`. In production the retriever/reranker models are baked into the container image and referenced by a **local filesystem path** (`RETRIEVER_MODEL_PATH=/opt/retriever_model`), which is not a valid Hub repo id. `model_info()` raised:

```
HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/opt/retriever_model'.
```

This crashed the Lambda during import — before any message could be processed — so all messages went to the DLQ.

Two compounding problems:
1. A local path is not a valid Hub repo id, so validation fails.
2. The lookup hits the Hub over the internet, but the production VPC has **no internet route** — so the call could never succeed in prod regardless of the value.

The `Loading weights: 100%` line in the prod logs confirms the model itself loaded fine from disk; only the metadata lookup crashed.

### Fix

`get_model_info()` now:
- Skips the Hub lookup for local directory paths and returns just the `id` (no network call).
- Degrades gracefully on `HFValidationError` instead of crashing import.
- Still raises on `RepositoryNotFoundError` (unchanged behavior).

`ModelInfo` fields are all `Optional` and the Lambda already treats `model_info` as optional, so metadata simply omits the Hub timestamps for baked-in models (which it could not fetch in the prod VPC anyway).

### Why CI didn't catch it

In tests, `RETRIEVER_MODEL_PATH` is unset, so `TTC_RETRIEVER` falls back to the `NCHS/ttc-retriever-mvp` repo id — a valid id — and the lookup succeeds. The failure only manifests with a local model path, i.e. exclusively in the deployed container.

## Changes

- `get_model_info()`: short-circuit local paths; catch `HFValidationError`.
- Two regression tests: local-path skips the Hub lookup; invalid repo id degrades instead of raising.
- Version bump `0.2.4` → `0.2.5` (root `pyproject.toml` + `uv.lock`) to cut the hotfix release.

## Testing

- `packages/text-to-code` unit suite: 81 passed.
- `just ruff`: clean. `just ty`: no new diagnostics (2 pre-existing `fastapi` errors in `local_server.py` are unrelated).
- Direct repro: `get_model_info('/opt')` now returns degraded info instead of raising.