### PR TITLE
Updating e2e snapshot tests to use approximates

### DIFF
--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_covid/eicr_covid_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_covid/eicr_covid_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.5339932441711426
+          "score": 0.5339929461479187
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.48232781887054443
+          "score": 0.48232677578926086
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.3767828047275543
+          "score": 0.3767831325531006
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_covid/eicr_covid_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_covid/eicr_covid_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.5339929461479187
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.48232677578926086
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.3767831325531006
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_test/eicr_test_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_test/eicr_test_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.7127655744552612
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.5247519016265869
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.35545843839645386
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/eicr_test/eicr_test_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/eicr_test/eicr_test_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.7127660512924194
+          "score": 0.7127655744552612
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.5247527956962585
+          "score": 0.5247519016265869
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.35545873641967773
+          "score": 0.35545843839645386
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/patient_alliance/patient_alliance_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/patient_alliance/patient_alliance_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.9280856847763062
+          "score": 0.9280852675437927
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.7176281213760376
+          "score": 0.7176284790039062
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.4391096830368042
+          "score": 0.43911027908325195
         }
       ],
       "unmatched_reason": null
@@ -193,15 +193,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.8556041121482849
+          "score": 0.8556044697761536
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.8011030554771423
+          "score": 0.8011022210121155
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.41517966985702515
+          "score": 0.4151797890663147
         }
       ],
       "unmatched_reason": null
@@ -282,15 +282,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.8958897590637207
+          "score": 0.8958885669708252
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.7696039080619812
+          "score": 0.769603967666626
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.46864479780197144
+          "score": 0.4686448574066162
         }
       ],
       "unmatched_reason": null
@@ -371,11 +371,11 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.9189866781234741
+          "score": 0.9189857840538025
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.7184052467346191
+          "score": 0.7184037566184998
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
@@ -464,11 +464,11 @@
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.6544067859649658
+          "score": 0.6544061303138733
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.4040239453315735
+          "score": 0.40402400493621826
         }
       ],
       "unmatched_reason": null
@@ -549,15 +549,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.8650304079055786
+          "score": 0.8650293350219727
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.6328892707824707
+          "score": 0.6328886151313782
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.379848450422287
+          "score": 0.37984851002693176
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/patient_alliance/patient_alliance_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/patient_alliance/patient_alliance_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.9280852675437927
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.7176284790039062
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.43911027908325195
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null
@@ -193,15 +193,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.8556044697761536
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.8011022210121155
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.4151797890663147
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null
@@ -282,15 +282,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.8958885669708252
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.769603967666626
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.4686448574066162
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null
@@ -371,15 +371,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.9189857840538025
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.7184037566184998
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.4288814067840576
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null
@@ -460,15 +460,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.9232457280158997
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.6544061303138733
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.40402400493621826
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null
@@ -549,15 +549,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.8650293350219727
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.6328886151313782
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.37984851002693176
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.6874608993530273
+          "score": 0.7127664685249329
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.6614065766334534
+          "score": 0.5247528553009033
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.3470494747161865
+          "score": 0.35545864701271057
         }
       ],
       "unmatched_reason": null

--- a/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_ttc_metadata.json
+++ b/e2e/snapshots/test_e2e/test_upload_and_process/sample7/sample7_ttc_metadata.json
@@ -104,15 +104,15 @@
       "reranker_processed_results": [
         {
           "code_string": "Weed Allerg Mix3 IgE Qn",
-          "score": 0.6874630451202393
+          "score": 0.6874608993530273
         },
         {
           "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-          "score": 0.6614049077033997
+          "score": 0.6614065766334534
         },
         {
           "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-          "score": 0.3470492959022522
+          "score": 0.3470494747161865
         }
       ],
       "unmatched_reason": null

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -14,7 +14,8 @@ from pytest_snapshot.plugin import Snapshot
 from augmentation.models import Metadata as AugmentationMetadata
 from augmentation_lambda.lambda_function import handler as augmentation_lambda
 from shared_models import PassthroughReason, TTCAugmenterInput
-from text_to_code_lambda.lambda_function import handler as ttc_handler
+from text_to_code.services.reranker import ScoredResult
+from text_to_code_lambda import lambda_function
 from text_to_code_lambda.models.metadata import Metadata as TTCMetadata
 from validation import validate_eicr
 
