### PR TITLE
fix: bolstering handler messaging in lambdas

### DIFF
--- a/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
+++ b/packages/augmentation-lambda/src/augmentation_lambda/lambda_function.py
@@ -38,32 +38,86 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
     """
     logger.info("Received event", record_count=len(event["Records"]))
 
-    failures: list[dict[str, str]] = []
-    successes: list[str] = []
+    batch_item_failures: list[dict[str, str]] = []
+    failures: list[dict[str, object]] = []
+    successes: list[dict[str, str]] = []
 
     for record in event.records:
         try:
-            _process_record(record)
-            successes.append(record.message_id)
-        except Exception:
+            output = _process_record(record)
+
+            if output is None:
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "skipped",
+                    }
+                )
+            elif output.metadata.passthrough_reason is not None:
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "passthrough_written",
+                    }
+                )
+            else:
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "processed",
+                    }
+                )
+        except Exception as e:
             logger.exception(
                 "Error processing record",
+                error=str(e),
                 message_id=record.message_id,
                 status="error",
             )
-            failures.append({"itemIdentifier": record.message_id})
+            batch_item_failures.append({"itemIdentifier": record.message_id})
+            failures.append(
+                {
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "message_id": record.message_id,
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            )
+
+    if batch_item_failures:
+        status = "partial_failure"
+    elif any(success["status"] == "passthrough_written" for success in successes):
+        status = "success_with_passthrough"
+    else:
+        status = "success"
+
+    response: dict[str, object] = {
+        "batchItemFailures": batch_item_failures,
+        "failures": failures,
+        "message": "Augmentation invocation completed",
+        "num_failure_eicrs": len(batch_item_failures),
+        "num_processing_error_eicrs": len(failures),
+        "num_success_eicrs": len(successes),
+        "status": status,
+        "successes": successes,
+    }
 
     logger.info(
         "Augmentation invocation completed",
-        status="partial_failure" if failures else "success",
-        num_failure_eicrs=len(failures),
+        batch_item_failures=batch_item_failures,
+        failures=failures,
+        num_failure_eicrs=len(batch_item_failures),
+        num_processing_error_eicrs=len(failures),
         num_success_eicrs=len(successes),
+        status=status,
+        successes=successes,
     )
 
-    return {"batchItemFailures": failures}
+    return response
 
 
-def _process_record(record: SQSRecord) -> None:
+def _process_record(record: SQSRecord) -> TTCAugmenterOutput | None:
     """Process a single SQS record containing an S3 event.
 
     :param record: The SQS record with an EventBridge S3 event in the body.
