### PR TITLE
fix: Adding code to regenerate validation test files

### DIFF
--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -15,3 +15,8 @@ all *ARGS:
 [doc("Run tests with coverage, specifying the package to measure coverage for")]
 coverage *ARGS:
     uv run pytest {{ ARGS }} --cov={{ARGS}} --cov-report=term-missing
+
+[doc("Regenerate validation temp files and run validation tests")]
+validation:
+    uv run python -c "from pathlib import Path; output = Path('validation/src/validation/eicr-validator/output'); [file.unlink(missing_ok=True) for file in (output / 'stage1.sch.tmp', output / 'stage2.sch.tmp', output / 'validator.xsl.tmp', output / 'voc_ttc.xml')]"
+    uv run pytest packages/validation

--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -18,5 +18,5 @@ coverage *ARGS:
 
 [doc("Regenerate validation temp files and run validation tests")]
 validation:
-    uv run python -c "from pathlib import Path; output = Path('validation/src/validation/eicr-validator/output'); [file.unlink(missing_ok=True) for file in (output / 'stage1.sch.tmp', output / 'stage2.sch.tmp', output / 'validator.xsl.tmp', output / 'voc_ttc.xml')]"
+    uv run python -c "from pathlib import Path; output = Path('packages/validation/src/validation/eicr-validator/output'); [file.unlink(missing_ok=True) for file in (output / 'stage1.sch.tmp', output / 'stage2.sch.tmp', output / 'validator.xsl.tmp', output / 'voc_ttc.xml')]"
     uv run pytest packages/validation

--- a/README.md
+++ b/README.md
@@ -56,18 +56,18 @@ Given TTC results, the augmenter:
 
 This is a **uv workspace** (Python). All Python packages live under `packages/`.
 
-| Package                                                | Role                                                                                                 |
-| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| [`shared-models`](packages/shared-models/)             | Pydantic models shared across packages: `DataField`, `TTCAugmentation`, `TTCAugmenterInput`          |
-| [`text-to-code`](packages/text-to-code/)               | Core TTC logic: XML parsing, candidate evaluation, embedding, and OpenSearch query building          |
-| [`augmentation`](packages/augmentation/)               | Writes TTC results back into eICR XML as `<translation>` elements                                    |
-| [`text-to-code-lambda`](packages/text-to-code-lambda/) | AWS Lambda handler for the TTC workflow (S3 → SQS triggered); also exposes the synchronous demo API   |
-| [`augmentation-lambda`](packages/augmentation-lambda/) | AWS Lambda handler for the augmentation workflow, triggered by SQS events                            |
-| [`index-lambda`](packages/index-lambda/)               | AWS Lambda that bootstraps the OpenSearch KNN index (1024-dim HNSW/faiss/cosine) at deploy time      |
-| [`lambda-handler`](packages/lambda-handler/)           | Shared Lambda runtime utilities (S3/OpenSearch clients, event parsing) used by the Lambda packages   |
-| [`utils`](packages/utils/)                             | Path, regex, and LOINC name parsing utilities                                                        |
-| [`data-curation`](packages/data-curation/)             | Scripts for pulling terminology data from LOINC, SNOMED, UMLS, and HL7 APIs; generates training data |
-| [`validation`](packages/validation/)                   | Functionality to validate an eICR and to create Schematron output                                    |
+| Package                                                | Role                                                                                                       |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| [`shared-models`](packages/shared-models/)             | Pydantic models shared across packages: `DataField`, `TTCAugmentation`, `TTCAugmenterInput`                |
+| [`text-to-code`](packages/text-to-code/)               | Core TTC logic: XML parsing, candidate evaluation, embedding, and OpenSearch query building                |
+| [`augmentation`](packages/augmentation/)               | Writes TTC results back into eICR XML as `<translation>` elements                                          |
+| [`text-to-code-lambda`](packages/text-to-code-lambda/) | AWS Lambda handler for the TTC workflow (S3 → SQS triggered); also exposes the synchronous demo API        |
+| [`augmentation-lambda`](packages/augmentation-lambda/) | AWS Lambda handler for the augmentation workflow, triggered by SQS events                                  |
+| [`index-lambda`](packages/index-lambda/)               | AWS Lambda that bootstraps the OpenSearch KNN index (1024-dim HNSW/faiss/cosine) at deploy time            |
+| [`lambda-handler`](packages/lambda-handler/)           | Shared Lambda runtime utilities (S3/OpenSearch clients, event parsing) used by the Lambda packages         |
+| [`utils`](packages/utils/)                             | Path, regex, and LOINC name parsing utilities                                                              |
+| [`data-curation`](packages/data-curation/)             | Scripts for pulling terminology data from LOINC, SNOMED, UMLS, and HL7 APIs; generates training data       |
+| [`validation`](packages/validation/)                   | Functionality to validate an eICR and to create Schematron output                                          |
 | [`frontend`](frontend/)                                | Static HTML/CSS/JS demo page for the synchronous text-to-code API (run with [`demo.sh`](frontend/demo.sh)) |
 
 ### Architecture Diagram