@@ -315,6 +316,26 @@ def _assert_augmented_eicr_retains_original_content(
     )
 
 
+def _mock_ttc_rerank(mocker) -> None:
+    ranked_results: list[ScoredResult] = [
+        {"code_string": "Weed Allerg Mix3 IgE Qn", "score": 0.7127664685249329},
+        {
+            "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
+            "score": 0.5247528553009033,
+        },
+        {
+            "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
+            "score": 0.35545864701271057,
+        },
+    ]
+
+    mocker.patch.object(
+        lambda_function,
+        "rerank",
+        return_value=ranked_results,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -465,7 +486,7 @@ class TestEndToEndSimulated:
         with time_machine.travel(
             datetime(2026, 2, 13, 15, 27, 0, tzinfo=ZoneInfo("America/New_York")), tick=False
         ):
-            _ = ttc_handler(sqs_event, mock_lambda_context)
+            _ = lambda_function.handler(sqs_event, mock_lambda_context)
 
             q2 = _drain_sqs_for_prefix(aws["sqs"], infra["queue2_url"], TTC_OUTPUT_PREFIX)
 
@@ -497,7 +518,10 @@ class TestEndToEndSimulated:
         snapshot: Snapshot,
         mock_opensearch,
         mock_lambda_context,
+        mocker,
     ):
+        _mock_ttc_rerank(mocker)
+
         self._run_eicr_pipeline(
             aws,
             infra,
@@ -620,7 +644,10 @@ class TestNamespacePreservation:
         infra,
         mock_opensearch,
         mock_lambda_context,
+        mocker,
     ):
+        _mock_ttc_rerank(mocker)
+
         with open(NAMESPACE_PRESERVATION_SCHEMATRON_PATH, "rb") as schematron_file:
             aws["s3"].upload_fileobj(
                 schematron_file,
@@ -641,7 +668,7 @@ class TestNamespacePreservation:
             )
 
         q1 = _drain_sqs_for_prefix(aws["sqs"], infra["queue1_url"], TTC_INPUT_PREFIX)