@@ -71,7 +125,7 @@ def _process_record(record: SQSRecord) -> None:
     """
     if not record.body:
         logger.warning("Empty SQS body", message_id=record.message_id, status="skipped")
-        return
+        return None
 
     s3_event = json.loads(record.body)
 
@@ -103,6 +157,8 @@ def _process_record(record: SQSRecord) -> None:
             status="passthrough" if output.metadata.passthrough_reason is not None else "success",
             passthrough_reason=output.metadata.passthrough_reason,
         )
+
+        return output
 
 
 def _introduced_validation_error(original_eicr: str, augmented_eicr: str) -> str | None:

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_error_missing_eicr/handler_error_missing_eicr_result.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_error_missing_eicr/handler_error_missing_eicr_result.json
@@ -3,5 +3,20 @@
     {
       "itemIdentifier": "msg-missing-eicr"
     }
-  ]
+  ],
+  "failures": [
+    {
+      "error": "S3 object not found: dibbs-text-to-code/TextToCodeSubmissionV2/2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
+      "error_type": "FileNotFoundError",
+      "message_id": "msg-missing-eicr",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "Augmentation invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 0,
+  "status": "partial_failure",
+  "successes": []
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_error_missing_ttc_output/handler_error_missing_ttc_output_result.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_error_missing_ttc_output/handler_error_missing_ttc_output_result.json
@@ -3,5 +3,20 @@
     {
       "itemIdentifier": "msg-missing-ttc"
     }
-  ]
+  ],
+  "failures": [
+    {
+      "error": "S3 object not found: dibbs-text-to-code/TTCAugmentationMetadataV2/2025/09/03/1-5f84c7a5-91d7f5c6a2b7c9e08f0d1234",
+      "error_type": "FileNotFoundError",
+      "message_id": "msg-missing-ttc",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "Augmentation invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 0,
+  "status": "partial_failure",
+  "successes": []
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_mixed_batch_results/handler_mixed_batch_results_result.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_mixed_batch_results/handler_mixed_batch_results_result.json
@@ -3,5 +3,25 @@
     {
       "itemIdentifier": "msg-fail"
     }
+  ],
+  "failures": [
+    {
+      "error": "S3 object not found: dibbs-text-to-code/TTCAugmentationMetadataV2/nonexistent/id",
+      "error_type": "FileNotFoundError",
+      "message_id": "msg-fail",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "Augmentation invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 1,
+  "status": "partial_failure",
+  "successes": [
+    {
+      "message_id": "msg-success",
+      "status": "processed"
+    }
   ]
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_success/handler_success_result.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_success/handler_success_result.json
@@ -8,7 +8,7 @@
   "status": "success",
   "successes": [
     {
-      "message_id": "msg-routing",
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
       "status": "processed"
     }
   ]

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_augmentation_fails/augmentation_fails_result.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_augmentation_fails/augmentation_fails_result.json
@@ -5,11 +5,11 @@
   "num_failure_eicrs": 0,
   "num_processing_error_eicrs": 0,
   "num_success_eicrs": 1,
-  "status": "success",
+  "status": "success_with_passthrough",
   "successes": [
     {
-      "message_id": "msg-routing",
-      "status": "processed"
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+      "status": "passthrough_written"
     }
   ]
 }

--- a/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_ttc_output_has_passthrough_reason/ttc_passthrough_result.json
+++ b/packages/augmentation-lambda/tests/snapshots/test_augmentation_lambda_function/test_handler_writes_original_eicr_when_ttc_output_has_passthrough_reason/ttc_passthrough_result.json
@@ -5,11 +5,11 @@
   "num_failure_eicrs": 0,
   "num_processing_error_eicrs": 0,
   "num_success_eicrs": 1,
-  "status": "success",
+  "status": "success_with_passthrough",
   "successes": [
     {
-      "message_id": "msg-routing",
-      "status": "processed"
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+      "status": "passthrough_written"
     }
   ]
 }

--- a/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
+++ b/packages/augmentation-lambda/tests/test_augmentation_lambda_function.py
@@ -27,7 +27,38 @@ EXPECTED_ORIGINAL_EICR_ID = CdaInstanceIdentifier(
 EXPECTED_AUGMENTED_EICR_ID = CdaInstanceIdentifier(
     root="d44dc1c6-8a0c-5236-906e-12f6475589ec", extension=None
 )
-NO_BATCH_ITEM_FAILURES = {"batchItemFailures": []}
+
+
+def _expected_handler_response(
+    batch_item_failures: list[dict[str, str]] | None = None,
+    failures: list[dict[str, object]] | None = None,
+    successes: list[dict[str, str]] | None = None,
+    status: str = "success",
+) -> dict[str, object]:
+    resolved_batch_item_failures = batch_item_failures or []
+    resolved_failures = failures or []
+    resolved_successes = successes or []
+
+    return {
+        "batchItemFailures": resolved_batch_item_failures,
+        "failures": resolved_failures,
+        "message": "Augmentation invocation completed",
+        "num_failure_eicrs": len(resolved_batch_item_failures),
+        "num_processing_error_eicrs": len(resolved_failures),
+        "num_success_eicrs": len(resolved_successes),
+        "status": status,
+        "successes": resolved_successes,
+    }
+
+
+NO_BATCH_ITEM_FAILURES = _expected_handler_response(
+    successes=[
+        {
+            "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+            "status": "processed",
+        }
+    ],
+)
 
 
 def _serialize_snapshot_value(value: dict[str, object]) -> str:
@@ -100,6 +131,10 @@ class TestHandler:
 
         # Assert handler function returns expected values
         assert result == NO_BATCH_ITEM_FAILURES
+        snapshot.assert_match(
+            _serialize_snapshot_value(result),
+            "handler_success_result.json",
+        )
 
         # Verify augmented eICR was written
         augmented_eicr = lambda_handler.get_file_content_from_s3(
@@ -159,7 +194,19 @@ class TestHandler:
 
         result = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert result == NO_BATCH_ITEM_FAILURES
+        assert result == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
+        snapshot.assert_match(
+            _serialize_snapshot_value(result),
+            "ttc_passthrough_result.json",
+        )
         augmenter_mock.assert_not_called()
 
         augmented_eicr = lambda_handler.get_file_content_from_s3(
@@ -253,7 +300,19 @@ class TestHandler:
 
         result = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert result == NO_BATCH_ITEM_FAILURES
+        assert result == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
+        snapshot.assert_match(
+            _serialize_snapshot_value(result),
+            "augmentation_fails_result.json",
+        )
 
         augmented_eicr = lambda_handler.get_file_content_from_s3(
             bucket_name=S3_BUCKET,
@@ -341,7 +400,15 @@ class TestHandler:
 
         result = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert result == NO_BATCH_ITEM_FAILURES
+        assert result == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
         validate_mock.assert_called_once()
 
         augmented_eicr = lambda_handler.get_file_content_from_s3(
@@ -391,7 +458,15 @@ class TestHandler:
 
         result = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert result == NO_BATCH_ITEM_FAILURES
+        assert result == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
         assert validate_mock.call_count == EXPECTED_DIFF_VALIDATION_CALLS
 
         augmented_eicr = lambda_handler.get_file_content_from_s3(
@@ -574,7 +649,14 @@ class TestHandler:
             datetime(2026, 2, 13, 15, 27, 57, tzinfo=ZoneInfo("America/New_York")), tick=False
         ):
             result = lambda_function.handler(event, mock_lambda_context)
-        assert result == NO_BATCH_ITEM_FAILURES
+        assert result == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "msg-routing",
+                    "status": "processed",
+                }
+            ],
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(result),
             "handler_source_bucket_routing_result.json",
@@ -614,7 +696,20 @@ class TestHandler:
 
         result = lambda_function.handler(event, mock_lambda_context)
 
-        assert result == {"batchItemFailures": [{"itemIdentifier": "msg-missing-eicr"}]}
+        assert result == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": "msg-missing-eicr"}],
+            failures=[
+                {
+                    "error": f"S3 object not found: {S3_BUCKET}/TextToCodeSubmissionV2/{TEST_PERSISTENCE_ID}",
+                    "error_type": "FileNotFoundError",
+                    "message_id": "msg-missing-eicr",
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(result),
             "handler_error_missing_eicr_result.json",
@@ -640,7 +735,20 @@ class TestHandler:
 
         result = lambda_function.handler(event, mock_lambda_context)
 
-        assert result == {"batchItemFailures": [{"itemIdentifier": "msg-missing-ttc"}]}
+        assert result == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": "msg-missing-ttc"}],
+            failures=[
+                {
+                    "error": f"S3 object not found: {S3_BUCKET}/{TTC_OUTPUT_PREFIX}{TEST_PERSISTENCE_ID}",
+                    "error_type": "FileNotFoundError",
+                    "message_id": "msg-missing-ttc",
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(result),
             "handler_error_missing_ttc_output_result.json",
@@ -666,7 +774,25 @@ class TestHandler:
 
         result = lambda_function.handler(event, mock_lambda_context)
 
-        assert result == {"batchItemFailures": [{"itemIdentifier": "msg-fail"}]}
+        assert result == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": "msg-fail"}],
+            failures=[
+                {
+                    "error": f"S3 object not found: {S3_BUCKET}/{TTC_OUTPUT_PREFIX}nonexistent/id",
+                    "error_type": "FileNotFoundError",
+                    "message_id": "msg-fail",
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[
+                {
+                    "message_id": "msg-success",
+                    "status": "processed",
+                }
+            ],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(result),
             "handler_mixed_batch_results_result.json",
@@ -677,4 +803,11 @@ class TestHandler:
 
         result = lambda_function.handler(event, mock_lambda_context)
 
-        assert result == NO_BATCH_ITEM_FAILURES
+        assert result == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "msg-empty-body",
+                    "status": "skipped",
+                }
+            ],
+        )

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -70,33 +70,93 @@ def handler(event: SQSEvent, context: LambdaContext) -> dict:
 
     logger.info("Received event", record_count=len(event["Records"]), status="processing")
 
-    failures: list[dict[str, str]] = []
-    successes: list[str] = []
+    batch_item_failures: list[dict[str, str]] = []
+    failures: list[dict[str, object]] = []
+    successes: list[dict[str, str]] = []
 
     for record in event.records:
         try:
-            process_record(record, opensearch_client)
-            successes.append(record.message_id)
+            output = process_record(record, opensearch_client)
+
+            if output is None:
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "skipped",
+                    }
+                )
+            elif output.passthrough_reason is not None:
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "passthrough_written",
+                    }
+                )
+            else:
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "processed",
+                    }
+                )
         except Exception as e:
             logger.exception(
                 "Error processing record",
+                error=str(e),
                 message_id=record.message_id,
                 status="error",
             )
             passthrough_written = _write_ttc_exception_passthrough_output(record, e)
+            failures.append(
+                {
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "message_id": record.message_id,
+                    "passthrough_written": passthrough_written,
+                    "sqs_retry": not passthrough_written,
+                }
+            )
+
             if passthrough_written:
-                successes.append(record.message_id)
+                successes.append(
+                    {
+                        "message_id": record.message_id,
+                        "status": "passthrough_written",
+                    }
+                )
             else:
-                failures.append({"itemIdentifier": record.message_id})
+                batch_item_failures.append({"itemIdentifier": record.message_id})
+
+    if batch_item_failures:
+        status = "partial_failure"
+    elif any(success["status"] == "passthrough_written" for success in successes):
+        status = "success_with_passthrough"
+    else:
+        status = "success"
+
+    response: dict[str, object] = {
+        "batchItemFailures": batch_item_failures,
+        "failures": failures,
+        "message": "TTC invocation completed",
+        "num_failure_eicrs": len(batch_item_failures),
+        "num_processing_error_eicrs": len(failures),
+        "num_success_eicrs": len(successes),
+        "status": status,
+        "successes": successes,
+    }
 
     logger.info(
         "TTC invocation completed",
-        status="partial_failure" if failures else "success",
-        num_failure_eicrs=len(failures),
+        batch_item_failures=batch_item_failures,
+        failures=failures,
+        num_failure_eicrs=len(batch_item_failures),
+        num_processing_error_eicrs=len(failures),
         num_success_eicrs=len(successes),
+        status=status,
+        successes=successes,
     )
 
-    return {"batchItemFailures": failures}
+    return response
 
 
 def _write_ttc_exception_passthrough_output(record: SQSRecord, error: Exception) -> bool:
@@ -168,14 +228,14 @@ def _write_ttc_exception_passthrough_output(record: SQSRecord, error: Exception)
         return False
 
 
-def process_record(record: SQSRecord, opensearch_client: OpenSearch) -> None:
+def process_record(record: SQSRecord, opensearch_client: OpenSearch) -> TTCAugmenterInput | None:
     """Process each SQS record.
 
     :param record: The SQS record to process
     """
     if not record.body:
         logger.warning("Empty SQS body", message_id=record.message_id, status="skipped")
-        return
+        return None
 
     s3_event = json.loads(record.body)
 
@@ -201,7 +261,7 @@ def process_record(record: SQSRecord, opensearch_client: OpenSearch) -> None:
         trigger_s3_key=object_key,
     ):
         logger.info("Processing TTC event", status="processing")
-        _process_record_pipeline(persistence_id, opensearch_client, bucket_name)
+        return _process_record_pipeline(persistence_id, opensearch_client, bucket_name)
 
 
 def _load_schematron_data_fields(persistence_id: str, bucket_name: str) -> list:
@@ -330,7 +390,7 @@ def _process_record_pipeline(  # noqa: PLR0915
     persistence_id: str,
     opensearch_client: OpenSearch,
     bucket_name: str,
-) -> None:
+) -> TTCAugmenterInput:
     """The main pipeline for processing each record.
 
     The pipeline includes:
@@ -526,6 +586,8 @@ def _process_record_pipeline(  # noqa: PLR0915
         status="matched" if ttc_output.nonstandard_codes else "no_matches_found",
         passthrough_reason=passthrough_reason,
     )
+
+    return ttc_output
 
 
 def _save_outputs(

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_continues_processing_after_record_exception/handler_continues_processing_after_record_exception_result.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_continues_processing_after_record_exception/handler_continues_processing_after_record_exception_result.json
@@ -3,5 +3,25 @@
     {
       "itemIdentifier": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7"
     }
+  ],
+  "failures": [
+    {
+      "error": "boom",
+      "error_type": "Exception",
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "TTC invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 1,
+  "status": "partial_failure",
+  "successes": [
+    {
+      "message_id": "second-message-id",
+      "status": "skipped"
+    }
   ]
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_fails_when_event_has_no_bucket/handler_fails_when_event_has_no_bucket_result.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_fails_when_event_has_no_bucket/handler_fails_when_event_has_no_bucket_result.json
@@ -3,5 +3,20 @@
     {
       "itemIdentifier": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7"
     }
-  ]
+  ],
+  "failures": [
+    {
+      "error": "No bucket name found in S3 event payload. The TTC lambda derives its target bucket from the event and does not use a static bucket configuration. Ensure the EventBridge/S3 event includes detail.bucket.name.",
+      "error_type": "ValueError",
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "TTC invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 0,
+  "status": "partial_failure",
+  "successes": []
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_returns_failure_when_record_exception_has_empty_body/handler_returns_failure_when_record_exception_has_empty_body_result.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_returns_failure_when_record_exception_has_empty_body/handler_returns_failure_when_record_exception_has_empty_body_result.json
@@ -3,5 +3,20 @@
     {
       "itemIdentifier": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7"
     }
-  ]
+  ],
+  "failures": [
+    {
+      "error": "boom",
+      "error_type": "Exception",
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "TTC invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 0,
+  "status": "partial_failure",
+  "successes": []
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_returns_failure_when_ttc_exception_passthrough_write_fails/handler_returns_failure_when_ttc_exception_passthrough_write_fails_result.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_returns_failure_when_ttc_exception_passthrough_write_fails/handler_returns_failure_when_ttc_exception_passthrough_write_fails_result.json
@@ -3,5 +3,20 @@
     {
       "itemIdentifier": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7"
     }
-  ]
+  ],
+  "failures": [
+    {
+      "error": "boom",
+      "error_type": "Exception",
+      "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "TTC invocation completed",
+  "num_failure_eicrs": 1,
+  "num_processing_error_eicrs": 1,
+  "num_success_eicrs": 0,
+  "status": "partial_failure",
+  "successes": []
 }

--- a/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_returns_failures_when_all_records_raise/handler_returns_failures_when_all_records_raise_result.json
+++ b/packages/text-to-code-lambda/tests/snapshots/test_lambda_function/test_handler_returns_failures_when_all_records_raise/handler_returns_failures_when_all_records_raise_result.json
@@ -6,5 +6,27 @@
     {
       "itemIdentifier": "second-message-id"
     }
-  ]
+  ],
+  "failures": [
+    {
+      "error": "first failure",
+      "error_type": "Exception",
+      "message_id": "first-message-id",
+      "passthrough_written": false,
+      "sqs_retry": true
+    },
+    {
+      "error": "second failure",
+      "error_type": "Exception",
+      "message_id": "second-message-id",
+      "passthrough_written": false,
+      "sqs_retry": true
+    }
+  ],
+  "message": "TTC invocation completed",
+  "num_failure_eicrs": 2,
+  "num_processing_error_eicrs": 2,
+  "num_success_eicrs": 0,
+  "status": "partial_failure",
+  "successes": []
 }

