### PR TITLE
Remove USWDS government banner and CDC identifier

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,13 +1,3 @@
-// ── GOV BANNER TOGGLE ──
-(function () {
-  const btn = document.getElementById('banner-toggle');
-  const content = document.getElementById('banner-content');
-  btn.addEventListener('click', () => {
-    const open = content.classList.toggle('open');
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  });
-})();
-
 // ── STEP INDICATOR (Upload → Review → Export) ──
 function setStep(n) {
   document.querySelectorAll('#step-indicator .usa-step-indicator__segment').forEach(seg => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,27 +11,6 @@
 </head>
 <body>
 
-  <!-- ── GOVERNMENT BANNER ── -->
-  <section class="usa-banner" aria-label="Official government website">
-    <div class="usa-banner__inner">
-      <span class="banner-flag" aria-hidden="true"></span>
-      <span class="usa-banner__text">An official website of the United States government</span>
-      <button class="usa-banner__button" id="banner-toggle" aria-expanded="false" aria-controls="banner-content">
-        Here's how you know <span class="arrow">▼</span>
-      </button>
-    </div>
-    <div class="usa-banner__content" id="banner-content">
-      <div class="usa-banner__guidance">
-        <span class="ico ico-gov" aria-hidden="true">⌂</span>
-        <p><strong>Official websites use .gov</strong>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p>
-      </div>
-      <div class="usa-banner__guidance">
-        <span class="ico ico-https" aria-hidden="true"><span class="lock"></span></span>
-        <p><strong>Secure .gov websites use HTTPS</strong>A lock (<span class="lock" style="vertical-align:-1px"></span>) or <strong>https://</strong> means you've safely connected to the .gov website.</p>
-      </div>
-    </div>
-  </section>
-
   <!-- ── HEADER ── -->
   <header class="usa-header">
     <div class="usa-header__inner">
@@ -287,29 +266,6 @@
       </nav>
     </div>
   </footer>
-
-  <!-- ── USWDS IDENTIFIER ── -->
-  <section class="usa-identifier" aria-label="Agency identifier">
-    <div class="usa-identifier__inner">
-      <div class="usa-identifier__masthead">
-        <span class="usa-identifier__logo" aria-hidden="true">CDC</span>
-        <p class="usa-identifier__id">
-          An official website of the <strong>Centers for Disease Control and Prevention</strong>, part of the U.S. Department of Health and Human Services.
-        </p>
-      </div>
-      <nav class="usa-identifier__required" aria-label="Important links">
-        <a href="#">About CDC</a>
-        <a href="#">Accessibility</a>
-        <a href="#">FOIA requests</a>
-        <a href="#">No FEAR Act data</a>
-        <a href="#">Privacy policy</a>
-        <a href="#">Vulnerability disclosure</a>
-      </nav>
-      <p class="usa-identifier__gov">
-        Looking for U.S. government information and services? Visit <a href="https://www.usa.gov">USA.gov</a>
-      </p>
-    </div>
-  </section>
 
   <script src="app.js"></script>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -81,33 +81,6 @@ button:focus-visible, .chip:focus-visible, .act-btn:focus-visible, a:focus-visib
 .grid-container { max-width: 64rem; margin: 0 auto; padding: 0 1rem; }
 .grid-container--wide { max-width: 87.5rem; margin: 0 auto; padding: 0 1rem; }
 
-/* ── GOV BANNER ───────────────────────────────────────────── */
-.usa-banner { background: var(--base-lightest); font-size: 0.8125rem; line-height: 1.3; }
-.usa-banner__inner { max-width: 64rem; margin: 0 auto; padding: 0.5rem 1rem; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
-.banner-flag {
-  flex: none; width: 16px; height: 11px; border-radius: 1px; position: relative;
-  background: repeating-linear-gradient(to bottom, #b22234 0 1.57px, #fff 1.57px 3.14px);
-  overflow: hidden;
-}
-.banner-flag::before { content: ""; position: absolute; left: 0; top: 0; width: 8px; height: 6px; background: #3c3b6e; }
-.usa-banner__text { color: var(--base-darker); }
-.usa-banner__button {
-  background: none; border: 0; padding: 0; cursor: pointer; color: var(--link);
-  font-family: inherit; font-size: 0.8125rem; text-decoration: underline; display: inline-flex; align-items: center; gap: 4px;
-}
-.usa-banner__button .arrow { transition: transform 0.15s; font-size: 0.6rem; }
-.usa-banner__button[aria-expanded="true"] .arrow { transform: rotate(180deg); }
-.usa-banner__content { display: none; max-width: 64rem; margin: 0 auto; padding: 1.25rem 1rem 1.75rem; gap: 2rem; }
-.usa-banner__content.open { display: grid; grid-template-columns: 1fr 1fr; }
-.usa-banner__guidance { display: flex; gap: 0.75rem; align-items: flex-start; font-size: 0.875rem; color: var(--base-darker); }
-.usa-banner__guidance .ico { flex: none; width: 2.5rem; height: 2.5rem; border-radius: 50%; display: grid; place-items: center; font-size: 1.05rem; }
-.ico-gov { background: var(--primary-lighter); color: var(--primary-darker); }
-.ico-https { background: var(--success-light); color: var(--success-dark); }
-.usa-banner__guidance strong { display: block; }
-.lock { display: inline-block; width: 0.65rem; height: 0.55rem; border: 1.5px solid var(--success-dark); border-radius: 0 0 1px 1px; position: relative; vertical-align: -1px; margin: 0 1px; }
-.lock::before { content: ""; position: absolute; left: 50%; top: -0.42rem; transform: translateX(-50%); width: 0.42rem; height: 0.42rem; border: 1.5px solid var(--success-dark); border-bottom: 0; border-radius: 0.42rem 0.42rem 0 0; }
-@media (max-width: 40rem) { .usa-banner__content.open { grid-template-columns: 1fr; } }
-
 /* ── HEADER (dark blue-cool, DIBBs) ───────────────────────── */
 .usa-header { background: var(--primary-darker); }
 .usa-header__inner { max-width: 64rem; margin: 0 auto; padding: 0 1rem; display: flex; align-items: stretch; justify-content: space-between; flex-wrap: wrap; }
@@ -337,19 +310,6 @@ main { padding-bottom: 3.5rem; }
 .agency-footer__links { display: flex; gap: 1.25rem; flex-wrap: wrap; font-size: 0.9rem; }
 .agency-footer__links a { color: #fff; text-decoration: none; }
 .agency-footer__links a:hover { color: #fff; text-decoration: underline; }
-
-/* ── USWDS IDENTIFIER ─────────────────────────────────────── */
-.usa-identifier { background: var(--base-darkest); color: var(--base-light); padding: 1.5rem 0; }
-.usa-identifier__inner { max-width: 64rem; margin: 0 auto; padding: 0 1rem; }
-.usa-identifier__masthead { display: flex; align-items: center; gap: 0.75rem; padding-bottom: 0.9rem; border-bottom: 1px solid #454545; flex-wrap: wrap; }
-.usa-identifier__logo { width: 2.5rem; height: 2.5rem; border-radius: 50%; background: #454545; display: grid; place-items: center; font-size: 0.7rem; font-weight: 700; color: #fff; flex: none; }
-.usa-identifier__id { font-size: 0.92rem; line-height: 1.4; }
-.usa-identifier__id strong { color: #fff; font-weight: 700; }
-.usa-identifier__required { display: flex; flex-wrap: wrap; gap: 0.4rem 1.5rem; padding: 0.9rem 0; font-size: 0.9rem; }
-.usa-identifier__required a { color: var(--base-light); text-decoration: none; }
-.usa-identifier__required a:hover { color: #fff; text-decoration: underline; }
-.usa-identifier__gov { font-size: 0.9rem; padding-top: 0.5rem; }
-.usa-identifier__gov a { color: var(--primary-light); }
 
 @media (max-width: 48rem) {
   .result-body { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary

Removes the USWDS government banner and CDC agency identifier from the TTC demo frontend. The TTC product footer remains.

- Remove `usa-banner` section (HTML, CSS, JS toggle)
- Remove `usa-identifier` section (HTML, CSS)

## Test plan

- [ ] Open `frontend/index.html` locally and confirm banner and identifier are gone
- [ ] Confirm TTC product footer still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)