@@ -201,6 +201,14 @@ just test e2e
 ```
 
 e2e test use [boto3](https://github.com/boto/boto3) to mock the various AWS systems we use: S3, SQS, and Lambdas. However, it currently does not simulate EventBridge invoking the Lambdas and passing them the SQS event, instead SQS event is manually built and passed to the lambda handler function.
+
+## Validation test:
+
+To ensure the latest schematron updates are being used when running `packages/validation` locally, use the following command:
+
+```sh
+just test validation
+```
 
 ### Type checks
 

--- a/packages/validation/src/validation/main.py
+++ b/packages/validation/src/validation/main.py
@@ -73,6 +73,21 @@ def _normalize_whitespace(value: str | None) -> str:
     return " ".join(value.split()) if value else ""
 
 
+def _needs_regeneration(output_file: Path, source_files: tuple[Path, ...]) -> bool:
+    """Determine whether a generated validation file is missing or stale.
+
+    :param output_file: The generated validation file to check.
+    :param source_files: The source files used to generate the output file.
+    :return: True when the generated file should be regenerated.
+    """
+    if not output_file.exists():
+        return True
+
+    output_modified_time = output_file.stat().st_mtime
+
+    return any(source_file.stat().st_mtime > output_modified_time for source_file in source_files)
+
+
 def _run_validator(eicr: str | None, redo_all_steps: bool = False) -> list[_RawAssert]:
     """Compile the schematron and run it against the eICR, returning failed asserts.
 
@@ -100,7 +115,7 @@ def _run_validator(eicr: str | None, redo_all_steps: bool = False) -> list[_RawA
             else:
                 logger.info("Will use existing files for Step 1-3")
 
-            if not STAGE1_OUTPUT.exists():
+            if _needs_regeneration(STAGE1_OUTPUT, (APHL_SCHEMATRON, XSLT_INCLUDE)):
                 # Step 1: Process includes
                 # Note: For schxslt, you typically apply the XSLT to the SCH file as the source
                 logger.info("--- Step 1: Process Includes against Schematron File")
@@ -110,7 +125,7 @@ def _run_validator(eicr: str | None, redo_all_steps: bool = False) -> list[_RawA
                     output_file=str(STAGE1_OUTPUT),
                 )
 
-            if not STAGE2_OUTPUT.exists():
+            if _needs_regeneration(STAGE2_OUTPUT, (STAGE1_OUTPUT, XSLT_EXPAND)):
                 # Step 2: Expand abstract rules
                 logger.info("--- Step 2: Expand abstract rules using output from Step 1")
                 xsltproc.transform_to_file(
@@ -119,7 +134,7 @@ def _run_validator(eicr: str | None, redo_all_steps: bool = False) -> list[_RawA
                     output_file=str(STAGE2_OUTPUT),
                 )
 
-            if not VALIDATOR_OUTPUT.exists():
+            if _needs_regeneration(VALIDATOR_OUTPUT, (STAGE2_OUTPUT, XSLT_COMPILE)):
                 # Step 3: Compile to an SVRL-producing XSLT stylesheet
                 logger.info(
                     "--- Step 3: Compile to an SVRL-producing XSLT stylesheet using the output from Step 2"
@@ -134,7 +149,7 @@ def _run_validator(eicr: str | None, redo_all_steps: bool = False) -> list[_RawA
             # Guarded like the stage artifacts above: on Lambda the package dir is read-only
             # and this file is baked into the image at build time (Dockerfile.augmentation),
             # so an unconditional copy would crash with OSError [Errno 30] on every invocation.
-            if not VOC_OUTPUT.exists():
+            if _needs_regeneration(VOC_OUTPUT, (VOC_SOURCE,)):
                 shutil.copy2(VOC_SOURCE, VOC_OUTPUT)
 
             # Step 4: Apply the generated XSLT to the source XML

--- a/packages/validation/tests/test_validation.py
+++ b/packages/validation/tests/test_validation.py
@@ -265,52 +265,34 @@ def test_validation_regenerates_stale_generated_files(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     """Tests that stale generated validation files are regenerated when source files are newer."""
-    stage1_output = tmp_path / "stage1.sch.tmp"
-    stage2_output = tmp_path / "stage2.sch.tmp"
-    validator_output = tmp_path / "validator.xsl.tmp"
-    voc_output = tmp_path / "voc_ttc.xml"
-
-    aphl_schematron = tmp_path / "schema.sch"
-    xslt_include = tmp_path / "include.xsl"
-    xslt_expand = tmp_path / "expand.xsl"
-    xslt_compile = tmp_path / "compile.xsl"
-    voc_source = tmp_path / "source_voc_ttc.xml"
-
-    stage1_output.write_text("old stage 1")
-    stage2_output.write_text("old stage 2")
-    validator_output.write_text("old validator")
-    voc_output.write_text("old voc")
-
-    aphl_schematron.write_text("<schema />")
-    xslt_include.write_text("<include />")
-    xslt_expand.write_text("<expand />")
-    xslt_compile.write_text("<compile />")
-    voc_source.write_text("<voc />")
+    outputs = {
+        "STAGE1_OUTPUT": tmp_path / "stage1.sch.tmp",
+        "STAGE2_OUTPUT": tmp_path / "stage2.sch.tmp",
+        "VALIDATOR_OUTPUT": tmp_path / "validator.xsl.tmp",
+        "VOC_OUTPUT": tmp_path / "voc_ttc.xml",
+    }
+    sources = {
+        "APHL_SCHEMATRON": tmp_path / "schema.sch",
+        "XSLT_INCLUDE": tmp_path / "include.xsl",
+        "XSLT_EXPAND": tmp_path / "expand.xsl",
+        "XSLT_COMPILE": tmp_path / "compile.xsl",
+        "VOC_SOURCE": tmp_path / "source_voc_ttc.xml",
+    }
 
     old_time = 1_000_000_000
     new_time = 1_000_000_100
 
-    for output_file in (stage1_output, stage2_output, validator_output, voc_output):
-        output_file.touch()
-        output_file.chmod(0o644)
-        output_file.write_text(output_file.read_text())
-        output_file.stat()
-        output_file.touch()
-
+    for output_file in outputs.values():
+        output_file.write_text("old generated file")
         os.utime(output_file, (old_time, old_time))
 
-    for source_file in (aphl_schematron, xslt_include, xslt_expand, xslt_compile, voc_source):
+    for source_file in sources.values():
+        source_file.write_text("<source />")
         os.utime(source_file, (new_time, new_time))
 
-    monkeypatch.setattr(validation_main, "STAGE1_OUTPUT", stage1_output)
-    monkeypatch.setattr(validation_main, "STAGE2_OUTPUT", stage2_output)
-    monkeypatch.setattr(validation_main, "VALIDATOR_OUTPUT", validator_output)
-    monkeypatch.setattr(validation_main, "VOC_OUTPUT", voc_output)
-    monkeypatch.setattr(validation_main, "APHL_SCHEMATRON", aphl_schematron)
-    monkeypatch.setattr(validation_main, "XSLT_INCLUDE", xslt_include)
-    monkeypatch.setattr(validation_main, "XSLT_EXPAND", xslt_expand)
-    monkeypatch.setattr(validation_main, "XSLT_COMPILE", xslt_compile)
-    monkeypatch.setattr(validation_main, "VOC_SOURCE", voc_source)
+    for attribute, file_path in [*outputs.items(), *sources.items()]:
+        monkeypatch.setattr(validation_main, attribute, file_path)
+
     monkeypatch.setattr(validation_main, "PySaxonProcessor", FakeSaxonProcessor)
 
     results = validate_eicr("<ClinicalDocument />")
@@ -321,7 +303,7 @@ def test_validation_regenerates_stale_generated_files(
             location=FAKE_LOCATION,
         )
     ]
-    assert stage1_output.read_text() == "<generated />"
-    assert stage2_output.read_text() == "<generated />"
-    assert validator_output.read_text() == "<generated />"
-    assert voc_output.read_text() == "<voc />"
+    assert outputs["STAGE1_OUTPUT"].read_text() == "<generated />"
+    assert outputs["STAGE2_OUTPUT"].read_text() == "<generated />"
+    assert outputs["VALIDATOR_OUTPUT"].read_text() == "<generated />"
+    assert outputs["VOC_OUTPUT"].read_text() == "<source />"

--- a/packages/validation/tests/test_validation.py
+++ b/packages/validation/tests/test_validation.py
@@ -1,3 +1,4 @@
+import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -258,3 +259,69 @@ def test_build_schematron_report_xml_normalizes_real_location():
     assert context is not None
     assert context.startswith("/ClinicalDocument[1]/")
     assert context.endswith("/observation[1]")
+
+
+def test_validation_regenerates_stale_generated_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Tests that stale generated validation files are regenerated when source files are newer."""
+    stage1_output = tmp_path / "stage1.sch.tmp"
+    stage2_output = tmp_path / "stage2.sch.tmp"
+    validator_output = tmp_path / "validator.xsl.tmp"
+    voc_output = tmp_path / "voc_ttc.xml"
+
+    aphl_schematron = tmp_path / "schema.sch"
+    xslt_include = tmp_path / "include.xsl"
+    xslt_expand = tmp_path / "expand.xsl"
+    xslt_compile = tmp_path / "compile.xsl"
+    voc_source = tmp_path / "source_voc_ttc.xml"
+
+    stage1_output.write_text("old stage 1")
+    stage2_output.write_text("old stage 2")
+    validator_output.write_text("old validator")
+    voc_output.write_text("old voc")
+
+    aphl_schematron.write_text("<schema />")
+    xslt_include.write_text("<include />")
+    xslt_expand.write_text("<expand />")
+    xslt_compile.write_text("<compile />")
+    voc_source.write_text("<voc />")
+
+    old_time = 1_000_000_000
+    new_time = 1_000_000_100
+
+    for output_file in (stage1_output, stage2_output, validator_output, voc_output):
+        output_file.touch()
+        output_file.chmod(0o644)
+        output_file.write_text(output_file.read_text())
+        output_file.stat()
+        output_file.touch()
+
+        os.utime(output_file, (old_time, old_time))
+
+    for source_file in (aphl_schematron, xslt_include, xslt_expand, xslt_compile, voc_source):
+        os.utime(source_file, (new_time, new_time))
+
+    monkeypatch.setattr(validation_main, "STAGE1_OUTPUT", stage1_output)
+    monkeypatch.setattr(validation_main, "STAGE2_OUTPUT", stage2_output)
+    monkeypatch.setattr(validation_main, "VALIDATOR_OUTPUT", validator_output)
+    monkeypatch.setattr(validation_main, "VOC_OUTPUT", voc_output)
+    monkeypatch.setattr(validation_main, "APHL_SCHEMATRON", aphl_schematron)
+    monkeypatch.setattr(validation_main, "XSLT_INCLUDE", xslt_include)
+    monkeypatch.setattr(validation_main, "XSLT_EXPAND", xslt_expand)
+    monkeypatch.setattr(validation_main, "XSLT_COMPILE", xslt_compile)
+    monkeypatch.setattr(validation_main, "VOC_SOURCE", voc_source)
+    monkeypatch.setattr(validation_main, "PySaxonProcessor", FakeSaxonProcessor)
+
+    results = validate_eicr("<ClinicalDocument />")
+
+    assert results == [
+        ValidationResult(
+            error_id=LabTestNameOrderedSchematronErrors.MISSING_CODE_ATTRIBUTE.value,
+            location=FAKE_LOCATION,
+        )
+    ]
+    assert stage1_output.read_text() == "<generated />"
+    assert stage2_output.read_text() == "<generated />"
+    assert validator_output.read_text() == "<generated />"
+    assert voc_output.read_text() == "<voc />"


### PR DESCRIPTION
## Description

This adds code to `validation/main.py` that checks the last modified date of the two dependent files to see if new temps are needed. This should be testable locally by making a nonsense change (adding a `<>` to the blank line 3 of the `packages/validation/src/validation/eicr-validator/schematron/APHL_TextToCodeSchematron_09252025.sch`) and then confirming that new temp files were generated in `packages/validation/src/validation/eicr-validator/output`.

This also adds a just command to manually remove the files to generate new ones, regardless of whether the files had changed.

These changes are needed to address issues that can arise where locally, the temp files become stale as a result of changes to the schematron or xslt compile file.

## Related Issues

Closes #638, #655 

## Additional Notes

[Add any additional context or notes that reviewers should know about.]

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