--- a/packages/text-to-code-lambda/tests/test_lambda_function.py
+++ b/packages/text-to-code-lambda/tests/test_lambda_function.py
@@ -24,7 +24,37 @@ TTC_METADATA_PREFIX = os.environ["TTC_METADATA_PREFIX"]
 
 EXPECTED_EXCEPTION_RESULTS = 2
 
-NO_BATCH_ITEM_FAILURES = {"batchItemFailures": []}
+
+def _expected_handler_response(
+    batch_item_failures: list[dict[str, str]] | None = None,
+    failures: list[dict[str, object]] | None = None,
+    successes: list[dict[str, str]] | None = None,
+    status: str = "success",
+) -> dict[str, object]:
+    resolved_batch_item_failures = batch_item_failures or []
+    resolved_failures = failures or []
+    resolved_successes = successes or []
+
+    return {
+        "batchItemFailures": resolved_batch_item_failures,
+        "failures": resolved_failures,
+        "message": "TTC invocation completed",
+        "num_failure_eicrs": len(resolved_batch_item_failures),
+        "num_processing_error_eicrs": len(resolved_failures),
+        "num_success_eicrs": len(resolved_successes),
+        "status": status,
+        "successes": resolved_successes,
+    }
+
+
+NO_BATCH_ITEM_FAILURES = _expected_handler_response(
+    successes=[
+        {
+            "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+            "status": "processed",
+        }
+    ],
+)
 
 
 def _get_serialized_object(key: str) -> str:
@@ -194,7 +224,7 @@ class TestHandler:
         example_sqs_event["Records"] = []
         expected_num_errors = 0
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response()
         assert resp["batchItemFailures"] == []
         assert mock_opensearch.search.call_count == expected_num_errors
 
@@ -206,7 +236,14 @@ class TestHandler:
         expected_num_errors = 0
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
         assert "Empty SQS body" in caplog_warning.text
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "skipped",
+                }
+            ],
+        )
         assert mock_opensearch.search.call_count == expected_num_errors
 
     def test_handler_fails_when_event_has_no_bucket(
@@ -223,9 +260,20 @@ class TestHandler:
 
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert resp == {
-            "batchItemFailures": [{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}]
-        }
+        assert resp == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}],
+            failures=[
+                {
+                    "error": "No bucket name found in S3 event payload. The TTC lambda derives its target bucket from the event and does not use a static bucket configuration. Ensure the EventBridge/S3 event includes detail.bucket.name.",
+                    "error_type": "ValueError",
+                    "message_id": example_sqs_event["Records"][0]["messageId"],
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(resp),
             "handler_fails_when_event_has_no_bucket_result.json",
@@ -246,7 +294,15 @@ class TestHandler:
         )
 
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
 
         ttc_output = _get_serialized_object(f"{TTC_OUTPUT_PREFIX}{mock_aws_setup.persistence_id}")
         snapshot.assert_match(ttc_output, "no_relevant_schematron_fields_ttc_output.json")
@@ -283,9 +339,25 @@ class TestHandler:
 
         assert process_record_mock.call_count == EXPECTED_EXCEPTION_RESULTS
         assert passthrough_output_mock.call_count == 1
-        assert resp == {
-            "batchItemFailures": [{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}]
-        }
+        assert resp == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}],
+            failures=[
+                {
+                    "error": "boom",
+                    "error_type": "Exception",
+                    "message_id": example_sqs_event["Records"][0]["messageId"],
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[
+                {
+                    "message_id": "second-message-id",
+                    "status": "skipped",
+                }
+            ],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(resp),
             "handler_continues_processing_after_record_exception_result.json",
@@ -318,12 +390,30 @@ class TestHandler:
 
         assert process_record_mock.call_count == EXPECTED_EXCEPTION_RESULTS
         assert passthrough_output_mock.call_count == EXPECTED_EXCEPTION_RESULTS
-        assert resp == {
-            "batchItemFailures": [
+        assert resp == _expected_handler_response(
+            batch_item_failures=[
                 {"itemIdentifier": "first-message-id"},
                 {"itemIdentifier": "second-message-id"},
-            ]
-        }
+            ],
+            failures=[
+                {
+                    "error": "first failure",
+                    "error_type": "Exception",
+                    "message_id": "first-message-id",
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                },
+                {
+                    "error": "second failure",
+                    "error_type": "Exception",
+                    "message_id": "second-message-id",
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                },
+            ],
+            successes=[],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(resp),
             "handler_returns_failures_when_all_records_raise_result.json",
@@ -348,7 +438,24 @@ class TestHandler:
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
         assert process_record_mock.call_count == 1
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            failures=[
+                {
+                    "error": "boom",
+                    "error_type": "Exception",
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "passthrough_written": True,
+                    "sqs_retry": False,
+                }
+            ],
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
 
         ttc_output = _get_serialized_object(f"{TTC_OUTPUT_PREFIX}{mock_aws_setup.persistence_id}")
         snapshot.assert_match(ttc_output, "record_exception_id_ttc_output.json")
@@ -380,9 +487,20 @@ class TestHandler:
 
         assert process_record_mock.call_count == 1
         assert save_outputs_mock.call_count == 1
-        assert resp == {
-            "batchItemFailures": [{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}]
-        }
+        assert resp == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}],
+            failures=[
+                {
+                    "error": "boom",
+                    "error_type": "Exception",
+                    "message_id": example_sqs_event["Records"][0]["messageId"],
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(resp),
             "handler_returns_failure_when_ttc_exception_passthrough_write_fails_result.json",
@@ -408,9 +526,20 @@ class TestHandler:
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
         assert process_record_mock.call_count == 1
-        assert resp == {
-            "batchItemFailures": [{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}]
-        }
+        assert resp == _expected_handler_response(
+            batch_item_failures=[{"itemIdentifier": example_sqs_event["Records"][0]["messageId"]}],
+            failures=[
+                {
+                    "error": "boom",
+                    "error_type": "Exception",
+                    "message_id": example_sqs_event["Records"][0]["messageId"],
+                    "passthrough_written": False,
+                    "sqs_retry": True,
+                }
+            ],
+            successes=[],
+            status="partial_failure",
+        )
         snapshot.assert_match(
             _serialize_snapshot_value(resp),
             "handler_returns_failure_when_record_exception_has_empty_body_result.json",
@@ -440,7 +569,15 @@ class TestHandler:
 
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
 
         retriever_embed_mock.assert_not_called()
         reranker_mock.assert_not_called()
@@ -498,7 +635,15 @@ class TestHandler:
 
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
 
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
 
         assert mock_opensearch.search.call_count == 0
         assert reranker_mock.call_count == 0
@@ -519,7 +664,15 @@ class TestHandler:
         snapshot,
     ):
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
 
         ttc_output = _get_serialized_object(
             f"{TTC_OUTPUT_PREFIX}{mock_aws_setup_malformed_eicr_no_relevant_schematron.persistence_id}"
@@ -554,7 +707,15 @@ class TestHandler:
         )
 
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
-        assert resp == NO_BATCH_ITEM_FAILURES
+        assert resp == _expected_handler_response(
+            successes=[
+                {
+                    "message_id": "f9ccdff5-0acb-4933-8995-bd7f0ab5f2f7",
+                    "status": "passthrough_written",
+                }
+            ],
+            status="success_with_passthrough",
+        )
 
         ttc_output = _get_serialized_object(f"{TTC_OUTPUT_PREFIX}{mock_aws_setup.persistence_id}")
         snapshot.assert_match(ttc_output, "reranker_returns_empty_ttc_output.json")


### PR DESCRIPTION
## Description

This a sub-branch of #669 , I'm mostly sure that `batchItemFailures` needs to be the only thing returned by the messenger, but I'm not entirely sure. Ideally, we would return metadata, so I wanted to see what that would look like by fixing what is returned to return more meaningful logged data about how data is going through the pipeline.

## Related Issues

Closes #[Link any related issues or tasks from your project management system.]

## Additional Notes

[Add any additional context or notes that reviewers should know about.]

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist

Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers

Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