-        ttc_handler(
+        lambda_function.handler(
             _build_sqs_event([json.loads(q1[0]["Body"])], QUEUE_1_NAME), mock_lambda_context
         )
 

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -315,37 +315,6 @@ def _assert_augmented_eicr_retains_original_content(
     )
 
 
-def _read_ttc_metadata_snapshot(eicr_id: str) -> object:
-    snapshot_path = (
-        BASE_FOLDER
-        / "snapshots"
-        / "test_e2e"
-        / "test_upload_and_process"
-        / eicr_id
-        / f"{eicr_id}_ttc_metadata.json"
-    )
-    return json.loads(snapshot_path.read_text(encoding="utf-8"))
-
-
-def _is_json_number(value: object) -> bool:
-    return isinstance(value, int | float) and not isinstance(value, bool)
-
-
-def _approximate_ttc_metadata_score_values(value: object) -> object:
-    if isinstance(value, dict):
-        return {
-            str(key): pytest.approx(child_value, abs=0.0001, rel=0)
-            if key == "score" and _is_json_number(child_value)
-            else _approximate_ttc_metadata_score_values(child_value)
-            for key, child_value in value.items()
-        }
-
-    if isinstance(value, list):
-        return [_approximate_ttc_metadata_score_values(item) for item in value]
-
-    return value
-
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -557,8 +526,9 @@ class TestEndToEndSimulated:
         ttc_metadata = TTCMetadata.model_validate_json(
             self._read_s3_object(aws, f"{TTC_METADATA_PREFIX}{TEST_PERSISTENCE_ID}.json")
         )
-        assert ttc_metadata.model_dump(mode="json") == _approximate_ttc_metadata_score_values(
-            _read_ttc_metadata_snapshot(eicr_id)
+        snapshot.assert_match(
+            json.dumps(ttc_metadata.model_dump(mode="json"), indent=2, sort_keys=True),
+            f"{eicr_id}_ttc_metadata.json",
         )
 
         augmentation_metadata = AugmentationMetadata.model_validate_json(

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -315,6 +315,37 @@ def _assert_augmented_eicr_retains_original_content(
     )
 
 
+def _read_ttc_metadata_snapshot(eicr_id: str) -> object:
+    snapshot_path = (
+        BASE_FOLDER
+        / "snapshots"
+        / "test_e2e"
+        / "test_upload_and_process"
+        / eicr_id
+        / f"{eicr_id}_ttc_metadata.json"
+    )
+    return json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+
+def _is_json_number(value: object) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _approximate_ttc_metadata_score_values(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            str(key): pytest.approx(child_value, abs=0.0001, rel=0)
+            if key == "score" and _is_json_number(child_value)
+            else _approximate_ttc_metadata_score_values(child_value)
+            for key, child_value in value.items()
+        }
+
+    if isinstance(value, list):
+        return [_approximate_ttc_metadata_score_values(item) for item in value]
+
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -526,9 +557,8 @@ class TestEndToEndSimulated:
         ttc_metadata = TTCMetadata.model_validate_json(
             self._read_s3_object(aws, f"{TTC_METADATA_PREFIX}{TEST_PERSISTENCE_ID}.json")
         )
-        snapshot.assert_match(
-            json.dumps(ttc_metadata.model_dump(mode="json"), indent=2, sort_keys=True),
-            f"{eicr_id}_ttc_metadata.json",
+        assert ttc_metadata.model_dump(mode="json") == _approximate_ttc_metadata_score_values(
+            _read_ttc_metadata_snapshot(eicr_id)
         )
 
         augmentation_metadata = AugmentationMetadata.model_validate_json(

--- a/packages/lambda-handler/tests/conftest.py
+++ b/packages/lambda-handler/tests/conftest.py
@@ -6,9 +6,11 @@ from collections.abc import Iterator
 import boto3
 import moto
 import pytest
+import pytest_mock
 from botocore.client import BaseClient
 
 from lambda_handler import reset_cached_clients
+from text_to_code.services.reranker import ScoredResult
 
 
 @pytest.fixture(scope="function")
@@ -39,6 +41,30 @@ def mock_aws_setup(
         yield s3
 
     reset_cached_clients()
+
+
+@pytest.fixture(autouse=True)
+def mock_rerank(mocker: pytest_mock.MockerFixture) -> None:
+    """Mock the rerank function to return a fixed set of results for testing.
+
+    :param mocker: Pytest mocker fixture
+    """
+    ranked_results: list[ScoredResult] = [
+        {"code_string": "Weed Allerg Mix3 IgE Qn", "score": 0.7127664685249329},
+        {
+            "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
+            "score": 0.5247528553009033,
+        },
+        {
+            "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
+            "score": 0.35545864701271057,
+        },
+    ]
+
+    mocker.patch(
+        "text_to_code_lambda.lambda_function.rerank",
+        return_value=ranked_results,
+    )
 
 
 @pytest.fixture

--- a/packages/lambda-handler/tests/conftest.py
+++ b/packages/lambda-handler/tests/conftest.py
@@ -6,11 +6,9 @@ from collections.abc import Iterator
 import boto3
 import moto
 import pytest
-import pytest_mock
 from botocore.client import BaseClient
 
 from lambda_handler import reset_cached_clients
-from text_to_code.services.reranker import ScoredResult
 
 
 @pytest.fixture(scope="function")
@@ -41,30 +39,6 @@ def mock_aws_setup(
         yield s3
 
     reset_cached_clients()
-
-
-@pytest.fixture(autouse=True)
-def mock_rerank(mocker: pytest_mock.MockerFixture) -> None:
-    """Mock the rerank function to return a fixed set of results for testing.
-
-    :param mocker: Pytest mocker fixture
-    """
-    ranked_results: list[ScoredResult] = [
-        {"code_string": "Weed Allerg Mix3 IgE Qn", "score": 0.7127664685249329},
-        {
-            "code_string": "(Artemisia vulgaris+Chenopodium album+Plantago lanceolata+Solidago virgaurea+Urtica dioica) Ab.IgE:PrThr:Pt:Ser:Ord:Multidisk",
-            "score": 0.5247528553009033,
-        },
-        {
-            "code_string": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-            "score": 0.35545864701271057,
-        },
-    ]
-
-    mocker.patch(
-        "text_to_code_lambda.lambda_function.rerank",
-        return_value=ranked_results,
-    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

It's been a minor blocker on some PRs to square the .000001 differences between snapshots that can arise on github actions. This should resolve it.

## Related Issues

## Additional Notes

[Add any additional context or notes that reviewers should know about.]

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
