### PR TITLE
perf: Speed up the TTC pipeline 3x under load, add load-test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cov.xml
 
 # Embedding variability spike outputs
 docs/spikes/embedding-variability/outputs/
+
+# Load test corpora and results (scripts/load_test.sh)
+load_test_runs/

--- a/Dockerfile.ttc
+++ b/Dockerfile.ttc
@@ -23,9 +23,12 @@ RUN pip install --no-cache-dir huggingface_hub
 # the workspace pin and trips CVE-2025-47273. Upgrade explicitly.
 RUN pip install --no-cache-dir --upgrade 'setuptools>=78.1.1'
 
-# Download retriever at build time (private repo, needs token)
+# Download retriever at build time (private repo, needs token). The cache
+# cleanup must happen in the same RUN: snapshot_download duplicates blobs into
+# /root/.cache, and a separate RUN would freeze them into this layer.
 RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
-  python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='NCHS/ttc-retriever-mvp', local_dir='/opt/retriever_model', ignore_patterns=['*.git*', '*.md', 'onnx/*', 'openvino/*', 'pytorch_model.bin', 'tf_model.h5', 'flax_model.msgpack', 'model.onnx'])"
+  python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='NCHS/ttc-retriever-mvp', local_dir='/opt/retriever_model', ignore_patterns=['*.git*', '*.md', 'onnx/*', 'openvino/*', 'pytorch_model.bin', 'tf_model.h5', 'flax_model.msgpack', 'model.onnx'])" \
+  && rm -rf /root/.cache/huggingface
 
 # Download reranker at build time (private repo, needs token)
 RUN --mount=type=secret,id=huggingface_token,env=HF_TOKEN \
@@ -54,5 +57,12 @@ RUN rm -rf ${LAMBDA_TASK_ROOT}/shared-models ${LAMBDA_TASK_ROOT}/utils ${LAMBDA_
 
 ENV RETRIEVER_MODEL_PATH="/opt/retriever_model"
 ENV RERANKER_MODEL_PATH="/opt/reranker_model"
+
+# Models load from the baked-in local paths above, but huggingface_hub still
+# attempts Hub metadata checks by default. The prod VPC has no internet, so
+# each attempt would hang until socket timeout on every cold start — force
+# offline mode. Placed after all RUN layers so build-time downloads still work.
+ENV HF_HUB_OFFLINE=1
+ENV TRANSFORMERS_OFFLINE=1
 
 CMD ["text_to_code_lambda.lambda_function.handler"]

--- a/docs/load-tests/2026-07-10-perf-audit-improvements.html
+++ b/docs/load-tests/2026-07-10-perf-audit-improvements.html
@@ -1,0 +1,572 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TTC Load Test — perf-audit-improvements A/B</title>
+</head>
+<body>
+<style>
+  :root {
+    --bg: #F7F9FA;
+    --surface: #FFFFFF;
+    --ink: #182430;
+    --muted: #5B6B7A;
+    --line: #DDE4EA;
+    --line-soft: #E9EEF2;
+    --base-bar: #8494A3;
+    --accent: #0E7C6B;
+    --accent-ink: #0A5F52;
+    --accent-soft: rgba(14, 124, 107, 0.10);
+    --warn: #9A6A1B;
+    --warn-bg: #FBF3E2;
+    --warn-line: #E8D9B8;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #10161C;
+      --surface: #171F27;
+      --ink: #E6EDF3;
+      --muted: #8FA0AF;
+      --line: #27323D;
+      --line-soft: #1F2933;
+      --base-bar: #5D6B7A;
+      --accent: #33C1A6;
+      --accent-ink: #4FD3BA;
+      --accent-soft: rgba(51, 193, 166, 0.12);
+      --warn: #D9A54A;
+      --warn-bg: #2A2213;
+      --warn-line: #4A3B1E;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #10161C;
+    --surface: #171F27;
+    --ink: #E6EDF3;
+    --muted: #8FA0AF;
+    --line: #27323D;
+    --line-soft: #1F2933;
+    --base-bar: #5D6B7A;
+    --accent: #33C1A6;
+    --accent-ink: #4FD3BA;
+    --accent-soft: rgba(51, 193, 166, 0.12);
+    --warn: #D9A54A;
+    --warn-bg: #2A2213;
+    --warn-line: #4A3B1E;
+  }
+  :root[data-theme="light"] {
+    --bg: #F7F9FA;
+    --surface: #FFFFFF;
+    --ink: #182430;
+    --muted: #5B6B7A;
+    --line: #DDE4EA;
+    --line-soft: #E9EEF2;
+    --base-bar: #8494A3;
+    --accent: #0E7C6B;
+    --accent-ink: #0A5F52;
+    --accent-soft: rgba(14, 124, 107, 0.10);
+    --warn: #9A6A1B;
+    --warn-bg: #FBF3E2;
+    --warn-line: #E8D9B8;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: "Avenir Next", "Segoe UI", system-ui, -apple-system, sans-serif;
+    line-height: 1.55;
+    margin: 0;
+  }
+  .wrap { max-width: 940px; margin: 0 auto; padding: 48px 24px 80px; }
+
+  .eyebrow {
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 10px;
+  }
+  h1 {
+    font-size: clamp(26px, 4vw, 34px);
+    font-weight: 650;
+    letter-spacing: -0.015em;
+    line-height: 1.15;
+    margin: 0 0 12px;
+    text-wrap: balance;
+  }
+  .meta {
+    color: var(--muted);
+    font-size: 14px;
+    margin: 0 0 8px;
+  }
+  .meta code {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+    font-size: 13px;
+    background: var(--line-soft);
+    border-radius: 4px;
+    padding: 1px 5px;
+  }
+
+  .hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 14px;
+    margin: 32px 0 8px;
+  }
+  .stat {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 20px 22px 18px;
+  }
+  .stat .big {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 34px;
+    font-weight: 600;
+    color: var(--accent);
+    line-height: 1.1;
+  }
+  .stat .label { font-size: 14px; font-weight: 600; margin-top: 6px; }
+  .stat .sub { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+  section { margin-top: 52px; }
+  h2 {
+    font-size: 20px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+  .section-sub { color: var(--muted); font-size: 14px; margin: 0 0 20px; max-width: 68ch; }
+
+  .chart-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 20px 20px 12px;
+    margin-bottom: 16px;
+  }
+  .chart-title { font-size: 15px; font-weight: 600; margin: 0 0 2px; }
+  .chart-sub { font-size: 13px; color: var(--muted); margin: 0 0 8px; }
+  .chart-scroll { overflow-x: auto; }
+  .chart-scroll svg { display: block; min-width: 560px; width: 100%; height: auto; }
+
+  .legend { display: flex; gap: 18px; font-size: 13px; color: var(--muted); margin: 4px 0 10px; }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; }
+  .swatch { width: 12px; height: 12px; border-radius: 3px; display: inline-block; }
+  .swatch.base { background: var(--base-bar); }
+  .swatch.branch { background: var(--accent); }
+
+  .table-scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
+  th, td { padding: 9px 14px; text-align: right; white-space: nowrap; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th {
+    font-size: 11.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    border-bottom: 1px solid var(--line);
+    font-weight: 600;
+  }
+  tbody td {
+    border-bottom: 1px solid var(--line-soft);
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+  }
+  tbody td:first-child { font-family: inherit; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr.group td {
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    background: var(--line-soft);
+  }
+  td.delta-good { color: var(--accent-ink); font-weight: 600; }
+  td.delta-flat { color: var(--muted); }
+
+  .callout {
+    border: 1px solid var(--warn-line);
+    background: var(--warn-bg);
+    border-radius: 8px;
+    padding: 16px 20px;
+    font-size: 14px;
+    margin-top: 16px;
+  }
+  .callout strong { color: var(--warn); }
+
+  .pill {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    border-radius: 999px;
+    padding: 2px 10px;
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+  }
+
+  .cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+  .mini {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 16px 18px;
+    font-size: 14px;
+  }
+  .mini h3 { font-size: 14px; font-weight: 650; margin: 0 0 6px; }
+  .mini p { margin: 0; color: var(--muted); font-size: 13.5px; }
+  .mini .num {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+
+  footer {
+    margin-top: 56px;
+    padding-top: 20px;
+    border-top: 1px solid var(--line);
+    color: var(--muted);
+    font-size: 13px;
+    max-width: 72ch;
+  }
+  footer p { margin: 0 0 10px; }
+  a { color: var(--accent-ink); }
+</style>
+
+<div class="wrap">
+  <header>
+    <p class="eyebrow">DIBBs Text to Code · Load Test</p>
+    <h1>perf-audit-improvements: 3.4&times; faster end-to-end, zero regressions</h1>
+    <p class="meta">
+      A/B burst test, 300 documents per pass &times; 2 passes per arm &middot; July 10, 2026 &middot; us-east-2 &middot;
+      baseline run <code>886f100a</code> (main) vs branch run <code>0f388461</code> (perf-audit-improvements)
+    </p>
+    <p class="meta">
+      Each arm: parallel S3 upload burst &rarr; Lambda scale-out &rarr; full drain. Pass 1 exercises the cold
+      result-cache path (embed + OpenSearch KNN); pass 2 re-submits identical texts to exercise the warm
+      result-cache path. Metrics from CloudWatch <code>REPORT</code> lines and S3 timestamps.
+    </p>
+  </header>
+
+  <div class="hero">
+    <div class="stat">
+      <div class="big">3.1&times;</div>
+      <div class="label">TTC Lambda faster (cold path)</div>
+      <div class="sub">median 200.0 s &rarr; 63.7 s per invocation</div>
+    </div>
+    <div class="stat">
+      <div class="big">3.4&times;</div>
+      <div class="label">Faster end-to-end</div>
+      <div class="sub">median submission &rarr; augmented eICR: 314 s &rarr; 93 s</div>
+    </div>
+    <div class="stat">
+      <div class="big">0</div>
+      <div class="label">Errors or timeouts, either arm</div>
+      <div class="sub">300/300 documents delivered in every pass</div>
+    </div>
+  </div>
+
+  <section>
+    <h2>Cold path: full embedding + OpenSearch KNN (pass 1)</h2>
+    <p class="section-sub">
+      Every document carries a salted candidate text, guaranteeing a result-cache miss &mdash; each invocation
+      does real embedding and KNN work under a 300-document burst. Durations improve roughly 68% at every
+      percentile, so the gain holds across the whole distribution, not just the median.
+    </p>
+    <div class="legend">
+      <span><i class="swatch base"></i>baseline (main)</span>
+      <span><i class="swatch branch"></i>perf-audit-improvements</span>
+    </div>
+    <div class="chart-card">
+      <p class="chart-title">TTC Lambda invocation duration <span class="pill">&minus;68% median</span></p>
+      <p class="chart-sub">seconds per invocation, CloudWatch REPORT lines, 300 invocations per arm</p>
+      <div class="chart-scroll" id="chart-ttc-cold"></div>
+    </div>
+    <div class="chart-card">
+      <p class="chart-title">End-to-end pipeline latency <span class="pill">&minus;70% median</span></p>
+      <p class="chart-sub">seconds from eICR submission to augmented eICR landing in S3, per document</p>
+      <div class="chart-scroll" id="chart-e2e"></div>
+    </div>
+    <div class="chart-card">
+      <p class="chart-title">Augmentation Lambda tail latency <span class="pill">&minus;85% max</span></p>
+      <p class="chart-sub">milliseconds per invocation &mdash; the baseline's long tail (10.2 s max) disappears when the upstream TTC burst clears 3&times; sooner</p>
+      <div class="chart-scroll" id="chart-aug"></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Warm path: result-cache hits (pass 2)</h2>
+    <p class="section-sub">
+      Pass 2 re-submits the same salted texts under fresh filenames, so every lookup hits the result cache
+      that pass 1 filled. The already-fast path got faster &mdash; the batched cache lookup (mget) shows up
+      most in the tail, where the worst invocation dropped 46%.
+    </p>
+    <div class="legend">
+      <span><i class="swatch base"></i>baseline (main)</span>
+      <span><i class="swatch branch"></i>perf-audit-improvements</span>
+    </div>
+    <div class="chart-card">
+      <p class="chart-title">TTC Lambda invocation duration, warm cache <span class="pill">&minus;18% median</span></p>
+      <p class="chart-sub">milliseconds per invocation &mdash; note the scale: both arms complete end-to-end in 2&ndash;3 s on this path</p>
+      <div class="chart-scroll" id="chart-ttc-warm"></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Throughput</h2>
+    <div class="cols">
+      <div class="mini">
+        <h3>Baseline drain</h3>
+        <p><span class="num">300</span> documents in <span class="num">321 s</span> &asymp; <span class="num">56 docs/min</span></p>
+      </div>
+      <div class="mini">
+        <h3>Branch drain</h3>
+        <p><span class="num">300</span> documents in <span class="num">105 s</span> &asymp; <span class="num">171 docs/min</span> &mdash; <strong>3.1&times; the burst throughput</strong> with the same Lambda and OpenSearch footprint</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Full numbers</h2>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Metric</th><th>Baseline (main)</th><th>Branch</th><th>&Delta;</th></tr>
+        </thead>
+        <tbody>
+          <tr class="group"><td colspan="4">TTC Lambda &mdash; pass 1 (cold cache), ms</td></tr>
+          <tr><td>p50</td><td>199,965</td><td>63,734</td><td class="delta-good">&minus;68.1%</td></tr>
+          <tr><td>p90</td><td>267,467</td><td>84,569</td><td class="delta-good">&minus;68.4%</td></tr>
+          <tr><td>p99</td><td>278,099</td><td>88,549</td><td class="delta-good">&minus;68.2%</td></tr>
+          <tr><td>max</td><td>285,851</td><td>93,010</td><td class="delta-good">&minus;67.5%</td></tr>
+          <tr class="group"><td colspan="4">End-to-end (submission &rarr; augmented eICR) &mdash; pass 1, s</td></tr>
+          <tr><td>p50</td><td>314</td><td>93</td><td class="delta-good">&minus;70.4%</td></tr>
+          <tr><td>p90</td><td>318</td><td>98</td><td class="delta-good">&minus;69.2%</td></tr>
+          <tr><td>p99</td><td>320</td><td>101</td><td class="delta-good">&minus;68.4%</td></tr>
+          <tr><td>max</td><td>321</td><td>105</td><td class="delta-good">&minus;67.3%</td></tr>
+          <tr class="group"><td colspan="4">TTC Lambda &mdash; pass 2 (warm result cache), ms</td></tr>
+          <tr><td>p50</td><td>154.9</td><td>126.4</td><td class="delta-good">&minus;18.4%</td></tr>
+          <tr><td>p90</td><td>178.3</td><td>142.4</td><td class="delta-good">&minus;20.1%</td></tr>
+          <tr><td>p99</td><td>207.1</td><td>177.6</td><td class="delta-good">&minus;14.2%</td></tr>
+          <tr><td>max</td><td>341.1</td><td>185.5</td><td class="delta-good">&minus;45.6%</td></tr>
+          <tr class="group"><td colspan="4">Augmentation Lambda &mdash; pass 1, ms</td></tr>
+          <tr><td>p50</td><td>196.2</td><td>120.1</td><td class="delta-good">&minus;38.8%</td></tr>
+          <tr><td>p90</td><td>322.2</td><td>181.9</td><td class="delta-good">&minus;43.5%</td></tr>
+          <tr><td>p99</td><td>7,162.1</td><td>1,464.6</td><td class="delta-good">&minus;79.6%</td></tr>
+          <tr><td>max</td><td>10,169.5</td><td>1,495.2</td><td class="delta-good">&minus;85.3%</td></tr>
+          <tr><td>cold starts</td><td>25</td><td>30</td><td class="delta-flat">&mdash;</td></tr>
+          <tr><td>avg init</td><td>1,597.2</td><td>1,332.3</td><td class="delta-good">&minus;16.6%</td></tr>
+          <tr><td>max init</td><td>6,049.8</td><td>4,513.1</td><td class="delta-good">&minus;25.4%</td></tr>
+          <tr class="group"><td colspan="4">Reliability &mdash; both passes</td></tr>
+          <tr><td>invocations attributed (each lambda, each pass)</td><td>300</td><td>300</td><td class="delta-flat">exact</td></tr>
+          <tr><td>documents delivered</td><td>300/300</td><td>300/300</td><td class="delta-flat">100%</td></tr>
+          <tr><td>errors + timeouts</td><td>0</td><td>0</td><td class="delta-flat">clean</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>Correctness: no behavioral regression signal</h2>
+    <p class="section-sub">
+      Every augmented eICR's predicted LOINC translation was compared against the expected code for its base
+      test case (10 curated hard cases &times; 30 salted variants each).
+    </p>
+    <div class="cols">
+      <div class="mini">
+        <h3>Deterministic within each arm</h3>
+        <p>Pass 1 and pass 2 produced <span class="num">byte-identical</span> match profiles in both arms
+        (60/300 and 47/300) &mdash; the result cache returns exactly what the live KNN path computed.</p>
+      </div>
+      <div class="mini">
+        <h3>Same hard cases miss in both arms</h3>
+        <p>The same 7 known-hard cases (CBC panel, K+, BUN, POC oxymorphone, VLDL, hep&nbsp;A IgM, MCHC, glucose
+        challenge) missed in <span class="num">all 30/30</span> variants in <em>both</em> arms &mdash; a
+        pre-existing model behavior, untouched by this branch.</p>
+      </div>
+      <div class="mini">
+        <h3>Two borderline cases flipped</h3>
+        <p>pCO2 Venous: <span class="num">30/30 &rarr; 18/30</span> matched; fentanyl screen:
+        <span class="num">30/30 &rarr; 29/30</span>. This accounts for the entire 60-vs-47 delta.</p>
+      </div>
+    </div>
+    <div class="callout">
+      <strong>Read the match-rate delta with care.</strong> The test salts every candidate text with a unique
+      run/arm marker to force cache misses &mdash; so the two arms embedded <em>different strings</em>
+      (<code>&hellip;[lt-886f100a-baseline-004]</code> vs <code>&hellip;[lt-0f388461-branch-004]</code>), and
+      borderline nearest-neighbor results can flip on the salt alone. The branch arm shows this directly:
+      pCO2 Venous matched on 18 salt variants and missed on 12 <em>within the same arm, same code</em>. The
+      per-arm difference is consistent with salt-induced embedding noise on borderline cases, not a ranking
+      change &mdash; but if we want to rule out an effect from the batched-embedding change, the clean check
+      is a fixed unsalted corpus run through both images offline.
+    </div>
+  </section>
+
+  <section>
+    <h2>What changed on the branch</h2>
+    <div class="cols">
+      <div class="mini">
+        <h3>Dropped the S3 pre-flight HEAD; bounded client timeouts</h3>
+        <p>One fewer round-trip per document and no unbounded hangs under load.</p>
+      </div>
+      <div class="mini">
+        <h3>Batched result-cache lookups and embeddings</h3>
+        <p>One OpenSearch mget and one model forward-pass per document instead of per candidate.</p>
+      </div>
+      <div class="mini">
+        <h3>Cached the Saxon processor and compiled validator stylesheet</h3>
+        <p>Schematron parsing cost paid once per container, not once per invocation.</p>
+      </div>
+      <div class="mini">
+        <h3>Hardened cold start against Hub lookups and cache bloat</h3>
+        <p>The image no longer reaches for Hugging Face Hub at init; augmentation init time dropped 17% on average.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <p><strong>Methodology.</strong> Each arm deployed its image, then ran
+    <code style="font-family: ui-monospace, Menlo, monospace;">./scripts/load_test.sh run --arm &lt;label&gt; --docs 300 --passes 2</code>:
+    300 salted eICRs uploaded to S3 in a 24-way parallel burst (SQS batch size 1, no reserved concurrency,
+    forcing Lambda scale-out), drained fully, then measured from CloudWatch Logs Insights over REPORT lines
+    and the S3 LastModified join (TextToCodeSubmissionV2 &rarr; AugmentationEICRV2). Invocation counts matched
+    the document count exactly in every pass, so no foreign traffic contaminated the windows.</p>
+    <p><strong>Known gap.</strong> TTC Lambda cold-start counts came back null from the Logs Insights query in
+    both arms (the report drops null fields), so cold-start init time for the TTC container isn't compared here;
+    the augmentation lambda's cold starts (25 vs 30) confirm containers were recycled for both arms.</p>
+    <p>Raw results: <code style="font-family: ui-monospace, Menlo, monospace;">load_test_runs/886f100a-baseline/</code> and
+    <code style="font-family: ui-monospace, Menlo, monospace;">load_test_runs/0f388461-branch/</code> (results_p1.json / results_p2.json).</p>
+  </footer>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  function css(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  // Grouped bar chart: two series across percentile categories, value labels
+  // above bars, delta badge under each category.
+  function barChart(elId, spec) {
+    var el = document.getElementById(elId);
+    if (!el) return;
+    var W = 660, H = 250, padL = 46, padR = 10, padT = 26, padB = 40;
+    var plotW = W - padL - padR, plotH = H - padT - padB;
+    var n = spec.labels.length;
+    var groupW = plotW / n;
+    var barW = Math.min(52, groupW * 0.32);
+    var gap = 10;
+    var max = spec.max;
+    var ink = css("--ink"), muted = css("--muted"), line = css("--line");
+    var colors = [css("--base-bar"), css("--accent")];
+
+    var s = '<svg viewBox="0 0 ' + W + " " + H + '" role="img" aria-label="' + spec.aria + '">';
+
+    // gridlines + y labels
+    var ticks = spec.ticks;
+    for (var t = 0; t < ticks.length; t++) {
+      var y = padT + plotH - (ticks[t] / max) * plotH;
+      s += '<line x1="' + padL + '" y1="' + y + '" x2="' + (W - padR) + '" y2="' + y +
+           '" stroke="' + line + '" stroke-width="1"/>';
+      s += '<text x="' + (padL - 8) + '" y="' + (y + 4) + '" text-anchor="end" font-size="11" ' +
+           'font-family="ui-monospace,Menlo,monospace" fill="' + muted + '">' + spec.tickFmt(ticks[t]) + "</text>";
+    }
+
+    for (var i = 0; i < n; i++) {
+      var cx = padL + groupW * i + groupW / 2;
+      var vals = [spec.series[0].values[i], spec.series[1].values[i]];
+      for (var k = 0; k < 2; k++) {
+        var h = (vals[k] / max) * plotH;
+        var x = cx - barW - gap / 2 + k * (barW + gap);
+        var y2 = padT + plotH - h;
+        s += '<rect x="' + x + '" y="' + y2 + '" width="' + barW + '" height="' + h +
+             '" rx="3" fill="' + colors[k] + '"/>';
+        s += '<text x="' + (x + barW / 2) + '" y="' + (y2 - 6) + '" text-anchor="middle" font-size="11.5" ' +
+             'font-weight="600" font-family="ui-monospace,Menlo,monospace" fill="' + ink + '">' +
+             spec.valFmt(vals[k]) + "</text>";
+      }
+      // category label
+      s += '<text x="' + cx + '" y="' + (padT + plotH + 17) + '" text-anchor="middle" font-size="12.5" ' +
+           'font-weight="600" fill="' + ink + '">' + spec.labels[i] + "</text>";
+      // delta
+      var d = (spec.series[1].values[i] / spec.series[0].values[i] - 1) * 100;
+      s += '<text x="' + cx + '" y="' + (padT + plotH + 33) + '" text-anchor="middle" font-size="11.5" ' +
+           'font-weight="600" font-family="ui-monospace,Menlo,monospace" fill="' + css("--accent-ink") + '">' +
+           (d <= 0 ? "−" : "+") + Math.abs(d).toFixed(0) + "%</text>";
+    }
+    s += "</svg>";
+    el.innerHTML = s;
+  }
+
+  var P = ["p50", "p90", "p99", "max"];
+
+  function render() {
+    barChart("chart-ttc-cold", {
+      aria: "TTC lambda duration percentiles, cold cache: baseline vs branch",
+      labels: P,
+      series: [
+        { values: [200.0, 267.5, 278.1, 285.9] },
+        { values: [63.7, 84.6, 88.5, 93.0] }
+      ],
+      max: 320, ticks: [0, 100, 200, 300],
+      tickFmt: function (v) { return v + "s"; },
+      valFmt: function (v) { return v.toFixed(0) + "s"; }
+    });
+
+    barChart("chart-e2e", {
+      aria: "End-to-end latency percentiles: baseline vs branch",
+      labels: P,
+      series: [
+        { values: [314, 318, 320, 321] },
+        { values: [93, 98, 101, 105] }
+      ],
+      max: 360, ticks: [0, 120, 240, 360],
+      tickFmt: function (v) { return v + "s"; },
+      valFmt: function (v) { return v + "s"; }
+    });
+
+    barChart("chart-aug", {
+      aria: "Augmentation lambda duration percentiles: baseline vs branch",
+      labels: P,
+      series: [
+        { values: [196.2, 322.2, 7162.1, 10169.5] },
+        { values: [120.1, 181.9, 1464.6, 1495.2] }
+      ],
+      max: 11000, ticks: [0, 2500, 5000, 7500, 10000],
+      tickFmt: function (v) { return v >= 1000 ? (v / 1000) + "s" : v + "ms"; },
+      valFmt: function (v) { return v >= 1000 ? (v / 1000).toFixed(1) + "s" : v.toFixed(0) + "ms"; }
+    });
+
+    barChart("chart-ttc-warm", {
+      aria: "TTC lambda duration percentiles, warm cache: baseline vs branch",
+      labels: P,
+      series: [
+        { values: [154.9, 178.3, 207.1, 341.1] },
+        { values: [126.4, 142.4, 177.6, 185.5] }
+      ],
+      max: 380, ticks: [0, 100, 200, 300],
+      tickFmt: function (v) { return v + "ms"; },
+      valFmt: function (v) { return v.toFixed(0) + "ms"; }
+    });
+  }
+
+  render();
+
+  // Re-render when the viewer flips the theme so bar colors follow the tokens.
+  new MutationObserver(render).observe(document.documentElement, {
+    attributes: true, attributeFilter: ["data-theme"]
+  });
+  if (window.matchMedia) {
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", render);
+  }
+})();
+</script>
+
+</body>
+</html>

--- a/docs/spikes/lambda-performance-tuning-levers.md
+++ b/docs/spikes/lambda-performance-tuning-levers.md
@@ -1,0 +1,36 @@
+# Lambda performance tuning levers (not yet applied)
+
+A 2026-07 performance audit fixed the code-level hot spots (node-relative XPath
+extraction, batched cache lookups and embeddings, Saxon processor/stylesheet
+caching, removal of the S3 pre-flight HEAD, HF offline mode in the TTC image).
+Two infrastructure levers were identified but deliberately **not** changed,
+because they alter cost or delivery behavior. They are recorded here so the
+trade-offs don't have to be rediscovered.
+
+## Provisioned concurrency on the TTC Lambda
+
+Every new concurrent execution of `ttc-lambda` cold-starts torch plus two
+SentenceTransformer models (multi-second init). There is currently no
+`provisioned_concurrency_config` or `reserved_concurrent_executions` in
+`terraform/`.
+
+- **When to apply:** if eICR volume becomes bursty or latency-sensitive enough
+  that scale-out cold starts show up in end-to-end delivery times.
+- **Cost:** provisioned concurrency bills for idle warm containers; at current
+  steady, low-volume SQS traffic the cold-start rate is low and the spend is
+  likely not justified.
+
+## SQS batch size > 1
+
+Both event source mappings use `batch_size = 1` (`terraform/main.tf`). Raising
+it would let one warm container process several eICRs per poll, amortizing
+per-invocation overhead.
+
+- **Safety:** partial-batch-failure is already wired
+  (`function_response_types = ["ReportBatchItemFailures"]` and
+  `batchItemFailures` in both handlers), so a failing record would not force
+  retries of its batch-mates.
+- **Why it's 1 today:** each record is ML-heavy and isolated; `batch_size = 1`
+  keeps per-record timeout budgets simple (one record gets the Lambda's full
+  900s/300s). Raising it requires checking that the timeout still covers the
+  worst-case batch.

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -23,43 +23,51 @@ def mock_opensearch(request: pytest.FixtureRequest) -> Iterator[MagicMock]:
     candidates: list[str] = getattr(request, "param", ["dummy"])
     candidate_iter = iter(candidates)
 
-    def build_response(*args, **kwargs) -> dict:  # noqa: ANN002, ANN003
-        value = next(candidate_iter)
+    def build_source(value: str) -> dict:
         return {
-            "found": True,
-            "_source": {
-                "cache_key": "test_cache_key",
-                "text": value,
-                "data_field": "Lab Test Name Resulted",
-                "codeid": 0,
-                "loinc_code": {
-                    "code": "82041-5",
-                    "code_system": "2.16.840.1.113883.6.1",
-                    "code_system_name": "LOINC",
-                    "display_name": "Weed Allerg Mix3 IgE Qn",
-                    "original_text": value,
-                },
-                "loinc_name_type": "Long Common Name",
-                "description": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
-                "loinc_type": "Order",
-                "s3": {
-                    "bucket": "dibbs-ttc",
-                    "key": "ingestion/loinc_lab_names_intfloat_e5-large-v2_20251008_00000.jsonl",
-                },
-                "search_score": 0.9563,
-                "reranker_score": 0.6789,
-                "opensearch_retrieved_scores": {
-                    "took": 234,
-                    "timed_out": False,
-                    "_shards": {"total": 1, "successful": 1, "failed": 0, "skipped": 0},
-                    "hits": {
-                        "total": {},
-                        "hits": [],
-                    },
-                },
-                "reranker_processed_results": {"results": []},
-                "cached_at": "2026-05-15T18:14:45.020655+00:00",
+            "cache_key": "test_cache_key",
+            "text": value,
+            "data_field": "Lab Test Name Resulted",
+            "codeid": 0,
+            "loinc_code": {
+                "code": "82041-5",
+                "code_system": "2.16.840.1.113883.6.1",
+                "code_system_name": "LOINC",
+                "display_name": "Weed Allerg Mix3 IgE Qn",
+                "original_text": value,
             },
+            "loinc_name_type": "Long Common Name",
+            "description": "Weed Allergen Mix 3 (Mugwort+Goosefoot or Lambs quarters+English plantain+Goldenrod+Nettle) IgE Ab [Measurement] in Serum",
+            "loinc_type": "Order",
+            "s3": {
+                "bucket": "dibbs-ttc",
+                "key": "ingestion/loinc_lab_names_intfloat_e5-large-v2_20251008_00000.jsonl",
+            },
+            "search_score": 0.9563,
+            "reranker_score": 0.6789,
+            "opensearch_retrieved_scores": {
+                "took": 234,
+                "timed_out": False,
+                "_shards": {"total": 1, "successful": 1, "failed": 0, "skipped": 0},
+                "hits": {
+                    "total": {},
+                    "hits": [],
+                },
+            },
+            "reranker_processed_results": {"results": []},
+            "cached_at": "2026-05-15T18:14:45.020655+00:00",
+        }
+
+    def build_response(*args, **kwargs) -> dict:  # noqa: ANN002, ANN003
+        return {"found": True, "_source": build_source(next(candidate_iter))}
+
+    def build_mget_response(*args, **kwargs) -> dict:  # noqa: ANN002, ANN003
+        body = kwargs.get("body") or (args[0] if args else {})
+        return {
+            "docs": [
+                {"_id": doc_id, "found": True, "_source": build_source(next(candidate_iter))}
+                for doc_id in body.get("ids", [])
+            ]
         }
 
     opensearch_client = MagicMock()
@@ -124,6 +132,7 @@ def mock_opensearch(request: pytest.FixtureRequest) -> Iterator[MagicMock]:
     }
 
     opensearch_client.get.side_effect = build_response
+    opensearch_client.mget.side_effect = build_mget_response
     with patch(
         "lambda_handler.create_opensearch_client",
         return_value=opensearch_client,

--- a/packages/lambda-handler/src/lambda_handler/lambda_handler.py
+++ b/packages/lambda-handler/src/lambda_handler/lambda_handler.py
@@ -5,6 +5,7 @@ import boto3
 from aws_lambda_powertools import Logger
 from aws_lambda_typing import events as lambda_events
 from botocore.client import BaseClient
+from botocore.config import Config
 from botocore.credentials import Credentials
 from botocore.exceptions import ClientError
 from opensearchpy import OpenSearch, RequestsHttpConnection
@@ -20,6 +21,16 @@ logger = Logger(service="lambda-handler", child=True)
 _cached_aws_auth: AWS4Auth | None = None
 _cached_s3_client: BaseClient | None = None
 _cached_opensearch_client: OpenSearch | None = None
+
+# Without explicit timeouts a stalled connection blocks until the Lambda
+# itself times out (up to 900s); bound each call well below that instead.
+_S3_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=60,
+    retries={"mode": "adaptive", "max_attempts": 3},
+)
+_OPENSEARCH_TIMEOUT_SECONDS = 30
+_OPENSEARCH_MAX_RETRIES = 2
 
 
 def reset_cached_clients() -> None:
@@ -84,6 +95,7 @@ def create_s3_client() -> BaseClient:
             "s3",
             endpoint_url=endpoint_url,
             region_name=region_name,
+            config=_S3_CLIENT_CONFIG,
         )
         logger.info("Created S3 client", status="success")
 
@@ -107,6 +119,9 @@ def create_opensearch_client() -> OpenSearch:
             use_ssl=True,
             verify_certs=True,
             connection_class=RequestsHttpConnection,
+            timeout=_OPENSEARCH_TIMEOUT_SECONDS,
+            max_retries=_OPENSEARCH_MAX_RETRIES,
+            retry_on_timeout=True,
         )
         logger.info("Created OpenSearch client", status="success")
 
@@ -129,17 +144,21 @@ def get_file_content_from_s3(bucket_name: str, object_key: str) -> str:
         status="processing",
     )
 
-    # Check if object exists
-    if not check_s3_object_exists(client, bucket_name, object_key):
-        logger.warning(
-            "S3 object not found",
-            bucket_name=bucket_name,
-            s3_key=object_key,
-            status="error",
-        )
-        raise FileNotFoundError(f"S3 object not found: {bucket_name}/{object_key}")
-
-    response = client.get_object(Bucket=bucket_name, Key=object_key)
+    try:
+        response = client.get_object(Bucket=bucket_name, Key=object_key)
+    except ClientError as e:
+        # GET reports a missing key as NoSuchKey (HEAD reports 404); a
+        # pre-flight existence check would double the round trips, so map
+        # the GET error to the same FileNotFoundError callers rely on.
+        if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
+            logger.warning(
+                "S3 object not found",
+                bucket_name=bucket_name,
+                s3_key=object_key,
+                status="error",
+            )
+            raise FileNotFoundError(f"S3 object not found: {bucket_name}/{object_key}") from e
+        raise
     logger.info(
         "Retrieved file content from S3",
         bucket_name=bucket_name,

--- a/packages/lambda-handler/src/lambda_handler/lambda_handler.py
+++ b/packages/lambda-handler/src/lambda_handler/lambda_handler.py
@@ -150,7 +150,7 @@ def get_file_content_from_s3(bucket_name: str, object_key: str) -> str:
         # GET reports a missing key as NoSuchKey (HEAD reports 404); a
         # pre-flight existence check would double the round trips, so map
         # the GET error to the same FileNotFoundError callers rely on.
-        if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
+        if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
             logger.warning(
                 "S3 object not found",
                 bucket_name=bucket_name,
@@ -158,6 +158,12 @@ def get_file_content_from_s3(bucket_name: str, object_key: str) -> str:
                 status="error",
             )
             raise FileNotFoundError(f"S3 object not found: {bucket_name}/{object_key}") from e
+        logger.error(
+            "Unexpected error while fetching file from S3",
+            bucket_name=bucket_name,
+            s3_key=object_key,
+            status="error",
+        )
         raise
     logger.info(
         "Retrieved file content from S3",

--- a/packages/lambda-handler/tests/test_lambda_handler.py
+++ b/packages/lambda-handler/tests/test_lambda_handler.py
@@ -66,6 +66,11 @@ class TestGetFileContentFromS3:
             lambda_handler.get_file_content_from_s3(mock_aws_setup.bucket_name, "nonexistent.txt")
         assert str(e.value) == f"S3 object not found: {mock_aws_setup.bucket_name}/nonexistent.txt"
 
+    def test_get_file_content_from_s3_propagates_unexpected_error(self, mock_aws_setup):
+        """A non-404 S3 error must propagate as-is, not be masked as FileNotFoundError."""
+        with pytest.raises(Exception, match="The specified bucket does not exist"):
+            lambda_handler.get_file_content_from_s3("nonexistent-bucket", "test.txt")
+
 
 class TestPutFile:
     def test_put_file(self, mock_aws_setup):

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -542,35 +542,41 @@ def _process_record_pipeline(  # noqa: PLR0912, PLR0915
         if cache_keys:
             cached_results = get_cached_results(opensearch_client, RESULT_CACHE_INDEX, cache_keys)
             for work in work_items:
-                if work.cache_key is None:
-                    continue
-                work.cached_result = cached_results.get(work.cache_key)
-                _record_cache_metric(
-                    HitValue.hit if work.cached_result is not None else HitValue.miss
-                )
+                if work.cache_key is not None:
+                    work.cached_result = cached_results.get(work.cache_key)
 
-        # Phase 3: embed all cache-miss candidates in one batched encode call.
-        miss_texts = [
-            work.selected_candidate.value
-            for work in work_items
-            if work.selected_candidate is not None and work.cached_result is None
-        ]
-        if miss_texts:
+        # Phase 3: embed the cache-miss candidates in one batched encode call.
+        # Errors that share a cache key share one resolution in phase 4, so
+        # only the first occurrence of each missing key is embedded.
+        cache_misses: list[_ErrorWork] = []
+        miss_texts: list[str] = []
+        seen_miss_keys: set[str] = set()
+        for work in work_items:
+            if work.selected_candidate is None or work.cached_result is not None:
+                continue
+            if work.cache_key is None or work.cache_key in seen_miss_keys:
+                continue
+            seen_miss_keys.add(work.cache_key)
+            cache_misses.append(work)
+            miss_texts.append(work.selected_candidate.value)
+        if cache_misses:
             logger.info(
                 "Embedding the relevant text strings for each error in the eICR",
                 status="processing",
             )
             embeddings = embed_batch(miss_texts)
-            cache_misses = [
-                work
-                for work in work_items
-                if work.selected_candidate is not None and work.cached_result is None
-            ]
             for work, vector in zip(cache_misses, embeddings, strict=True):
                 work.embedding = vector.tolist()
 
         # Phase 4: resolve each error — from the cache when hit, otherwise via
         # KNN search + rerank — and assemble details in the original error order.
+        # Duplicate candidates reuse the first occurrence's resolution, mirroring
+        # the sequential flow where later duplicates hit the cache entry written
+        # moments earlier — including in the cache metric, which counts a reused
+        # successful match as a hit.
+        resolved_misses: dict[
+            str, tuple[Code | None, str | None, OpenSearchResult, list[ScoredResult] | None]
+        ] = {}
         for work in work_items:
             error = work.error
             selected_candidate = work.selected_candidate
@@ -586,6 +592,7 @@ def _process_record_pipeline(  # noqa: PLR0912, PLR0915
             # just pull out the fields we want to use directly
             elif work.cached_result is not None:
                 logger.info("Cache hit, retrieving cached results", status="processing")
+                _record_cache_metric(HitValue.hit)
                 cached_result = work.cached_result
                 new_translation = cached_result.loinc_code
                 opensearch_retrieved_scores = cached_result.opensearch_retrieved_scores
@@ -594,23 +601,44 @@ def _process_record_pipeline(  # noqa: PLR0912, PLR0915
             # Cache miss, so run everything normally, and then finally store
             # the prediction in the cache for future use
             else:
-                if work.embedding is None:
-                    # Unreachable: phase 3 embeds every cache-miss candidate.
-                    raise ValueError(
-                        f"Missing embedding for cache-miss candidate: {selected_candidate.value}"
+                if work.cache_key is None:
+                    # Unreachable: phase 1 computes a key for every candidate.
+                    raise ValueError(f"Missing cache key for candidate: {selected_candidate.value}")
+                if work.cache_key in resolved_misses:
+                    (
+                        new_translation,
+                        unmatched_message,
+                        opensearch_retrieved_scores,
+                        ranked_results,
+                    ) = resolved_misses[work.cache_key]
+                    _record_cache_metric(
+                        HitValue.hit if new_translation is not None else HitValue.miss
                     )
-                (
-                    new_translation,
-                    unmatched_message,
-                    opensearch_retrieved_scores,
-                    ranked_results,
-                ) = _match_candidate(
-                    selected_candidate,
-                    work.embedding,
-                    error.field,
-                    work.cache_key,
-                    opensearch_client,
-                )
+                else:
+                    _record_cache_metric(HitValue.miss)
+                    if work.embedding is None:
+                        # Unreachable: phase 3 embeds every cache-miss candidate.
+                        raise ValueError(
+                            f"Missing embedding for cache-miss candidate: {selected_candidate.value}"
+                        )
+                    (
+                        new_translation,
+                        unmatched_message,
+                        opensearch_retrieved_scores,
+                        ranked_results,
+                    ) = _match_candidate(
+                        selected_candidate,
+                        work.embedding,
+                        error.field,
+                        work.cache_key,
+                        opensearch_client,
+                    )
+                    resolved_misses[work.cache_key] = (
+                        new_translation,
+                        unmatched_message,
+                        opensearch_retrieved_scores,
+                        ranked_results,
+                    )
 
             if new_translation is not None:
                 nonstandard_code_replacements.append(

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/lambda_function.py
@@ -1,5 +1,6 @@
 import json
 import os
+from dataclasses import dataclass
 from enum import StrEnum
 from io import BytesIO
 
@@ -10,22 +11,25 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from opensearchpy import OpenSearch
 
 import lambda_handler
+from lambda_handler.models import OpenSearchResult
 from shared_models import (
     LOINC_NAME,
     LOINC_OID,
     Code,
+    DataField,
     NonstandardCodeInstance,
     PassthroughReason,
     TTCAugmenterInput,
 )
-from text_to_code.models import OpenSearchResultCacheSource
+from text_to_code.models import Candidate, OpenSearchResultCacheSource
 from text_to_code.models import query as query_models
 from text_to_code.models.model_info import TTCModelInfo
+from text_to_code.models.schematron import SchematronErrorDetail
 from text_to_code.services import eicr_processor, evaluator, schematron_processor
-from text_to_code.services.embedder import RETRIEVER_MODEL_INFO, embed
+from text_to_code.services.embedder import RETRIEVER_MODEL_INFO, embed_batch
 from text_to_code.services.query import QueryBuilder
 from text_to_code.services.reranker import RERANKER_MODEL_INFO, ScoredResult, rerank
-from text_to_code.services.result_cache import get_cached_result, put_new_cached_result
+from text_to_code.services.result_cache import get_cached_results, put_new_cached_result
 from text_to_code.services.utils import compute_cache_key
 
 from .models.metadata import Metadata, TTCSchematronIssueDetail
@@ -388,7 +392,100 @@ def _record_cache_metric(hit_value: HitValue) -> None:
         metric.add_dimension(name="lastLoincUpdate", value="02-23-2026")
 
 
-def _process_record_pipeline(  # noqa: PLR0915
+@dataclass
+class _ErrorWork:
+    """Per-schematron-error state threaded through the pipeline's batched phases."""
+
+    error: SchematronErrorDetail
+    selected_candidate: Candidate | None
+    cache_key: str | None = None
+    cached_result: OpenSearchResultCacheSource | None = None
+    embedding: list[float] | None = None
+
+
+def _match_candidate(
+    selected_candidate: Candidate,
+    embedding: list[float],
+    data_field: DataField,
+    cache_key: str | None,
+    opensearch_client: OpenSearch,
+) -> tuple[Code | None, str | None, OpenSearchResult, list[ScoredResult] | None]:
+    """Match a cache-miss candidate against OpenSearch and rerank the hits.
+
+    Runs the KNN query with the candidate's precomputed embedding, reranks the
+    hits, and writes a successful match back to the result cache.
+
+    :param selected_candidate: The candidate selected for the schematron error.
+    :param embedding: The candidate's precomputed embedding vector.
+    :param data_field: The data field associated with the error.
+    :param cache_key: The precomputed result-cache key for the candidate.
+    :param opensearch_client: The OpenSearch client.
+    :return: A ``(new_translation, unmatched_message, opensearch_retrieved_scores,
+      ranked_results)`` tuple; ``new_translation`` is None when no match was made.
+    """
+    new_translation = None
+    unmatched_message = None
+    ranked_results: list[ScoredResult] | None = None
+
+    vector_parameters = query_models.VectorSearchParams(vector=embedding, data_field=data_field)
+
+    logger.info(
+        "Querying OpenSearch with the relevant text strings and retrieving code suggestions",
+        status="processing",
+    )
+    query = QueryBuilder().with_vector_search(vector_parameters).build()
+
+    opensearch_retrieved_scores = lambda_handler.retrieve_opensearch_results(
+        query=query, index=OPENSEARCH_INDEX, opensearch_client=opensearch_client
+    )
+
+    # The OpenSearch results object has a couple levels of nesting,
+    # but all we care about for reranking is extracting the actual
+    # text strings of the ANN LOINC codes
+    results_list = opensearch_retrieved_scores.hits.hits
+    if results_list:
+        retrieved_loinc_names = [hit.source.description for hit in results_list]
+        ranked_results = rerank(selected_candidate.value, retrieved_loinc_names)
+
+        if ranked_results:
+            top_result = next(
+                (
+                    x
+                    for x in results_list
+                    if x.source.description == ranked_results[0]["code_string"]
+                ),
+            )
+            new_translation = Code(
+                code=top_result.source.loinc_code,
+                code_system=LOINC_OID,
+                code_system_name=LOINC_NAME,
+                display_name=top_result.source.description,
+                original_text=selected_candidate.value,
+            )
+
+            # Make sure we save the results of a successful standardization
+            # into the results cache for future use
+            put_new_cached_result(
+                opensearch_client,
+                RESULT_CACHE_INDEX,
+                selected_candidate.value,
+                data_field,
+                new_translation,
+                top_result.score,
+                ranked_results[0]["score"],
+                opensearch_retrieved_scores,
+                ranked_results,
+                cache_key=cache_key,
+            )
+        else:
+            unmatched_message = "Reranker did not return any results."
+    else:
+        unmatched_message = "Opensearch query returned no hits."
+
+    return new_translation, unmatched_message, opensearch_retrieved_scores, ranked_results
+
+
+def _process_record_pipeline(  # noqa: PLR0912, PLR0915
     persistence_id: str,
     opensearch_client: OpenSearch,
     bucket_name: str,
@@ -422,123 +519,107 @@ def _process_record_pipeline(  # noqa: PLR0915
     if schematron_data_fields:
         ttc_schematron_issues_details: list[TTCSchematronIssueDetail] = []
         passthrough_reason: PassthroughReason | None = None
-        for error in schematron_data_fields:
-            new_translation = None
-            unmatched_message = None
-            data_field = error.field
-            opensearch_retrieved_scores = None
-            ranked_results: list[ScoredResult] | None = None
 
-            text_candidates = processor.get_text_candidates(error.error_context, data_field)
+        # Phase 1: extract and select a candidate per error (CPU only).
+        work_items: list[_ErrorWork] = []
+        for error in schematron_data_fields:
+            text_candidates = processor.get_text_candidates(error.error_context, error.field)
 
             logger.info(
                 "Evaluating candidates and selecting relevant text for each error in the eICR",
                 status="processing",
             )
 
-            selected_candidate = evaluator.select_relevant_text(text_candidates, data_field)
-
+            selected_candidate = evaluator.select_relevant_text(text_candidates, error.field)
+            work = _ErrorWork(error=error, selected_candidate=selected_candidate)
             if selected_candidate:
-                # Before we run the full embedding, searching, and reranking process,
-                # first let's check if we've seen this nonstandard input before
-                cache_key = compute_cache_key(selected_candidate.value, data_field)
-                cached_result: OpenSearchResultCacheSource | None = get_cached_result(
-                    opensearch_client, RESULT_CACHE_INDEX, os_doc_id=cache_key
+                work.cache_key = compute_cache_key(selected_candidate.value, error.field)
+            work_items.append(work)
+
+        # Phase 2: before we run the full embedding, searching, and reranking
+        # process, check all candidates against the result cache in one mget.
+        cache_keys = [work.cache_key for work in work_items if work.cache_key is not None]
+        if cache_keys:
+            cached_results = get_cached_results(opensearch_client, RESULT_CACHE_INDEX, cache_keys)
+            for work in work_items:
+                if work.cache_key is None:
+                    continue
+                work.cached_result = cached_results.get(work.cache_key)
+                _record_cache_metric(
+                    HitValue.hit if work.cached_result is not None else HitValue.miss
                 )
 
-                # We've got a hit--no need to run our usual processes, we'll
-                # just pull out the fields we want to use directly
-                if cached_result is not None:
-                    logger.info("Cache hit, retrieving cached results", status="processing")
-                    _record_cache_metric(HitValue.hit)
-                    new_translation = cached_result.loinc_code
-                    nonstandard_code_replacements.append(
-                        NonstandardCodeInstance(
-                            schematron_error_xpath=error.error_context,
-                            field_type=error.field,
-                            new_translation=new_translation,
-                        ),
-                    )
-                    opensearch_retrieved_scores = cached_result.opensearch_retrieved_scores
-                    results_list = opensearch_retrieved_scores.hits.hits
-                    ranked_results = cached_result.reranker_processed_results["results"]
+        # Phase 3: embed all cache-miss candidates in one batched encode call.
+        miss_texts = [
+            work.selected_candidate.value
+            for work in work_items
+            if work.selected_candidate is not None and work.cached_result is None
+        ]
+        if miss_texts:
+            logger.info(
+                "Embedding the relevant text strings for each error in the eICR",
+                status="processing",
+            )
+            embeddings = embed_batch(miss_texts)
+            cache_misses = [
+                work
+                for work in work_items
+                if work.selected_candidate is not None and work.cached_result is None
+            ]
+            for work, vector in zip(cache_misses, embeddings, strict=True):
+                work.embedding = vector.tolist()
 
-                # Cache miss, so log that, run everything normally, and then finally store
-                # the prediction in the cache for future use
-                else:
-                    logger.info(
-                        "Embedding the relevant text strings for each error in the eICR",
-                        status="processing",
-                    )
-                    _record_cache_metric(HitValue.miss)
+        # Phase 4: resolve each error — from the cache when hit, otherwise via
+        # KNN search + rerank — and assemble details in the original error order.
+        for work in work_items:
+            error = work.error
+            selected_candidate = work.selected_candidate
+            new_translation = None
+            unmatched_message = None
+            opensearch_retrieved_scores = None
+            ranked_results: list[ScoredResult] | None = None
 
-                    vector_embedding = embed(selected_candidate.value)
-
-                    vector_parameters = query_models.VectorSearchParams(
-                        vector=vector_embedding.tolist(), data_field=data_field
-                    )
-
-                    logger.info(
-                        "Querying OpenSearch with the relevant text strings and retrieving code suggestions",
-                        status="processing",
-                    )
-                    query = QueryBuilder().with_vector_search(vector_parameters).build()
-
-                    opensearch_retrieved_scores = lambda_handler.retrieve_opensearch_results(
-                        query=query, index=OPENSEARCH_INDEX, opensearch_client=opensearch_client
-                    )
-
-                    # The OpenSearch results object has a couple levels of nesting,
-                    # but all we care about for reranking is extracting the actual
-                    # text strings of the ANN LOINC codes
-                    results_list = opensearch_retrieved_scores.hits.hits
-                    if results_list:
-                        retrieved_loinc_names = [hit.source.description for hit in results_list]
-                        ranked_results = rerank(selected_candidate.value, retrieved_loinc_names)
-
-                        if ranked_results:
-                            top_result = next(
-                                (
-                                    x
-                                    for x in results_list
-                                    if x.source.description == ranked_results[0]["code_string"]
-                                ),
-                            )
-                            new_translation = Code(
-                                code=top_result.source.loinc_code,
-                                code_system=LOINC_OID,
-                                code_system_name=LOINC_NAME,
-                                display_name=top_result.source.description,
-                                original_text=selected_candidate.value,
-                            )
-                            nonstandard_code_replacements.append(
-                                NonstandardCodeInstance(
-                                    schematron_error_xpath=error.error_context,
-                                    field_type=error.field,
-                                    new_translation=new_translation,
-                                ),
-                            )
-
-                            # Make sure we save the results of a successful standardization
-                            # into the results cache for future use
-                            put_new_cached_result(
-                                opensearch_client,
-                                RESULT_CACHE_INDEX,
-                                selected_candidate.value,
-                                data_field,
-                                new_translation,
-                                top_result.score,
-                                ranked_results[0]["score"],
-                                opensearch_retrieved_scores,
-                                ranked_results,
-                            )
-                        else:
-                            unmatched_message = "Reranker did not return any results."
-                    else:
-                        unmatched_message = "Opensearch query returned no hits."
-
-            else:
+            if selected_candidate is None:
                 unmatched_message = "No candidate found."
+
+            # We've got a hit--no need to run our usual processes, we'll
+            # just pull out the fields we want to use directly
+            elif work.cached_result is not None:
+                logger.info("Cache hit, retrieving cached results", status="processing")
+                cached_result = work.cached_result
+                new_translation = cached_result.loinc_code
+                opensearch_retrieved_scores = cached_result.opensearch_retrieved_scores
+                ranked_results = cached_result.reranker_processed_results["results"]
+
+            # Cache miss, so run everything normally, and then finally store
+            # the prediction in the cache for future use
+            else:
+                if work.embedding is None:
+                    # Unreachable: phase 3 embeds every cache-miss candidate.
+                    raise ValueError(
+                        f"Missing embedding for cache-miss candidate: {selected_candidate.value}"
+                    )
+                (
+                    new_translation,
+                    unmatched_message,
+                    opensearch_retrieved_scores,
+                    ranked_results,
+                ) = _match_candidate(
+                    selected_candidate,
+                    work.embedding,
+                    error.field,
+                    work.cache_key,
+                    opensearch_client,
+                )
+
+            if new_translation is not None:
+                nonstandard_code_replacements.append(
+                    NonstandardCodeInstance(
+                        schematron_error_xpath=error.error_context,
+                        field_type=error.field,
+                        new_translation=new_translation,
+                    ),
+                )
 
             ttc_schematron_issues_details.append(
                 TTCSchematronIssueDetail(

--- a/packages/text-to-code-lambda/src/text_to_code_lambda/service.py
+++ b/packages/text-to-code-lambda/src/text_to_code_lambda/service.py
@@ -18,7 +18,7 @@ from opensearchpy import OpenSearch
 import lambda_handler
 from shared_models import LOINC_NAME, LOINC_OID, Code, DataField
 from text_to_code.models import query as query_models
-from text_to_code.services.embedder import embed
+from text_to_code.services.embedder import embed, embed_batch
 from text_to_code.services.query import QueryBuilder
 from text_to_code.services.reranker import rerank
 
@@ -57,6 +57,8 @@ def code_for_text(
     data_field: DataField,
     opensearch_client: OpenSearch,
     index: str = OPENSEARCH_INDEX,
+    *,
+    embedding: list[float] | None = None,
 ) -> Code | None:
     """Map a single raw text string to its best LOINC ``Code``.
 
@@ -69,12 +71,13 @@ def code_for_text(
     :param data_field: The data field that determines the LOINC type filter.
     :param opensearch_client: An OpenSearch client used for the KNN query.
     :param index: The OpenSearch index to query.
+    :param embedding: A precomputed embedding for ``text`` (from a batched encode);
+      computed on the fly when omitted.
     :return: The top-ranked LOINC ``Code``, or ``None`` when there is no match.
     """
-    vector_embedding = embed(text)
-    vector_parameters = query_models.VectorSearchParams(
-        vector=vector_embedding.tolist(), data_field=data_field
-    )
+    if embedding is None:
+        embedding = embed(text).tolist()
+    vector_parameters = query_models.VectorSearchParams(vector=embedding, data_field=data_field)
     query = QueryBuilder().with_vector_search(vector_parameters).build()
 
     opensearch_results = lambda_handler.retrieve_opensearch_results(
@@ -133,8 +136,8 @@ def results_for_inputs(
     """Run a batch of inputs through TTC, preserving input order.
 
     Blank/whitespace-only inputs are returned as unmatched without querying.
-    Embedding is currently per-input; it can be batched later if the Testing CSV
-    grows large.
+    All non-blank inputs are embedded in a single batched encode call before
+    the per-input search and rerank.
 
     :param inputs: The raw clinical text strings to standardize.
     :param data_field: The data field that determines the LOINC type filter.
@@ -142,10 +145,15 @@ def results_for_inputs(
     :param index: The OpenSearch index to query.
     :return: One result dict per input, in the same order.
     """
-    results: list[dict] = []
-    for text in inputs:
-        if not text or not text.strip():
-            results.append(_to_result(text, None))
-            continue
-        results.append(_to_result(text, code_for_text(text, data_field, opensearch_client, index)))
+    results: list[dict] = [_to_result(text, None) for text in inputs]
+    pending = [(i, text) for i, text in enumerate(inputs) if text and text.strip()]
+    if not pending:
+        return results
+
+    embeddings = embed_batch([text for _, text in pending])
+    for (i, text), vector in zip(pending, embeddings, strict=True):
+        results[i] = _to_result(
+            text,
+            code_for_text(text, data_field, opensearch_client, index, embedding=vector.tolist()),
+        )
     return results

--- a/packages/text-to-code-lambda/tests/test_lambda_function.py
+++ b/packages/text-to-code-lambda/tests/test_lambda_function.py
@@ -13,9 +13,11 @@ from lambda_handler.models import (
     OpenSearchResult,
     OpenSearchShards,
 )
-from shared_models import Code
+from shared_models import Code, DataField
 from text_to_code.models import Candidate, LabXPaths, OpenSearchResultCacheSource
+from text_to_code.models.schematron import SchematronErrorDetail
 from text_to_code.services.reranker import ScoredResult
+from text_to_code.services.utils import compute_cache_key
 from text_to_code_lambda import lambda_function
 
 S3_BUCKET = os.environ["S3_BUCKET"]
@@ -88,8 +90,9 @@ class TestHandler:
     ):
         """Test handler with no failures when the result cache misses."""
         # We can directly mock the result cache's return value, since we're
-        # testing the lambda's logic, not the result cache's
-        mocker.patch("text_to_code_lambda.lambda_function.get_cached_result", return_value=None)
+        # testing the lambda's logic, not the result cache's. An empty dict
+        # means every cache key misses.
+        mocker.patch("text_to_code_lambda.lambda_function.get_cached_results", return_value={})
 
         ranked_results: list[ScoredResult] = [
             {"code_string": "Weed Allerg Mix3 IgE Qn", "score": 0.7127664685249329},
@@ -187,25 +190,27 @@ class TestHandler:
             took=57,
         )
 
-        mocker.patch(
-            "text_to_code_lambda.lambda_function.get_cached_result",
-            return_value=OpenSearchResultCacheSource(
-                cache_key="1357924680",
-                text=" A custom code in display name ",
-                data_field="Lab Test Name Ordered",
-                loinc_code=Code(
-                    code="82041-5",
-                    code_system="2.16.840.1.113883.6.1",
-                    code_system_name="LOINC",
-                    display_name="Weed Allerg Mix3 IgE Qn",
-                    original_text="A custom code in display name.",
-                ),
-                search_score=0.88,
-                reranker_score=0.7127664685249329,
-                opensearch_retrieved_scores=opensearch_retrieved_scores,
-                reranker_processed_results={"results": ranked_results},
-                cached_at=datetime.fromisoformat("2026-05-15T18:14:45.020655+00:00"),
+        cached_source = OpenSearchResultCacheSource(
+            cache_key="1357924680",
+            text=" A custom code in display name ",
+            data_field="Lab Test Name Ordered",
+            loinc_code=Code(
+                code="82041-5",
+                code_system="2.16.840.1.113883.6.1",
+                code_system_name="LOINC",
+                display_name="Weed Allerg Mix3 IgE Qn",
+                original_text="A custom code in display name.",
             ),
+            search_score=0.88,
+            reranker_score=0.7127664685249329,
+            opensearch_retrieved_scores=opensearch_retrieved_scores,
+            reranker_processed_results={"results": ranked_results},
+            cached_at=datetime.fromisoformat("2026-05-15T18:14:45.020655+00:00"),
+        )
+
+        mocker.patch(
+            "text_to_code_lambda.lambda_function.get_cached_results",
+            side_effect=lambda client, index, keys: dict.fromkeys(keys, cached_source),
         )
 
         resp = lambda_function.handler(example_sqs_event, mock_lambda_context)
@@ -561,7 +566,7 @@ class TestHandler:
             return_value=None,
         )
 
-        retriever_embed_mock = mocker.patch.object(lambda_function, "embed")
+        retriever_embed_mock = mocker.patch.object(lambda_function, "embed_batch")
         reranker_mock = mocker.patch.object(
             lambda_function,
             "rerank",
@@ -620,7 +625,7 @@ class TestHandler:
         )
 
         # Just bypass the cache here to test the desired functionality
-        mocker.patch("text_to_code_lambda.lambda_function.get_cached_result", return_value=None)
+        mocker.patch("text_to_code_lambda.lambda_function.get_cached_results", return_value={})
 
         mocker.patch(
             "text_to_code_lambda.lambda_function.lambda_handler.retrieve_opensearch_results",
@@ -655,6 +660,105 @@ class TestHandler:
             f"{TTC_METADATA_PREFIX}{mock_aws_setup.persistence_id.removesuffix('.xml')}.json"
         )
         snapshot.assert_match(ttc_metadata_output, "no_opensearch_hits_none_metadata_output.json")
+
+    def test_pipeline_batches_cache_lookups_and_embeddings_across_errors(
+        self,
+        mock_aws_setup,
+        mock_opensearch,
+        mocker,
+    ):
+        """Multiple errors share one mget and one batched encode covering only the misses."""
+        errors = [
+            SchematronErrorDetail(
+                field=DataField.LAB_TEST_NAME_ORDERED,
+                error="error-one",
+                error_message="first error",
+                error_context="/ClinicalDocument[1]/observation[1]",
+            ),
+            SchematronErrorDetail(
+                field=DataField.LAB_TEST_NAME_ORDERED,
+                error="error-two",
+                error_message="second error",
+                error_context="/ClinicalDocument[1]/observation[2]",
+            ),
+        ]
+        candidates = [
+            Candidate(value="cached input", xpath=LabXPaths.CODE_DISPLAY_NAME),
+            Candidate(value="uncached input", xpath=LabXPaths.CODE_DISPLAY_NAME),
+        ]
+        hit_key = compute_cache_key(candidates[0].value, DataField.LAB_TEST_NAME_ORDERED)
+        miss_key = compute_cache_key(candidates[1].value, DataField.LAB_TEST_NAME_ORDERED)
+
+        mocker.patch(
+            "text_to_code_lambda.lambda_function._load_original_eicr",
+            return_value="<ClinicalDocument />",
+        )
+        mocker.patch(
+            "text_to_code_lambda.lambda_function._load_schematron_data_fields",
+            return_value=errors,
+        )
+        mocker.patch(
+            "text_to_code_lambda.lambda_function.evaluator.select_relevant_text",
+            side_effect=candidates,
+        )
+
+        cached_source = mocker.MagicMock()
+        cached_source.loinc_code = Code(
+            code="82041-5",
+            code_system="2.16.840.1.113883.6.1",
+            code_system_name="LOINC",
+            display_name="Weed Allerg Mix3 IgE Qn",
+            original_text="cached input",
+        )
+        cached_source.reranker_processed_results = {"results": []}
+        cached_source.opensearch_retrieved_scores = OpenSearchResult(
+            took=1,
+            timed_out=False,
+            _shards=OpenSearchShards(total=1, successful=1, skipped=0, failed=0),
+            hits=OpenSearchHits(total={}, hits=[]),
+        )
+        get_cached_results_mock = mocker.patch(
+            "text_to_code_lambda.lambda_function.get_cached_results",
+            return_value={hit_key: cached_source, miss_key: None},
+        )
+
+        embed_batch_mock = mocker.patch.object(lambda_function, "embed_batch")
+        embed_batch_mock.return_value = [mocker.MagicMock(tolist=lambda: [0.1, 0.2])]
+
+        ranked_results: list[ScoredResult] = [
+            {"code_string": "Weed Allerg Mix3 IgE Qn", "score": 0.7}
+        ]
+        mocker.patch("text_to_code_lambda.lambda_function.rerank", return_value=ranked_results)
+        put_cached_mock = mocker.patch("text_to_code_lambda.lambda_function.put_new_cached_result")
+        metric_mock = mocker.patch("text_to_code_lambda.lambda_function._record_cache_metric")
+        mocker.patch("text_to_code_lambda.lambda_function._save_outputs")
+
+        ttc_output = lambda_function._process_record_pipeline(
+            "persistence-id", mock_opensearch, S3_BUCKET
+        )
+
+        # One mget covering both keys, in error order.
+        get_cached_results_mock.assert_called_once()
+        assert get_cached_results_mock.call_args.args[2] == [hit_key, miss_key]
+
+        # One batched encode covering only the cache miss.
+        embed_batch_mock.assert_called_once_with(["uncached input"])
+
+        # One metric per error, hit before miss.
+        assert [call.args[0] for call in metric_mock.call_args_list] == [
+            lambda_function.HitValue.hit,
+            lambda_function.HitValue.miss,
+        ]
+
+        # The miss's match was written back to the cache with its precomputed key.
+        put_cached_mock.assert_called_once()
+        assert put_cached_mock.call_args.kwargs["cache_key"] == miss_key
+
+        # Both errors produced translations, in the original error order.
+        assert [c.schematron_error_xpath for c in ttc_output.nonstandard_codes] == [
+            "/ClinicalDocument[1]/observation[1]",
+            "/ClinicalDocument[1]/observation[2]",
+        ]
 
     def test_handler_malformed_eicr_with_no_schematron_issues(
         self,
@@ -699,7 +803,7 @@ class TestHandler:
     ):
 
         # Bypass the cache to force us down the reranker path so this test makes sense
-        mocker.patch("text_to_code_lambda.lambda_function.get_cached_result", return_value=None)
+        mocker.patch("text_to_code_lambda.lambda_function.get_cached_results", return_value={})
 
         mocker.patch(
             "text_to_code_lambda.lambda_function.rerank",

--- a/packages/text-to-code-lambda/tests/test_lambda_function.py
+++ b/packages/text-to-code-lambda/tests/test_lambda_function.py
@@ -760,6 +760,81 @@ class TestHandler:
             "/ClinicalDocument[1]/observation[2]",
         ]
 
+    def test_pipeline_reuses_resolution_for_duplicate_candidates(
+        self,
+        mock_aws_setup,
+        mock_opensearch,
+        mocker,
+    ):
+        """Errors sharing a candidate embed, search, and cache-write once.
+
+        Mirrors the old sequential loop, where the second occurrence hit the
+        cache entry the first occurrence had just written.
+        """
+        errors = [
+            SchematronErrorDetail(
+                field=DataField.LAB_TEST_NAME_ORDERED,
+                error="error-one",
+                error_message="first error",
+                error_context="/ClinicalDocument[1]/observation[1]",
+            ),
+            SchematronErrorDetail(
+                field=DataField.LAB_TEST_NAME_ORDERED,
+                error="error-two",
+                error_message="second error",
+                error_context="/ClinicalDocument[1]/observation[2]",
+            ),
+        ]
+        candidate = Candidate(value="repeated input", xpath=LabXPaths.CODE_DISPLAY_NAME)
+
+        mocker.patch(
+            "text_to_code_lambda.lambda_function._load_original_eicr",
+            return_value="<ClinicalDocument />",
+        )
+        mocker.patch(
+            "text_to_code_lambda.lambda_function._load_schematron_data_fields",
+            return_value=errors,
+        )
+        mocker.patch(
+            "text_to_code_lambda.lambda_function.evaluator.select_relevant_text",
+            side_effect=[candidate, candidate],
+        )
+        mocker.patch("text_to_code_lambda.lambda_function.get_cached_results", return_value={})
+
+        embed_batch_mock = mocker.patch.object(lambda_function, "embed_batch")
+        embed_batch_mock.return_value = [mocker.MagicMock(tolist=lambda: [0.1, 0.2])]
+
+        ranked_results: list[ScoredResult] = [
+            {"code_string": "Weed Allerg Mix3 IgE Qn", "score": 0.7}
+        ]
+        rerank_mock = mocker.patch(
+            "text_to_code_lambda.lambda_function.rerank", return_value=ranked_results
+        )
+        put_cached_mock = mocker.patch("text_to_code_lambda.lambda_function.put_new_cached_result")
+        metric_mock = mocker.patch("text_to_code_lambda.lambda_function._record_cache_metric")
+        mocker.patch("text_to_code_lambda.lambda_function._save_outputs")
+
+        ttc_output = lambda_function._process_record_pipeline(
+            "persistence-id", mock_opensearch, S3_BUCKET
+        )
+
+        # The duplicate is embedded, searched, and cache-written exactly once.
+        embed_batch_mock.assert_called_once_with(["repeated input"])
+        rerank_mock.assert_called_once()
+        put_cached_mock.assert_called_once()
+
+        # First occurrence is a miss; the reused successful match counts as a hit.
+        assert [call.args[0] for call in metric_mock.call_args_list] == [
+            lambda_function.HitValue.miss,
+            lambda_function.HitValue.hit,
+        ]
+
+        # Both errors still produce translations, in the original error order.
+        assert [c.schematron_error_xpath for c in ttc_output.nonstandard_codes] == [
+            "/ClinicalDocument[1]/observation[1]",
+            "/ClinicalDocument[1]/observation[2]",
+        ]
+
     def test_handler_malformed_eicr_with_no_schematron_issues(
         self,
         example_sqs_event,

--- a/packages/text-to-code-lambda/tests/test_service.py
+++ b/packages/text-to-code-lambda/tests/test_service.py
@@ -39,6 +39,11 @@ def stub_embed(mocker):
     mocker.patch.object(
         service, "embed", return_value=SimpleNamespace(tolist=lambda: [0.1, 0.2, 0.3])
     )
+    mocker.patch.object(
+        service,
+        "embed_batch",
+        side_effect=lambda texts: [SimpleNamespace(tolist=lambda: [0.1, 0.2, 0.3]) for _ in texts],
+    )
 
 
 def test_code_for_text_returns_top_reranked_code(mocker):

--- a/packages/text-to-code/src/text_to_code/services/eicr_processor.py
+++ b/packages/text-to-code/src/text_to_code/services/eicr_processor.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 from lxml import etree
@@ -10,19 +11,15 @@ from text_to_code.services.utils import get_config_for_data_field
 
 logger = logging.getLogger(__name__)
 
-# The sub-xpaths are static config values evaluated once per matched context
-# node, so compile them once at import instead of on every .xpath() call.
-_SUB_XPATH_EVALUATORS: dict[str, etree.XPath] = {
-    xp.value: etree.XPath(xp.value) for xp in LabXPaths
-}
 
-
+@functools.cache
 def _sub_xpath_evaluator(sub_xpath: str) -> etree.XPath:
-    evaluator = _SUB_XPATH_EVALUATORS.get(sub_xpath)
-    if evaluator is None:
-        evaluator = etree.XPath(sub_xpath)
-        _SUB_XPATH_EVALUATORS[sub_xpath] = evaluator
-    return evaluator
+    """Compile the evaluator for a static sub-xpath config value, once per process.
+
+    :param sub_xpath: The sub-xpath expression to compile.
+    :returns: The compiled XPath evaluator.
+    """
+    return etree.XPath(sub_xpath)
 
 
 class EicrProcessor:
@@ -75,6 +72,14 @@ class EicrProcessor:
             return candidates
 
         for node in nodes:
+            if not isinstance(node, etree._Element):
+                # The base xpath can select attribute or text nodes (lxml smart
+                # strings), which cannot anchor a relative sub-xpath — calling
+                # the evaluator on one raises TypeError, not XPathError. The old
+                # absolute-path evaluation returned no matches here, so count
+                # each sub-xpath as candidate-less and move on.
+                no_candidate_count += len(sub_xpaths)
+                continue
             for sub_xpath in sub_xpaths:
                 # Absolute path kept only for error-log payloads; extraction
                 # evaluates the sub-xpath relative to the matched node.

--- a/packages/text-to-code/src/text_to_code/services/eicr_processor.py
+++ b/packages/text-to-code/src/text_to_code/services/eicr_processor.py
@@ -10,6 +10,20 @@ from text_to_code.services.utils import get_config_for_data_field
 
 logger = logging.getLogger(__name__)
 
+# The sub-xpaths are static config values evaluated once per matched context
+# node, so compile them once at import instead of on every .xpath() call.
+_SUB_XPATH_EVALUATORS: dict[str, etree.XPath] = {
+    xp.value: etree.XPath(xp.value) for xp in LabXPaths
+}
+
+
+def _sub_xpath_evaluator(sub_xpath: str) -> etree.XPath:
+    evaluator = _SUB_XPATH_EVALUATORS.get(sub_xpath)
+    if evaluator is None:
+        evaluator = etree.XPath(sub_xpath)
+        _SUB_XPATH_EVALUATORS[sub_xpath] = evaluator
+    return evaluator
+
 
 class EicrProcessor:
     """Processes an eICR."""
@@ -60,12 +74,14 @@ class EicrProcessor:
             )
             return candidates
 
-        for _ in nodes:
+        for node in nodes:
             for sub_xpath in sub_xpaths:
+                # Absolute path kept only for error-log payloads; extraction
+                # evaluates the sub-xpath relative to the matched node.
                 full_xpath = f"{base_xpath}/{sub_xpath}"
 
                 try:
-                    sub_nodes = self._get_by_xpath(full_xpath)
+                    sub_nodes = _sub_xpath_evaluator(sub_xpath)(node)
                 except etree.XPathError:
                     extraction_error_count += 1
                     self._log_text_candidate_extraction_error(

--- a/packages/text-to-code/src/text_to_code/services/embedder.py
+++ b/packages/text-to-code/src/text_to_code/services/embedder.py
@@ -26,3 +26,20 @@ def embed(text: str) -> Tensor:
         extra={"status": "processing"},
     )
     return _RETRIEVER.encode(text)
+
+
+def embed_batch(texts: list[str]) -> Tensor:
+    """Encode a batch of text strings into vector representations.
+
+    A single batched forward pass amortizes far better than repeated
+    single-string calls, so callers with several texts should prefer this
+    over calling :func:`embed` in a loop.
+
+    :param texts: Text strings to embed.
+    :returns: Tensor of one embedding row per input text, in input order.
+    """
+    logger.info(
+        "Embedding a batch of text strings.",
+        extra={"status": "processing", "batch_size": len(texts)},
+    )
+    return _RETRIEVER.encode(texts)

--- a/packages/text-to-code/src/text_to_code/services/embedder.py
+++ b/packages/text-to-code/src/text_to_code/services/embedder.py
@@ -1,5 +1,6 @@
 import logging
 
+import numpy as np
 from sentence_transformers import SentenceTransformer
 from torch import Tensor
 
@@ -28,7 +29,7 @@ def embed(text: str) -> Tensor:
     return _RETRIEVER.encode(text)
 
 
-def embed_batch(texts: list[str]) -> Tensor:
+def embed_batch(texts: list[str]) -> np.ndarray:
     """Encode a batch of text strings into vector representations.
 
     A single batched forward pass amortizes far better than repeated
@@ -36,7 +37,7 @@ def embed_batch(texts: list[str]) -> Tensor:
     over calling :func:`embed` in a loop.
 
     :param texts: Text strings to embed.
-    :returns: Tensor of one embedding row per input text, in input order.
+    :returns: Array of one embedding row per input text, in input order.
     """
     logger.info(
         "Embedding a batch of text strings.",

--- a/packages/text-to-code/src/text_to_code/services/evaluator.py
+++ b/packages/text-to-code/src/text_to_code/services/evaluator.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 from shared_models import DataField
@@ -125,11 +126,15 @@ def select_relevant_text(candidates: list[Candidate], field_type: DataField) -> 
     return None
 
 
+@functools.cache
 def _get_evaluation_criteria_for_data_field(data_field: DataField) -> BaseEvaluationCriteria:
-    """Retrieve a fresh evaluation criteria instance for the specified DataField.
+    """Retrieve the evaluation criteria instance for the specified DataField.
+
+    The returned instance is a cached frozen model shared across calls —
+    callers must not mutate its list fields.
 
     :param data_field: The data field being evaluated within the TTC module.
-    :returns: A new evaluation criteria instance for the specified DataField.
+    :returns: The evaluation criteria instance for the specified DataField.
     """
     try:
         cls = EVALUATION_REGISTRY[data_field]

--- a/packages/text-to-code/src/text_to_code/services/result_cache.py
+++ b/packages/text-to-code/src/text_to_code/services/result_cache.py
@@ -12,6 +12,65 @@ from text_to_code.models.result_cache import OpenSearchResultCacheSource
 from text_to_code.services.utils import compute_cache_key
 
 
+def _parse_cache_source(response_source: dict) -> OpenSearchResultCacheSource:
+    """Parse a cache document's ``_source`` body into a structured object.
+
+    :param response_source: The ``_source`` dictionary from an OpenSearch GET or
+      mget document response.
+    :returns: The Source of the OpenSearch Cache Result, expressed as a structured
+      object.
+    """
+    response_loinc = response_source["loinc_code"]
+    opensearch_results = response_source["opensearch_retrieved_scores"]
+
+    opensearch_retrieved_scores = OpenSearchResult(
+        took=opensearch_results["took"],
+        timed_out=opensearch_results["timed_out"],
+        _shards=OpenSearchShards(
+            total=opensearch_results["_shards"]["total"],
+            successful=opensearch_results["_shards"]["successful"],
+            skipped=opensearch_results["_shards"]["skipped"],
+            failed=opensearch_results["_shards"]["failed"],
+        ),
+        hits=OpenSearchHits(
+            total=opensearch_results["hits"]["total"],
+            hits=[
+                OpenSearchHit(
+                    _index=hit["_index"],
+                    _id=hit["_id"],
+                    _score=hit["_score"],
+                    _source=OpenSearchHitSource(
+                        id=hit["_source"]["id"],
+                        loinc_code=hit["_source"]["loinc_code"],
+                        loinc_name_type=hit["_source"]["loinc_name_type"],
+                        description=hit["_source"]["description"],
+                        loinc_type=hit["_source"]["loinc_type"],
+                    ),
+                )
+                for hit in opensearch_results["hits"]["hits"]
+            ],
+        ),
+    )
+
+    return OpenSearchResultCacheSource(
+        cache_key=response_source["cache_key"],
+        text=response_source["text"],
+        data_field=response_source["data_field"],
+        loinc_code=Code(
+            code=response_loinc["code"],
+            code_system=response_loinc["code_system"],
+            code_system_name=response_loinc["code_system_name"],
+            display_name=response_loinc["display_name"],
+            original_text=response_loinc["original_text"],
+        ),
+        search_score=response_source["search_score"],
+        reranker_score=response_source["reranker_score"],
+        opensearch_retrieved_scores=opensearch_retrieved_scores,
+        reranker_processed_results=response_source["reranker_processed_results"],
+        cached_at=response_source["cached_at"],
+    )
+
+
 def get_cached_result(
     opensearch_client: OpenSearch, index: str, os_doc_id: str
 ) -> OpenSearchResultCacheSource | None:
@@ -29,58 +88,38 @@ def get_cached_result(
     """
     response = opensearch_client.get(index=index, id=os_doc_id, ignore=404)
     if response and response["found"]:
-        response_source = response["_source"]
-        response_loinc = response_source["loinc_code"]
-        opensearch_results = response_source["opensearch_retrieved_scores"]
-
-        opensearch_retrieved_scores = OpenSearchResult(
-            took=opensearch_results["took"],
-            timed_out=opensearch_results["timed_out"],
-            _shards=OpenSearchShards(
-                total=opensearch_results["_shards"]["total"],
-                successful=opensearch_results["_shards"]["successful"],
-                skipped=opensearch_results["_shards"]["skipped"],
-                failed=opensearch_results["_shards"]["failed"],
-            ),
-            hits=OpenSearchHits(
-                total=opensearch_results["hits"]["total"],
-                hits=[
-                    OpenSearchHit(
-                        _index=hit["_index"],
-                        _id=hit["_id"],
-                        _score=hit["_score"],
-                        _source=OpenSearchHitSource(
-                            id=hit["_source"]["id"],
-                            loinc_code=hit["_source"]["loinc_code"],
-                            loinc_name_type=hit["_source"]["loinc_name_type"],
-                            description=hit["_source"]["description"],
-                            loinc_type=hit["_source"]["loinc_type"],
-                        ),
-                    )
-                    for hit in opensearch_results["hits"]["hits"]
-                ],
-            ),
-        )
-
-        return OpenSearchResultCacheSource(
-            cache_key=response_source["cache_key"],
-            text=response_source["text"],
-            data_field=response_source["data_field"],
-            loinc_code=Code(
-                code=response_loinc["code"],
-                code_system=response_loinc["code_system"],
-                code_system_name=response_loinc["code_system_name"],
-                display_name=response_loinc["display_name"],
-                original_text=response_loinc["original_text"],
-            ),
-            search_score=response_source["search_score"],
-            reranker_score=response_source["reranker_score"],
-            opensearch_retrieved_scores=opensearch_retrieved_scores,
-            reranker_processed_results=response_source["reranker_processed_results"],
-            cached_at=response_source["cached_at"],
-        )
+        return _parse_cache_source(response["_source"])
 
     return None
+
+
+def get_cached_results(
+    opensearch_client: OpenSearch, index: str, os_doc_ids: list[str]
+) -> dict[str, OpenSearchResultCacheSource | None]:
+    """Queries an OpenSearch Index for several document IDs in one mget call.
+
+    A single mget replaces one GET round trip per document, which matters when
+    a record produces several candidates to look up.
+
+    :param opensearch_client: An instantiated client meant for communicating with
+      the TTC OpenSearch instance.
+    :param index: The namespace of the Index to check.
+    :param os_doc_ids: The OpenSearch document `_id` parameters to check for.
+    :returns: A mapping of each requested document ID to its parsed cache source,
+      or None for IDs with no cached entry.
+    """
+    results: dict[str, OpenSearchResultCacheSource | None] = dict.fromkeys(os_doc_ids)
+    if not os_doc_ids:
+        return results
+
+    # ignore=404 mirrors get_cached_result: a missing cache index is an
+    # all-miss, not an error.
+    response = opensearch_client.mget(body={"ids": list(results)}, index=index, ignore=404)
+    for doc in (response or {}).get("docs", []):
+        if doc.get("found"):
+            results[doc["_id"]] = _parse_cache_source(doc["_source"])
+
+    return results
 
 
 def put_new_cached_result(  # noqa: PLR0913
@@ -93,6 +132,7 @@ def put_new_cached_result(  # noqa: PLR0913
     reranker_score: float,
     opensearch_retrieved_scores: OpenSearchResult,
     reranker_processed_results: list,
+    cache_key: str | None = None,
 ) -> bool:
     """Stores a hit for a new nonstandard input in the Result Cache index in OpenSearch.
 
@@ -114,10 +154,12 @@ def put_new_cached_result(  # noqa: PLR0913
       during the original processing of this input.
     :param reranker_processed_results: The list of ScoredResult objects produced by the
       reranker during original processing.
+    :param cache_key: The precomputed cache key for this input, if the caller already
+      computed it for the lookup; recomputed from the input when omitted.
     :returns: A boolean indicating whether the new cache hit was successfully added to
       the OpenSearch index.
     """
-    cache_key = compute_cache_key(candidate_input, data_field)
+    cache_key = cache_key or compute_cache_key(candidate_input, data_field)
     new_cache_hit: OpenSearchResultCacheSource = OpenSearchResultCacheSource(
         cache_key=cache_key,
         text=candidate_input,

--- a/packages/text-to-code/src/text_to_code/services/schematron_processor.py
+++ b/packages/text-to-code/src/text_to_code/services/schematron_processor.py
@@ -7,9 +7,13 @@ from text_to_code.models.schematron import _SCHEMATRON_ENUM_TO_FIELD, Schematron
 
 logger = logging.getLogger(__name__)
 
+# Built in reverse registry order so that when two enums share an error id
+# (e.g. "ttc-labTestNameOrdered-noCode" appears in both the Ordered and
+# Resulted enums) the FIRST enum's mapping wins, matching the original
+# first-match lookup loop.
 _ERROR_ID_TO_FIELD: dict[str, DataField] = {
     member.value: data_field
-    for error_enum, data_field in _SCHEMATRON_ENUM_TO_FIELD.items()
+    for error_enum, data_field in reversed(_SCHEMATRON_ENUM_TO_FIELD.items())
     for member in error_enum
 }
 

--- a/packages/text-to-code/src/text_to_code/services/schematron_processor.py
+++ b/packages/text-to-code/src/text_to_code/services/schematron_processor.py
@@ -7,6 +7,12 @@ from text_to_code.models.schematron import _SCHEMATRON_ENUM_TO_FIELD, Schematron
 
 logger = logging.getLogger(__name__)
 
+_ERROR_ID_TO_FIELD: dict[str, DataField] = {
+    member.value: data_field
+    for error_enum, data_field in _SCHEMATRON_ENUM_TO_FIELD.items()
+    for member in error_enum
+}
+
 
 def get_data_element_from_schematron_error(schematron_error_id: str) -> DataField | None:
     """Return the data field that the error message is associated with, if any.
@@ -15,10 +21,7 @@ def get_data_element_from_schematron_error(schematron_error_id: str) -> DataFiel
     :returns: The data field the schematron error is associated with,
         or None if not found.
     """
-    for error_enum, data_field in _SCHEMATRON_ENUM_TO_FIELD.items():
-        if schematron_error_id in (e.value for e in error_enum):
-            return data_field
-    return None
+    return _ERROR_ID_TO_FIELD.get(schematron_error_id)
 
 
 def _get_error_enum_value(schematron_error_id: str) -> str | None:
@@ -27,11 +30,7 @@ def _get_error_enum_value(schematron_error_id: str) -> str | None:
     :param schematron_error: The schematron error message being evaluated.
     :returns: The matching enum member value, or None if not found.
     """
-    for error_enum in _SCHEMATRON_ENUM_TO_FIELD:
-        for error in error_enum:
-            if schematron_error_id == error.value:
-                return error.value
-    return None
+    return schematron_error_id if schematron_error_id in _ERROR_ID_TO_FIELD else None
 
 
 def _get_eicr_id(xml_root: etree._Element) -> CdaInstanceIdentifier | None:

--- a/packages/text-to-code/src/text_to_code/services/utils.py
+++ b/packages/text-to-code/src/text_to_code/services/utils.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 from hashlib import sha256
@@ -14,13 +15,15 @@ logger = logging.getLogger(__name__)
 ConfigType = type[BaseLabField]
 
 
+@functools.cache
 def get_config_for_data_field(data_field: DataField) -> BaseLabField:
-    """Returns a fresh Pydantic config instance for a given data field.
+    """Returns the Pydantic config instance for a given data field.
 
-    Uses defaults defined in the config model unless overridden.
+    Uses defaults defined in the config model. The returned instance is a
+    cached frozen model shared across calls — callers must not mutate its
+    list fields.
 
     :param data_field: The data field of interest.
-    :param kwargs: Any overrides to use when creating the config instance.
     :returns: A Pydantic config instance for the specified data field.
     """
     try:

--- a/packages/text-to-code/tests/unit/conftest.py
+++ b/packages/text-to-code/tests/unit/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from text_to_code.services.evaluator import _get_evaluation_criteria_for_data_field
+from text_to_code.services.utils import get_config_for_data_field
+
+
+@pytest.fixture(autouse=True)
+def _clear_memoized_registry_lookups():
+    """Reset the registry lookup caches so tests that patch the registries stay isolated."""
+    get_config_for_data_field.cache_clear()
+    _get_evaluation_criteria_for_data_field.cache_clear()
+    yield
+    get_config_for_data_field.cache_clear()
+    _get_evaluation_criteria_for_data_field.cache_clear()

--- a/packages/text-to-code/tests/unit/test_eicr_processor.py
+++ b/packages/text-to-code/tests/unit/test_eicr_processor.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
 
@@ -84,17 +85,22 @@ class TestEmptyEicrProcessor:
         failed_sub_xpath = expected_sub_xpaths[0]
         successful_sub_xpath = expected_sub_xpaths[1]
 
-        def get_by_xpath(xpath) -> list[str | etree._Element]:
-            if xpath == BASE_XPATH:
-                return [processor._xml_root]
-            if xpath == f"{BASE_XPATH}/{failed_sub_xpath}":
-                raise etree.XPathError("boom")
-            if xpath == f"{BASE_XPATH}/{successful_sub_xpath}":
-                return ["successful candidate"]
-            return []
+        def sub_xpath_evaluator(sub_xpath: LabXPaths) -> Callable:
+            def evaluate(node: etree._Element) -> list[str | etree._Element]:
+                if sub_xpath == failed_sub_xpath:
+                    raise etree.XPathError("boom")
+                if sub_xpath == successful_sub_xpath:
+                    return ["successful candidate"]
+                return []
+
+            return evaluate
 
         with (
-            patch.object(processor, "_get_by_xpath", side_effect=get_by_xpath),
+            patch.object(processor, "_get_by_xpath", return_value=[processor._xml_root]),
+            patch(
+                "text_to_code.services.eicr_processor._sub_xpath_evaluator",
+                side_effect=sub_xpath_evaluator,
+            ),
             patch("text_to_code.services.eicr_processor.logger.exception") as mock_exception,
             patch("text_to_code.services.eicr_processor.logger.warning") as mock_warning,
         ):
@@ -132,15 +138,20 @@ class TestEmptyEicrProcessor:
         expected_sub_xpaths = get_config_for_data_field(DataField.LAB_TEST_NAME_RESULTED).xpaths
         failed_sub_xpath = expected_sub_xpaths[0]
 
-        def get_by_xpath(xpath) -> list[str | etree._Element]:
-            if xpath == BASE_XPATH:
-                return [processor._xml_root]
-            if xpath == f"{BASE_XPATH}/{failed_sub_xpath}":
-                return ["first candidate", processor._xml_root, "second candidate"]
-            return []
+        def sub_xpath_evaluator(sub_xpath: LabXPaths) -> Callable:
+            def evaluate(node: etree._Element) -> list[str | etree._Element]:
+                if sub_xpath == failed_sub_xpath:
+                    return ["first candidate", processor._xml_root, "second candidate"]
+                return []
+
+            return evaluate
 
         with (
-            patch.object(processor, "_get_by_xpath", side_effect=get_by_xpath),
+            patch.object(processor, "_get_by_xpath", return_value=[processor._xml_root]),
+            patch(
+                "text_to_code.services.eicr_processor._sub_xpath_evaluator",
+                side_effect=sub_xpath_evaluator,
+            ),
             patch.object(
                 processor,
                 "_extract_text_candidates_from_element",
@@ -186,15 +197,20 @@ class TestEmptyEicrProcessor:
         expected_sub_xpaths = get_config_for_data_field(DataField.LAB_TEST_NAME_RESULTED).xpaths
         empty_sub_xpath = expected_sub_xpaths[0]
 
-        def get_by_xpath(xpath) -> list[str | etree._Element]:
-            if xpath == BASE_XPATH:
-                return [processor._xml_root]
-            if xpath == f"{BASE_XPATH}/{empty_sub_xpath}":
-                return ["   "]
-            return []
+        def sub_xpath_evaluator(sub_xpath: LabXPaths) -> Callable:
+            def evaluate(node: etree._Element) -> list[str | etree._Element]:
+                if sub_xpath == empty_sub_xpath:
+                    return ["   "]
+                return []
+
+            return evaluate
 
         with (
-            patch.object(processor, "_get_by_xpath", side_effect=get_by_xpath),
+            patch.object(processor, "_get_by_xpath", return_value=[processor._xml_root]),
+            patch(
+                "text_to_code.services.eicr_processor._sub_xpath_evaluator",
+                side_effect=sub_xpath_evaluator,
+            ),
             patch("text_to_code.services.eicr_processor.logger.info") as mock_info,
         ):
             result = processor.get_text_candidates(BASE_XPATH, DataField.LAB_TEST_NAME_RESULTED)
@@ -211,6 +227,44 @@ class TestEmptyEicrProcessor:
                 "no_candidate_count": len(expected_sub_xpaths),
             },
         )
+
+    def test_get_text_candidates_extracts_per_node_without_duplicates(self):
+        """A base xpath matching multiple nodes yields each node's candidates exactly once."""
+        processor = EicrProcessor(
+            """
+            <ClinicalDocument>
+                <component>
+                    <structuredBody>
+                        <component>
+                            <section>
+                                <entry>
+                                    <component>
+                                        <observation>
+                                            <code displayName="First lab name." />
+                                        </observation>
+                                    </component>
+                                </entry>
+                                <entry>
+                                    <component>
+                                        <observation>
+                                            <code displayName="Second lab name." />
+                                        </observation>
+                                    </component>
+                                </entry>
+                            </section>
+                        </component>
+                    </structuredBody>
+                </component>
+            </ClinicalDocument>
+            """
+        )
+
+        result = processor.get_text_candidates(BASE_XPATH, DataField.LAB_TEST_NAME_RESULTED)
+
+        assert result == [
+            Candidate(value="First lab name.", xpath=LabXPaths.CODE_DISPLAY_NAME),
+            Candidate(value="Second lab name.", xpath=LabXPaths.CODE_DISPLAY_NAME),
+        ]
 
     def test_resolve_reference_returns_none_for_empty_reference_value(self):
         processor = EicrProcessor("<ClinicalDocument />")

--- a/packages/text-to-code/tests/unit/test_eicr_processor.py
+++ b/packages/text-to-code/tests/unit/test_eicr_processor.py
@@ -266,6 +266,23 @@ class TestEmptyEicrProcessor:
             Candidate(value="Second lab name.", xpath=LabXPaths.CODE_DISPLAY_NAME),
         ]
 
+    def test_get_text_candidates_skips_non_element_base_nodes(self):
+        """A base xpath selecting attribute nodes yields no candidates instead of crashing.
+
+        Relative sub-xpath evaluation raises TypeError (not XPathError) on lxml
+        smart strings; the old absolute-path evaluation just found no matches.
+        """
+        processor = EicrProcessor(
+            '<ClinicalDocument><observation><code code="12345" displayName="Lab name." />'
+            "</observation></ClinicalDocument>"
+        )
+
+        result = processor.get_text_candidates(
+            "/ClinicalDocument/observation/code/@code", DataField.LAB_TEST_NAME_RESULTED
+        )
+
+        assert result == []
+
     def test_resolve_reference_returns_none_for_empty_reference_value(self):
         processor = EicrProcessor("<ClinicalDocument />")
 

--- a/packages/text-to-code/tests/unit/test_schematron_processor.py
+++ b/packages/text-to-code/tests/unit/test_schematron_processor.py
@@ -35,6 +35,16 @@ class TestSchematronProcessor:
 
         assert result is None
 
+    def test_get_data_element_prefers_first_registry_match_for_duplicated_error_id(self):
+        """A duplicated error id must resolve to the first registry entry.
+
+        'ttc-labTestNameOrdered-noCode' appears in BOTH error enums; Lab Test
+        Name Ordered must win, matching the original first-match lookup.
+        """
+        result = get_data_element_from_schematron_error("ttc-labTestNameOrdered-noCode")
+
+        assert result == DataField.LAB_TEST_NAME_ORDERED
+
     def test_get_error_enum_value_returns_none_for_unknown_message(self):
         result = _get_error_enum_value("unknown schematron error")
 

--- a/packages/validation/src/validation/main.py
+++ b/packages/validation/src/validation/main.py
@@ -64,10 +64,14 @@ def _get_saxon() -> tuple:
     global _cached_validator_key  # noqa: PLW0603
 
     if _cached_proc is None or _cached_proc_factory is not PySaxonProcessor:
+        # Assign the globals only after every init step succeeds — a failure
+        # in new_xslt30_processor() must not leave a half-initialized cache
+        # that poisons every later call.
         proc = PySaxonProcessor(license=False).__enter__()
+        xsltproc = proc.new_xslt30_processor()
         _cached_proc = proc
         _cached_proc_factory = PySaxonProcessor
-        _cached_xsltproc = proc.new_xslt30_processor()
+        _cached_xsltproc = xsltproc
         _cached_executable = None
         _cached_validator_key = None
 

--- a/packages/validation/src/validation/main.py
+++ b/packages/validation/src/validation/main.py
@@ -3,6 +3,7 @@ import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from xml.sax.saxutils import escape
 
 from saxonche import PySaxonProcessor  # ty: ignore[unresolved-import]
@@ -32,6 +33,72 @@ logger = logging.getLogger(__name__)
 # Saxon emits failed-assert locations in EQName (Clark) notation, e.g.
 # ``/Q{urn:hl7-org:v3}ClinicalDocument[1]/Q{urn:hl7-org:v3}component[1]``.
 _NAMESPACE_STEP = re.compile(r"Q\{[^}]*\}")
+
+# SaxonC initializes a Graal VM once per process; creating and releasing
+# PySaxonProcessor repeatedly is slow and a known source of crashes in
+# saxonche, so one processor (and its compiled validator stylesheet) is kept
+# for the life of the process. Lambda containers are single-threaded and die
+# by process teardown, so no explicit release is needed. The factory is
+# tracked so tests that monkeypatch ``PySaxonProcessor`` get a fresh instance.
+_cached_proc = None
+_cached_proc_factory = None
+_cached_xsltproc = None
+_cached_executable = None
+_cached_validator_key: tuple[str, float, str, float] | None = None
+
+
+def _get_saxon() -> tuple:
+    """Return the process-wide Saxon processor and XSLT 3.0 processor.
+
+    Built once per process (or whenever the ``PySaxonProcessor`` module
+    attribute changes, so monkeypatched fakes in tests are picked up) and
+    reused afterwards. The context-manager protocol is entered exactly once
+    and never exited; see the module-level comment for why.
+
+    :return: A ``(saxon_processor, xslt30_processor)`` tuple.
+    """
+    global _cached_proc  # noqa: PLW0603
+    global _cached_proc_factory  # noqa: PLW0603
+    global _cached_xsltproc  # noqa: PLW0603
+    global _cached_executable  # noqa: PLW0603
+    global _cached_validator_key  # noqa: PLW0603
+
+    if _cached_proc is None or _cached_proc_factory is not PySaxonProcessor:
+        proc = PySaxonProcessor(license=False).__enter__()
+        _cached_proc = proc
+        _cached_proc_factory = PySaxonProcessor
+        _cached_xsltproc = proc.new_xslt30_processor()
+        _cached_executable = None
+        _cached_validator_key = None
+
+    return _cached_proc, _cached_xsltproc
+
+
+def _get_compiled_validator(xsltproc) -> Any:  # noqa: ANN001, ANN401
+    """Return the compiled validator stylesheet, recompiling only when stale.
+
+    Compiling the APHL validator XSLT is the most expensive part of a
+    validation call, so the executable is cached and keyed on the validator
+    (and vocab) paths and mtimes; ``redo_all_steps`` regenerating the files,
+    or tests monkeypatching the paths, changes the key and forces a recompile.
+
+    :param xsltproc: The XSLT 3.0 processor used to compile the stylesheet.
+    :return: The compiled stylesheet executable.
+    """
+    global _cached_executable  # noqa: PLW0603
+    global _cached_validator_key  # noqa: PLW0603
+
+    key = (
+        str(VALIDATOR_OUTPUT),
+        VALIDATOR_OUTPUT.stat().st_mtime,
+        str(VOC_OUTPUT),
+        VOC_OUTPUT.stat().st_mtime,
+    )
+    if _cached_executable is None or key != _cached_validator_key:
+        _cached_executable = xsltproc.compile_stylesheet(stylesheet_file=str(VALIDATOR_OUTPUT))
+        _cached_validator_key = key
+
+    return _cached_executable
 
 
 class ValidationResult(FrozenBaseModel):
@@ -100,83 +167,82 @@ def _run_validator(eicr: str | None, redo_all_steps: bool = False) -> list[_RawA
     asserts: list[_RawAssert] = []
 
     try:
-        with PySaxonProcessor(license=False) as proc:
-            logger.info(f"Saxon/C version: {proc.version}")
-            xsltproc = proc.new_xslt30_processor()
-            # The cached XSLT artifacts (steps 1-3) are written here. The wheel
-            # ships no output/ dir, so create it before the first write.
-            STAGE1_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-            if redo_all_steps:
-                logger.info("Remove all previous files generated at all steps")
-                STAGE1_OUTPUT.unlink(missing_ok=True)
-                STAGE2_OUTPUT.unlink(missing_ok=True)
-                VALIDATOR_OUTPUT.unlink(missing_ok=True)
-                VOC_OUTPUT.unlink(missing_ok=True)
-            else:
-                logger.info("Will use existing files for Step 1-3")
+        proc, xsltproc = _get_saxon()
+        logger.info(f"Saxon/C version: {proc.version}")
+        # The cached XSLT artifacts (steps 1-3) are written here. The wheel
+        # ships no output/ dir, so create it before the first write.
+        STAGE1_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+        if redo_all_steps:
+            logger.info("Remove all previous files generated at all steps")
+            STAGE1_OUTPUT.unlink(missing_ok=True)
+            STAGE2_OUTPUT.unlink(missing_ok=True)
+            VALIDATOR_OUTPUT.unlink(missing_ok=True)
+            VOC_OUTPUT.unlink(missing_ok=True)
+        else:
+            logger.info("Will use existing files for Step 1-3")
 
-            if _needs_regeneration(STAGE1_OUTPUT, (APHL_SCHEMATRON, XSLT_INCLUDE)):
-                # Step 1: Process includes
-                # Note: For schxslt, you typically apply the XSLT to the SCH file as the source
-                logger.info("--- Step 1: Process Includes against Schematron File")
-                xsltproc.transform_to_file(
-                    source_file=str(APHL_SCHEMATRON),
-                    stylesheet_file=str(XSLT_INCLUDE),
-                    output_file=str(STAGE1_OUTPUT),
-                )
+        if _needs_regeneration(STAGE1_OUTPUT, (APHL_SCHEMATRON, XSLT_INCLUDE)):
+            # Step 1: Process includes
+            # Note: For schxslt, you typically apply the XSLT to the SCH file as the source
+            logger.info("--- Step 1: Process Includes against Schematron File")
+            xsltproc.transform_to_file(
+                source_file=str(APHL_SCHEMATRON),
+                stylesheet_file=str(XSLT_INCLUDE),
+                output_file=str(STAGE1_OUTPUT),
+            )
 
-            if _needs_regeneration(STAGE2_OUTPUT, (STAGE1_OUTPUT, XSLT_EXPAND)):
-                # Step 2: Expand abstract rules
-                logger.info("--- Step 2: Expand abstract rules using output from Step 1")
-                xsltproc.transform_to_file(
-                    source_file=str(STAGE1_OUTPUT),
-                    stylesheet_file=str(XSLT_EXPAND),
-                    output_file=str(STAGE2_OUTPUT),
-                )
+        if _needs_regeneration(STAGE2_OUTPUT, (STAGE1_OUTPUT, XSLT_EXPAND)):
+            # Step 2: Expand abstract rules
+            logger.info("--- Step 2: Expand abstract rules using output from Step 1")
+            xsltproc.transform_to_file(
+                source_file=str(STAGE1_OUTPUT),
+                stylesheet_file=str(XSLT_EXPAND),
+                output_file=str(STAGE2_OUTPUT),
+            )
 
-            if _needs_regeneration(VALIDATOR_OUTPUT, (STAGE2_OUTPUT, XSLT_COMPILE)):
-                # Step 3: Compile to an SVRL-producing XSLT stylesheet
-                logger.info(
-                    "--- Step 3: Compile to an SVRL-producing XSLT stylesheet using the output from Step 2"
-                )
-                xsltproc.transform_to_file(
-                    source_file=str(STAGE2_OUTPUT),
-                    stylesheet_file=str(XSLT_COMPILE),
-                    output_file=str(VALIDATOR_OUTPUT),
-                )
+        if _needs_regeneration(VALIDATOR_OUTPUT, (STAGE2_OUTPUT, XSLT_COMPILE)):
+            # Step 3: Compile to an SVRL-producing XSLT stylesheet
+            logger.info(
+                "--- Step 3: Compile to an SVRL-producing XSLT stylesheet using the output from Step 2"
+            )
+            xsltproc.transform_to_file(
+                source_file=str(STAGE2_OUTPUT),
+                stylesheet_file=str(XSLT_COMPILE),
+                output_file=str(VALIDATOR_OUTPUT),
+            )
 
-            # Ensure the document()-referenced vocab sits next to the generated stylesheet.
-            # Guarded like the stage artifacts above: on Lambda the package dir is read-only
-            # and this file is baked into the image at build time (Dockerfile.augmentation),
-            # so an unconditional copy would crash with OSError [Errno 30] on every invocation.
-            if _needs_regeneration(VOC_OUTPUT, (VOC_SOURCE,)):
-                shutil.copy2(VOC_SOURCE, VOC_OUTPUT)
+        # Ensure the document()-referenced vocab sits next to the generated stylesheet.
+        # Guarded like the stage artifacts above: on Lambda the package dir is read-only
+        # and this file is baked into the image at build time (Dockerfile.augmentation),
+        # so an unconditional copy would crash with OSError [Errno 30] on every invocation.
+        if _needs_regeneration(VOC_OUTPUT, (VOC_SOURCE,)):
+            shutil.copy2(VOC_SOURCE, VOC_OUTPUT)
 
-            # Step 4: Apply the generated XSLT to the source XML
-            # Parse the XML string into an XDM node
-            xml_node = proc.parse_xml(xml_text=eicr)
+        # Step 4: Apply the generated XSLT to the source XML
+        # Parse the XML string into an XDM node
+        xml_node = proc.parse_xml(xml_text=eicr)
 
-            # Use the node as the source for transformation
-            executable = xsltproc.compile_stylesheet(stylesheet_file=str(VALIDATOR_OUTPUT))
-            result = executable.apply_templates_returning_value(xdm_value=xml_node)
-            logger.info(result)
+        # Use the node as the source for transformation
+        executable = _get_compiled_validator(xsltproc)
+        result = executable.apply_templates_returning_value(xdm_value=xml_node)
+        logger.info(result)
 
-            for x in result[0][0].children:
-                if x.local_name == "failed-assert":
-                    # The human-readable message lives in the <svrl:text> child.
-                    message = ""
-                    for child in x.children:
-                        if child.local_name == "text":
-                            message = (child.string_value or "").strip()
-                            break
-                    asserts.append(
-                        _RawAssert(
-                            error_id=x.get_attribute_value("id"),
-                            location=x.get_attribute_value("location"),
-                            test=_normalize_whitespace(x.get_attribute_value("test")),
-                            message=message,
-                        )
+        for x in result[0][0].children:
+            if x.local_name == "failed-assert":
+                # The human-readable message lives in the <svrl:text> child.
+                message = ""
+                for child in x.children:
+                    if child.local_name == "text":
+                        message = (child.string_value or "").strip()
+                        break
+                asserts.append(
+                    _RawAssert(
+                        error_id=x.get_attribute_value("id"),
+                        location=x.get_attribute_value("location"),
+                        test=_normalize_whitespace(x.get_attribute_value("test")),
+                        message=message,
                     )
+                )
     except Exception as e:
         logger.exception(f"An error occurred during validation: {e}")
         raise

--- a/packages/validation/tests/test_validation.py
+++ b/packages/validation/tests/test_validation.py
@@ -201,6 +201,46 @@ def test_validation_raises_when_validator_errors(
     assert "An error occurred during validation: validator failed" in caplog.text
 
 
+def test_validation_reuses_cached_processor_and_executable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Consecutive validations reuse one Saxon processor and one compiled stylesheet."""
+    stage1_output = tmp_path / "stage1.sch.tmp"
+    stage2_output = tmp_path / "stage2.sch.tmp"
+    validator_output = tmp_path / "validator.xsl.tmp"
+
+    stage1_output.write_text("existing stage 1")
+    stage2_output.write_text("existing stage 2")
+    validator_output.write_text("existing validator")
+
+    class CountingXsltProcessor(FakeXsltProcessor):
+        compile_count = 0
+
+        def compile_stylesheet(self, stylesheet_file: str) -> FakeExecutable:
+            CountingXsltProcessor.compile_count += 1
+            return super().compile_stylesheet(stylesheet_file)
+
+    class CountingSaxonProcessor(FakeSaxonProcessor):
+        init_count = 0
+
+        def __init__(self, license: bool) -> None:
+            CountingSaxonProcessor.init_count += 1
+            super().__init__(license)
+            self.xslt_processor = CountingXsltProcessor()
+
+    monkeypatch.setattr(validation_main, "STAGE1_OUTPUT", stage1_output)
+    monkeypatch.setattr(validation_main, "STAGE2_OUTPUT", stage2_output)
+    monkeypatch.setattr(validation_main, "VALIDATOR_OUTPUT", validator_output)
+    monkeypatch.setattr(validation_main, "PySaxonProcessor", CountingSaxonProcessor)
+
+    first = validate_eicr("<ClinicalDocument />")
+    second = validate_eicr("<ClinicalDocument />")
+
+    assert first == second
+    assert CountingSaxonProcessor.init_count == 1
+    assert CountingXsltProcessor.compile_count == 1
+
+
 def test_normalize_location_strips_eqname_prefixes():
     """Tests that Saxon EQName namespace prefixes are stripped to plain XPath steps."""
     raw = (

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,6 +119,44 @@ You must have AWS credentials available in the environment (e.g. via `aws sso lo
 
 Depedencies and installation instructions for those dependencies are exactly the same as for the `aws_e2e.sh` script above.
 
+## `load_test.sh`
+
+An A/B load test for the deployed pipeline, built to prove that a change does (or does not) move performance — something `batch_aws_test.sh` cannot show, because it runs serially against a single warm Lambda container.
+
+For one *arm* (a deployed image version), the script:
+
+1. Templates a corpus of a few hundred eICRs from the test-cases JSON. Each document's candidate text is **salted** with a unique run/arm/index marker (e.g. `K+, Whole Blood [lt-3f9a2c1b-baseline-042]`). The TTC result cache keys on a hash of the candidate text, so salting guarantees every document misses the cache and takes the full embedding + OpenSearch KNN path — no OpenSearch access is needed to reset state between runs or arms.
+2. Generates the paired Schematron reports locally in a single Saxon process (reports are validated once per base case and reused when their content is document-independent).
+3. Uploads all reports, then bursts the eICR uploads in parallel — forcing Lambda scale-out (SQS `batch_size = 1`, no reserved concurrency), which is what samples cold starts under load.
+4. Waits for the pipeline to drain (all augmented eICRs present), then measures from the source of truth rather than by log-tailing:
+   - **CloudWatch Logs Insights** over both lambdas' `REPORT` lines: duration p50/p90/p99, cold-start count, init duration, max memory, error count.
+   - **End-to-end latency** per document from S3 `LastModified` (submission → augmented object).
+   - **Correctness**: every augmented eICR's predicted LOINC translation vs. the expected code.
+5. Writes a `results_<pass>.json` per pass and prints a summary.
+
+With `--passes 2`, the second pass re-submits the *same salted texts* under fresh filenames/UUIDs — pass 1 measures the cold-cache (full KNN) path, pass 2 the warm result-cache path.
+
+### A/B protocol
+
+```sh
+# 1. Deploy the baseline (e.g. main) image, then:
+./scripts/load_test.sh run --arm baseline --docs 300 --passes 2
+
+# 2. Deploy the candidate branch image, then:
+./scripts/load_test.sh run --arm branch --docs 300 --passes 2
+
+# 3. Compare (repeat for p2):
+./scripts/load_test.sh compare \
+    load_test_runs/<run-id>-baseline/results_p1.json \
+    load_test_runs/<run-id>-branch/results_p1.json
+```
+
+Each redeploy recycles all Lambda containers, so both arms get a fair cold-start sample. Run the arms close together in time, in a window with **no other traffic** to the lambdas — invocations are attributed to the run by time window, and the report warns when invocation counts exceed the document count.
+
+Flags: `--docs` (default 300, max 900), `--passes` (default 1), `--concurrency` (parallel uploads, default 24), `--cases`, `--bucket` (default `dibbs-text-to-code`), `--out-dir` (default `load_test_runs/`, gitignored), `--drain-timeout` (default 1800s).
+
+Dependencies: only `aws` (CLI v2), `uv`, and `bash` — no `gum`/`jq`/`unbuffer`. Helper logic lives in `load_test_corpus.py` (corpus + Schematron reports) and `load_test_report.py` (Logs Insights metrics, S3 latency join, correctness check, and the `compare` table).
+
 ## Test Cases File Information
 
 The batch testing script relies on a JSON file of curated test cases to process in-bulk. The file can contain any number of test cases, but the structure of the file should be a JSON dictionary with a single key-value pair, with key `"test_cases"` and a value of an array of dictionaries. Each dictionary in the array is expected to have three properties: `nonstandard_in` (the narrative, free-text string representing the nonstandard eICR input), `correct_standardized_code` (the true name variant of the LOINC code represented by the input), and `numeric_loinc_code` (a string giving the hyphenated digit string assigned to the code in the LOINC hierarchy).

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# A/B load test for the deployed DIBBs TTC pipeline.
+#
+# Unlike batch_aws_test.sh (serial, one warm container, functional gate),
+# this script templates a corpus of a few hundred salted eICRs, uploads them
+# to S3 in a parallel burst to force Lambda scale-out (SQS batch_size=1, no
+# reserved concurrency), waits for the pipeline to drain, and then measures
+# from CloudWatch REPORT lines and S3 timestamps rather than by log-tailing:
+#
+#   - per-invocation duration percentiles, cold-start count, init duration,
+#     and max memory for both lambdas (CloudWatch Logs Insights)
+#   - end-to-end latency per document (S3 LastModified: submission -> augmented)
+#   - correctness: every augmented eICR's predicted LOINC vs. the expected code
+#
+# Every candidate text is salted with a unique run/arm/index marker, so the
+# TTC result cache (keyed by hash of the text) never hits across runs or
+# arms — no OpenSearch access needed to reset state. With --passes 2, the
+# second pass repeats the same salted texts under fresh filenames/UUIDs to
+# measure the warm result-cache path as well.
+#
+# A/B protocol:
+#   1. Deploy the baseline (main) image, then:  ./scripts/load_test.sh run --arm baseline
+#   2. Deploy the branch image, then:           ./scripts/load_test.sh run --arm branch
+#   3. ./scripts/load_test.sh compare load_test_runs/<id>-baseline/results_p1.json \
+#                                      load_test_runs/<id>-branch/results_p1.json
+#
+# Run each arm in a window with no other traffic to the lambdas; invocations
+# are attributed by time window and the report warns if counts don't line up.
+#
+# Usage:
+#   ./scripts/load_test.sh run --arm <label> [--docs 300] [--passes 1]
+#       [--concurrency 24] [--cases scripts/test_cases.json]
+#       [--bucket dibbs-text-to-code] [--out-dir load_test_runs]
+#       [--drain-timeout 1800]
+#   ./scripts/load_test.sh compare <baseline results.json> <branch results.json>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AWS_REGION="us-east-2"
+SETTLE_SECONDS=90   # CloudWatch Logs ingestion lag before querying Insights
+
+command -v aws >/dev/null || { echo "This script requires the AWS CLI." >&2; exit 1; }
+command -v uv >/dev/null || { echo "This script requires 'uv'. Install: https://docs.astral.sh/uv/" >&2; exit 1; }
+
+usage() {
+    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+run_py() {
+    uv run --project "$REPO_ROOT" --all-packages python "$@"
+}
+
+[[ $# -ge 1 ]] || usage
+COMMAND="$1"; shift
+
+# ── compare ───────────────────────────────────────────────────────────────────
+if [[ "$COMMAND" == "compare" ]]; then
+    [[ $# -eq 2 ]] || usage
+    exec uv run --project "$REPO_ROOT" --all-packages python "$SCRIPT_DIR/load_test_report.py" compare "$1" "$2"
+fi
+[[ "$COMMAND" == "run" ]] || usage
+
+# ── run: argument parsing ─────────────────────────────────────────────────────
+ARM="" DOCS=300 PASSES=1 CONCURRENCY=24 DRAIN_TIMEOUT=1800
+CASES="$SCRIPT_DIR/test_cases.json"
+BUCKET="dibbs-text-to-code"
+OUT_ROOT="$REPO_ROOT/load_test_runs"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --arm)           ARM="$2"; shift 2 ;;
+        --docs)          DOCS="$2"; shift 2 ;;
+        --passes)        PASSES="$2"; shift 2 ;;
+        --concurrency)   CONCURRENCY="$2"; shift 2 ;;
+        --cases)         CASES="$2"; shift 2 ;;
+        --bucket)        BUCKET="$2"; shift 2 ;;
+        --out-dir)       OUT_ROOT="$2"; shift 2 ;;
+        --drain-timeout) DRAIN_TIMEOUT="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+[[ -n "$ARM" ]] || { echo "--arm is required (e.g. --arm baseline)" >&2; exit 1; }
+[[ "$ARM" =~ ^[a-z0-9-]+$ ]] || { echo "--arm must be lowercase alphanumeric/hyphens (used in S3 keys)" >&2; exit 1; }
+(( DOCS >= 1 && DOCS <= 900 )) || { echo "--docs must be 1..900 (S3 list paging + SQS sanity bound)" >&2; exit 1; }
+[[ -f "$CASES" ]] || { echo "Missing test cases file: $CASES" >&2; exit 1; }
+
+RUN_ID="$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)"
+OUT="$OUT_ROOT/$RUN_ID-$ARM"
+mkdir -p "$OUT"
+
+echo "DIBBs TTC load test"
+echo "  run id:      $RUN_ID"
+echo "  arm:         $ARM"
+echo "  documents:   $DOCS per pass, $PASSES pass(es)"
+echo "  concurrency: $CONCURRENCY parallel uploads"
+echo "  bucket:      s3://$BUCKET"
+echo "  output:      $OUT"
+
+# ── corpus generation (local, one Saxon process) ──────────────────────────────
+echo
+echo "Generating corpus..."
+run_py "$SCRIPT_DIR/load_test_corpus.py" \
+    --cases "$CASES" --source-eicr "$SCRIPT_DIR/test_eicr.xml" \
+    --out-dir "$OUT" --docs "$DOCS" --passes "$PASSES" \
+    --run-id "$RUN_ID" --arm "$ARM"
+
+upload_all() {
+    local list_file="$1" local_dir="$2" s3_prefix="$3"
+    xargs -P "$CONCURRENCY" -I{} \
+        aws s3 cp --only-show-errors --region "$AWS_REGION" \
+        "$local_dir/{}" "s3://$BUCKET/$s3_prefix/{}" <"$list_file"
+}
+
+count_augmented() {
+    # `aws s3 ls` exits non-zero when the prefix has no matches yet, which
+    # would abort the drain poll under `set -o pipefail` — mask it.
+    { aws s3 ls --region "$AWS_REGION" \
+        "s3://$BUCKET/AugmentationEICRV2/loadtest_${RUN_ID}_${ARM}_${1}_" 2>/dev/null || true; } \
+        | wc -l | tr -d ' '
+}
+
+for (( PASS_NUM=1; PASS_NUM<=PASSES; PASS_NUM++ )); do
+    PASS="p$PASS_NUM"
+    FILES="$OUT/files_$PASS.txt"
+    EXPECTED="$(wc -l <"$FILES" | tr -d ' ')"
+
+    echo
+    echo "Pass $PASS: uploading $EXPECTED schematron reports..."
+    # Reports must all land under ValidationResponseV2/ before any eICR is
+    # uploaded — the eICR put is the S3 event that triggers the TTC lambda,
+    # which reads the paired report by the same filename.
+    upload_all "$FILES" "$OUT/reports" "ValidationResponseV2"
+
+    echo "Pass $PASS: uploading $EXPECTED eICRs (burst, $CONCURRENCY-way)..."
+    T0="$(date +%s)"
+    upload_all "$FILES" "$OUT/eicrs" "TextToCodeSubmissionV2"
+    echo "Pass $PASS: burst uploaded in $(( $(date +%s) - T0 ))s; waiting for the pipeline to drain..."
+
+    while :; do
+        DONE_COUNT="$(count_augmented "$PASS")"
+        ELAPSED=$(( $(date +%s) - T0 ))
+        printf '\r  %s/%s augmented eICRs (%ss elapsed)' "$DONE_COUNT" "$EXPECTED" "$ELAPSED"
+        if (( DONE_COUNT >= EXPECTED )); then echo; break; fi
+        if (( ELAPSED >= DRAIN_TIMEOUT )); then
+            echo
+            echo "  WARNING: drain timed out after ${DRAIN_TIMEOUT}s with $DONE_COUNT/$EXPECTED complete."
+            echo "  Continuing to the report — incomplete delivery is itself a finding."
+            break
+        fi
+        sleep 10
+    done
+
+    echo "  waiting ${SETTLE_SECONDS}s for CloudWatch Logs ingestion..."
+    sleep "$SETTLE_SECONDS"
+
+    run_py "$SCRIPT_DIR/load_test_report.py" report \
+        --manifest "$OUT/manifest.json" --pass "$PASS" \
+        --start "$(( T0 - 30 ))" --end "$(date +%s)" \
+        --bucket "$BUCKET" --region "$AWS_REGION" \
+        --out "$OUT/results_$PASS.json"
+done
+
+echo
+echo "Done. Compare arms with:"
+echo "  ./scripts/load_test.sh compare <baseline>/results_p1.json $OUT/results_p1.json"

--- a/scripts/load_test_corpus.py
+++ b/scripts/load_test_corpus.py
@@ -1,0 +1,153 @@
+# load_test_corpus.py
+#
+# Generates a salted eICR corpus (plus paired Schematron reports) for
+# scripts/load_test.sh.
+#
+# Each document is templated from scripts/test_eicr.xml with a base
+# nonstandard input from the test-cases JSON, then salted with a unique
+# run/arm/index marker (e.g. "K+, Whole Blood [lt-3f9a2c1b-baseline-042]").
+# The TTC result cache is keyed by sha256 of the lowercased candidate text,
+# so a unique salt guarantees every document misses the cache and takes the
+# full embedding + OpenSearch KNN path — without needing access to the
+# (VPC-only) OpenSearch domain to clear anything between runs.
+#
+# Salts are stable across passes: pass 2 reuses pass 1's salted texts with
+# fresh filenames and document UUIDs. A 2-pass run therefore measures the
+# cold-cache path (pass 1) and the warm result-cache path (pass 2).
+#
+# Schematron reports are expensive (one Saxon transform each), but templated
+# documents differ only in the salted text and document UUIDs. The generator
+# validates the first document of each base case and, if none of those
+# doc-specific values leak into the report XML, reuses that report for every
+# other document of the same base case. If they do leak, it falls back to
+# per-document validation for that base case.
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from pathlib import Path
+from xml.sax.saxutils import escape, quoteattr
+
+from validation import build_schematron_report_xml
+
+
+def template_eicr(src: str, name: str) -> tuple[str, str, str]:
+    """Template the source eICR with a candidate name and fresh document UUIDs.
+
+    Mirrors bash_eicr_templater.py: rewrites the first displayName and
+    originalText so the TTC pipeline has a unique text candidate to resolve,
+    and stamps fresh UUIDs on <id>/<setId> so the document looks new to
+    downstream systems.
+
+    :param src: The source eICR XML text.
+    :param name: The (salted) nonstandard input to inject.
+    :returns: A tuple of (templated XML, document id UUID, setId UUID).
+    """
+    doc_id, set_id = str(uuid.uuid4()), str(uuid.uuid4())
+    out = re.sub(r'displayName="[^"]*"', "displayName=" + quoteattr(name), src, count=1)
+    out = re.sub(
+        r"(<originalText[^>]*>)[^<]*(</originalText>)",
+        lambda m: m.group(1) + escape(name) + m.group(2),
+        out,
+        count=1,
+    )
+    out = re.sub(r'<id root="[0-9a-f-]+"', f'<id root="{doc_id}"', out, count=1)
+    out = re.sub(r'<setId extension="[0-9a-f-]+"', f'<setId extension="{set_id}"', out, count=1)
+    return out, doc_id, set_id
+
+
+def main() -> int:
+    """Generate the corpus, reports, per-pass file lists, and manifest."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", required=True, help="Path to the test-cases JSON file")
+    parser.add_argument("--source-eicr", required=True, help="Path to the template eICR XML")
+    parser.add_argument("--out-dir", required=True, help="Directory to write the corpus into")
+    parser.add_argument("--docs", type=int, required=True, help="Documents per pass")
+    parser.add_argument("--passes", type=int, default=1, help="Number of passes (default 1)")
+    parser.add_argument("--run-id", required=True, help="Unique id for this load-test run")
+    parser.add_argument("--arm", required=True, help="A/B arm label (e.g. baseline, branch)")
+    args = parser.parse_args()
+
+    with open(args.cases) as fp:
+        cases = json.load(fp)["test_cases"]
+    src = Path(args.source_eicr).read_text()
+
+    out_dir = Path(args.out_dir)
+    (out_dir / "eicrs").mkdir(parents=True, exist_ok=True)
+    (out_dir / "reports").mkdir(parents=True, exist_ok=True)
+
+    # base-case index -> reusable report XML, or None if doc-specific values
+    # leak into the report and each document needs its own Saxon run.
+    report_cache: dict[int, str | None] = {}
+    reused = generated = 0
+    manifest_docs = []
+
+    for pass_num in range(1, args.passes + 1):
+        pass_label = f"p{pass_num}"
+        filenames = []
+        for i in range(args.docs):
+            base_idx = i % len(cases)
+            case = cases[base_idx]
+            # The marker (not the pass) determines the result-cache key, so
+            # pass 2 repeats pass 1's texts and hits the cache pass 1 filled.
+            marker = f"[lt-{args.run_id}-{args.arm}-{i:03d}]"
+            salted = f"{case['nonstandard_in']} {marker}"
+            filename = f"loadtest_{args.run_id}_{args.arm}_{pass_label}_{i:04d}.xml"
+
+            doc, doc_id, set_id = template_eicr(src, salted)
+            (out_dir / "eicrs" / filename).write_text(doc)
+
+            if base_idx not in report_cache:
+                report = build_schematron_report_xml(doc)
+                leaks = any(v in report for v in (marker, doc_id, set_id))
+                report_cache[base_idx] = None if leaks else report
+                generated += 1
+            else:
+                cached = report_cache[base_idx]
+                if cached is not None:
+                    report = cached
+                    reused += 1
+                else:
+                    report = build_schematron_report_xml(doc)
+                    generated += 1
+            (out_dir / "reports" / filename).write_text(report)
+
+            filenames.append(filename)
+            manifest_docs.append(
+                {
+                    "filename": filename,
+                    "pass": pass_label,
+                    "index": i,
+                    "base_input": case["nonstandard_in"],
+                    "salted_input": salted,
+                    "expected_loinc": case["numeric_loinc_code"],
+                    "expected_name": case["correct_standardized_code"],
+                }
+            )
+            if (len(manifest_docs)) % 50 == 0:
+                print(f"  templated {len(manifest_docs)} documents...", file=sys.stderr)
+
+        (out_dir / f"files_{pass_label}.txt").write_text("\n".join(filenames) + "\n")
+
+    manifest = {
+        "run_id": args.run_id,
+        "arm": args.arm,
+        "docs_per_pass": args.docs,
+        "passes": args.passes,
+        "cases_file": str(args.cases),
+        "docs": manifest_docs,
+    }
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    print(
+        f"  corpus: {len(manifest_docs)} documents across {args.passes} pass(es); "
+        f"schematron reports: {generated} generated, {reused} reused",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/load_test_report.py
+++ b/scripts/load_test_report.py
@@ -1,0 +1,326 @@
+# load_test_report.py
+#
+# Metrics collection and A/B comparison for scripts/load_test.sh.
+#
+#   report  — for one pass of one arm: queries CloudWatch Logs Insights for
+#             the two lambdas' REPORT lines (duration percentiles, cold
+#             starts, init duration, memory), joins S3 LastModified times of
+#             submission vs. augmented objects for end-to-end latency, and
+#             checks every augmented eICR's predicted LOINC against the
+#             expected code. Writes a JSON results file and prints a summary.
+#   compare — prints a side-by-side delta table of two results JSON files
+#             (typically baseline vs. branch). Uses only the stdlib.
+#
+# Invocations are attributed to the run by time window, so run the load test
+# in a window with no other traffic to these lambdas; the summary warns when
+# the invocation count exceeds the document count.
+
+import argparse
+import concurrent.futures
+import json
+import sys
+import time
+import xml.etree.ElementTree as ET
+
+import boto3
+
+TTC_LOG_GROUP = "/aws/lambda/ttc-lambda"
+MAX_FAILURES_SHOWN = 10
+AUG_LOG_GROUP = "/aws/lambda/ttc-augmentation-lambda"
+SUBMISSION_PREFIX = "TextToCodeSubmissionV2/"
+AUGMENTED_PREFIX = "AugmentationEICRV2/"
+
+REPORT_STATS_QUERY = """
+filter @type = "REPORT"
+| stats count(*) as invocations,
+        pct(@duration, 50) as p50_ms,
+        pct(@duration, 90) as p90_ms,
+        pct(@duration, 99) as p99_ms,
+        max(@duration) as max_ms,
+        count(@initDuration) as cold_starts,
+        avg(@initDuration) as avg_init_ms,
+        max(@initDuration) as max_init_ms,
+        max(@maximumMemoryUsed) / 1000000 as max_mem_mb
+"""
+
+ERROR_COUNT_QUERY = r"""
+filter @message like /(\[ERROR\]|Task timed out)/
+| stats count(*) as errors
+"""
+
+
+def _run_insights_query(logs_client, log_group: str, query: str, start: int, end: int) -> dict:  # noqa: ANN001
+    """Run one CloudWatch Logs Insights query and return its single stats row.
+
+    :param logs_client: A boto3 CloudWatch Logs client.
+    :param log_group: The log group to query.
+    :param query: The Logs Insights query string (must produce one stats row).
+    :param start: Window start (epoch seconds).
+    :param end: Window end (epoch seconds).
+    :returns: The stats row as a field-name -> float mapping (empty if no data).
+    """
+    query_id = logs_client.start_query(
+        logGroupName=log_group, startTime=start, endTime=end, queryString=query
+    )["queryId"]
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        response = logs_client.get_query_results(queryId=query_id)
+        if response["status"] not in ("Scheduled", "Running"):
+            break
+        time.sleep(2)
+    if response["status"] != "Complete":
+        print(f"  WARNING: Logs Insights query on {log_group} ended {response['status']}")
+        return {}
+    if not response["results"]:
+        return {}
+    return {
+        field["field"]: round(float(field["value"]), 1)
+        for field in response["results"][0]
+        if field["value"] is not None
+    }
+
+
+def _list_last_modified(s3_client, bucket: str, prefix: str) -> dict[str, float]:  # noqa: ANN001
+    """Map object basename -> LastModified epoch seconds for a prefix.
+
+    :param s3_client: A boto3 S3 client.
+    :param bucket: The bucket to list.
+    :param prefix: The full key prefix to list under.
+    :returns: A mapping of key basename to LastModified as epoch seconds.
+    """
+    out: dict[str, float] = {}
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            out[obj["Key"].rsplit("/", 1)[-1]] = obj["LastModified"].timestamp()
+    return out
+
+
+def _predicted_loinc(xml: str) -> str | None:
+    """Extract the predicted LOINC translation code from an augmented eICR.
+
+    Mirrors bash_xml_parser.py: the first observation code's <translation>
+    is where the TTC pipeline writes its predicted standardization.
+
+    :param xml: The augmented eICR XML text.
+    :returns: The predicted LOINC code, or None if no translation was added.
+    """
+    node = ET.fromstring(xml).find(
+        "{*}component/{*}structuredBody/{*}component/{*}section/{*}entry/"
+        "{*}observation/{*}code/{*}translation"
+    )
+    return None if node is None else node.get("code")
+
+
+def _percentile(values: list[float], q: float) -> float | None:
+    """Nearest-rank percentile of a list of values.
+
+    :param values: The sample values (need not be sorted).
+    :param q: The percentile as a fraction (e.g. 0.5 for p50).
+    :returns: The percentile value, or None for an empty sample.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    return round(ordered[min(len(ordered) - 1, round(q * (len(ordered) - 1)))], 1)
+
+
+def run_report(args: argparse.Namespace) -> int:
+    """Collect metrics for one pass and write the results JSON.
+
+    :param args: Parsed CLI arguments for the report subcommand.
+    :returns: Process exit code.
+    """
+    with open(args.manifest) as fp:
+        manifest = json.load(fp)
+    docs = [d for d in manifest["docs"] if d["pass"] == args.pass_label]
+    if not docs:
+        print(f"No documents for pass {args.pass_label} in {args.manifest}", file=sys.stderr)
+        return 1
+    run_id, arm = manifest["run_id"], manifest["arm"]
+    run_prefix = f"loadtest_{run_id}_{arm}_{args.pass_label}_"
+
+    logs = boto3.client("logs", region_name=args.region)
+    s3 = boto3.client("s3", region_name=args.region)
+
+    lambda_stats = {}
+    for label, group in (("ttc_lambda", TTC_LOG_GROUP), ("augmentation_lambda", AUG_LOG_GROUP)):
+        stats = _run_insights_query(logs, group, REPORT_STATS_QUERY, args.start, args.end)
+        errors = _run_insights_query(logs, group, ERROR_COUNT_QUERY, args.start, args.end)
+        stats["errors"] = errors.get("errors", 0)
+        lambda_stats[label] = stats
+
+    submitted = _list_last_modified(s3, args.bucket, SUBMISSION_PREFIX + run_prefix)
+    augmented = _list_last_modified(s3, args.bucket, AUGMENTED_PREFIX + run_prefix)
+    e2e_latencies = [augmented[name] - submitted[name] for name in augmented if name in submitted]
+
+    def check_doc(doc: dict) -> dict:
+        """Fetch one augmented eICR and compare its predicted LOINC to expected.
+
+        :param doc: The manifest entry for the document.
+        :returns: The manifest entry annotated with predicted code and status.
+        """
+        if doc["filename"] not in augmented:
+            return {**doc, "predicted_loinc": None, "status": "missing"}
+        body = s3.get_object(Bucket=args.bucket, Key=AUGMENTED_PREFIX + doc["filename"])
+        predicted = _predicted_loinc(body["Body"].read().decode("utf-8"))
+        status = "match" if predicted == doc["expected_loinc"] else "mismatch"
+        return {**doc, "predicted_loinc": predicted, "status": status}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        checked = list(pool.map(check_doc, docs))
+
+    matches = sum(1 for d in checked if d["status"] == "match")
+    failures = [
+        {
+            "filename": d["filename"],
+            "base_input": d["base_input"],
+            "expected_loinc": d["expected_loinc"],
+            "predicted_loinc": d["predicted_loinc"],
+            "status": d["status"],
+        }
+        for d in checked
+        if d["status"] != "match"
+    ]
+
+    results = {
+        "run_id": run_id,
+        "arm": arm,
+        "pass": args.pass_label,
+        "window": {"start": args.start, "end": args.end},
+        "documents": len(docs),
+        "ttc_lambda": lambda_stats["ttc_lambda"],
+        "augmentation_lambda": lambda_stats["augmentation_lambda"],
+        "end_to_end_s": {
+            "completed": len(e2e_latencies),
+            "p50": _percentile(e2e_latencies, 0.50),
+            "p90": _percentile(e2e_latencies, 0.90),
+            "p99": _percentile(e2e_latencies, 0.99),
+            "max": _percentile(e2e_latencies, 1.0),
+        },
+        "correctness": {
+            "expected": len(docs),
+            "loinc_matches": matches,
+            "match_rate": round(matches / len(docs), 4),
+            "failures": failures,
+        },
+    }
+    with open(args.out, "w") as fp:
+        json.dump(results, fp, indent=2)
+
+    print(f"\n=== {arm} / {args.pass_label} — {len(docs)} documents ===")
+    for label in ("ttc_lambda", "augmentation_lambda"):
+        s = lambda_stats[label]
+        if not s:
+            print(f"  {label}: no REPORT lines found in window")
+            continue
+        print(
+            f"  {label}: {s.get('invocations', 0):.0f} invocations, "
+            f"p50 {s.get('p50_ms')}ms / p90 {s.get('p90_ms')}ms / p99 {s.get('p99_ms')}ms, "
+            f"{s.get('cold_starts', 0):.0f} cold starts (avg init {s.get('avg_init_ms')}ms), "
+            f"max mem {s.get('max_mem_mb')}MB, errors {s.get('errors'):.0f}"
+        )
+        if s.get("invocations", 0) > len(docs):
+            print(
+                f"  WARNING: {label} ran {s['invocations']:.0f} times for {len(docs)} documents "
+                "— other traffic or retries in the window; treat duration stats with care"
+            )
+    e2e = results["end_to_end_s"]
+    print(
+        f"  end-to-end: {e2e['completed']}/{len(docs)} completed, "
+        f"p50 {e2e['p50']}s / p90 {e2e['p90']}s / max {e2e['max']}s"
+    )
+    print(f"  correctness: {matches}/{len(docs)} predicted LOINC matches expected")
+    for f in failures[:MAX_FAILURES_SHOWN]:
+        print(
+            f"    {f['status']}: '{f['base_input']}' "
+            f"expected {f['expected_loinc']} got {f['predicted_loinc']}"
+        )
+    if len(failures) > MAX_FAILURES_SHOWN:
+        print(f"    ... and {len(failures) - MAX_FAILURES_SHOWN} more (see {args.out})")
+    print(f"  results written to {args.out}")
+    return 0
+
+
+def run_compare(args: argparse.Namespace) -> int:
+    """Print a side-by-side delta table of two results JSON files.
+
+    :param args: Parsed CLI arguments for the compare subcommand.
+    :returns: Process exit code.
+    """
+    with open(args.a) as fp:
+        a = json.load(fp)
+    with open(args.b) as fp:
+        b = json.load(fp)
+
+    def rows(results: dict) -> dict[str, float | None]:
+        """Flatten one results JSON into the comparison metrics.
+
+        :param results: A results JSON as written by the report subcommand.
+        :returns: Metric name -> value.
+        """
+        ttc, aug, e2e = (
+            results["ttc_lambda"],
+            results["augmentation_lambda"],
+            results["end_to_end_s"],
+        )
+        return {
+            "ttc p50 (ms)": ttc.get("p50_ms"),
+            "ttc p90 (ms)": ttc.get("p90_ms"),
+            "ttc p99 (ms)": ttc.get("p99_ms"),
+            "ttc max (ms)": ttc.get("max_ms"),
+            "ttc cold starts": ttc.get("cold_starts"),
+            "ttc avg init (ms)": ttc.get("avg_init_ms"),
+            "ttc max init (ms)": ttc.get("max_init_ms"),
+            "ttc max mem (MB)": ttc.get("max_mem_mb"),
+            "ttc errors": ttc.get("errors"),
+            "aug p50 (ms)": aug.get("p50_ms"),
+            "aug p90 (ms)": aug.get("p90_ms"),
+            "end-to-end p50 (s)": e2e.get("p50"),
+            "end-to-end p90 (s)": e2e.get("p90"),
+            "end-to-end max (s)": e2e.get("max"),
+            "completed docs": e2e.get("completed"),
+            "LOINC match rate": results["correctness"].get("match_rate"),
+        }
+
+    label_a = f"{a['arm']}/{a['pass']}"
+    label_b = f"{b['arm']}/{b['pass']}"
+    print(f"\n{'metric':<22} {label_a:>14} {label_b:>14} {'delta':>10} {'delta %':>9}")
+    print("-" * 74)
+    rows_a, rows_b = rows(a), rows(b)
+    for metric in rows_a:
+        va, vb = rows_a[metric], rows_b[metric]
+        if va is None or vb is None:
+            print(f"{metric:<22} {va!s:>14} {vb!s:>14} {'—':>10} {'—':>9}")
+            continue
+        delta = round(vb - va, 1)
+        pct = f"{delta / va * 100:+.1f}%" if va else "—"
+        print(f"{metric:<22} {va:>14} {vb:>14} {delta:>+10} {pct:>9}")
+    print()
+    return 0
+
+
+def main() -> int:
+    """Run the report or compare subcommand."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    report = sub.add_parser("report", help="Collect metrics for one pass of one arm")
+    report.add_argument("--manifest", required=True, help="Path to the corpus manifest.json")
+    report.add_argument("--pass", dest="pass_label", required=True, help="Pass label (e.g. p1)")
+    report.add_argument("--start", type=int, required=True, help="Window start (epoch seconds)")
+    report.add_argument("--end", type=int, required=True, help="Window end (epoch seconds)")
+    report.add_argument("--bucket", required=True, help="S3 bucket the pipeline ran against")
+    report.add_argument("--region", default="us-east-2", help="AWS region")
+    report.add_argument("--out", required=True, help="Path to write the results JSON")
+
+    compare = sub.add_parser("compare", help="Diff two results JSON files")
+    compare.add_argument("a", help="Baseline results JSON")
+    compare.add_argument("b", help="Comparison results JSON")
+
+    args = parser.parse_args()
+    return run_report(args) if args.command == "report" else run_compare(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
NOTE: Don't be scared of the huge number of added lines - almost all of that is the report, docs, load-test scripts, and tests. The actual diff of our lambda code is in the hundreds of lines. To make review easier, look at each individual commit.

## Summary

Performance hardening of the TTC pipeline, plus an A/B load-test harness that proves the gains against the deployed environment. Under a 300-document burst, the TTC lambda's median invocation time drops from **200 s to 64 s (3.1×)** and end-to-end latency (submission → augmented eICR) from **314 s to 93 s (3.4×)**, with **zero errors and 300/300 documents delivered in every pass of both arms**.

### Performance changes

- **Drop the S3 pre-flight HEAD and bound client timeouts** — one fewer round-trip per document; no unbounded hangs under load.
- **Speed up per-error CPU work in candidate extraction and lookups.**
- **Cache the Saxon processor and compiled validator stylesheet** — Schematron parse cost is paid once per container, not per invocation.
- **Batch result-cache lookups (mget) and embeddings** — one OpenSearch round-trip and one model forward-pass per document instead of per candidate.
- **Harden TTC image cold start against Hub lookups and cache bloat** — no Hugging Face Hub calls at init.

### Load-test harness (new)

`scripts/load_test.sh` (with `load_test_corpus.py` / `load_test_report.py`) bursts salted eICRs at the deployed pipeline to force Lambda scale-out, waits for a full drain, and measures from CloudWatch Logs Insights `REPORT` lines and S3 `LastModified` timestamps. Candidate texts are salted with a unique run/arm marker so every document misses the TTC result cache — no OpenSearch access needed to reset state — and a second pass re-submits the same salted texts to measure the warm result-cache path. See `scripts/README.md` for the A/B protocol.

## Load-test results (300 docs/pass × 2 passes per arm, us-east-2, 2026-07-10)

First series = **baseline (main, run `886f100a`)**, second series = **this branch (run `0f388461`)**.

### Cold path — full embedding + OpenSearch KNN (pass 1)

```mermaid
xychart-beta
    title "TTC lambda invocation duration (seconds)"
    x-axis ["p50", "p90", "p99", "max"]
    y-axis "seconds" 0 --> 320
    bar [200, 267.5, 278.1, 285.9]
    bar [63.7, 84.6, 88.5, 93]
```

```mermaid
xychart-beta
    title "End-to-end: submission to augmented eICR (seconds)"
    x-axis ["p50", "p90", "p99", "max"]
    y-axis "seconds" 0 --> 360
    bar [314, 318, 320, 321]
    bar [93, 98, 101, 105]
```

| Metric (pass 1) | Baseline | Branch | Δ |
|---|---:|---:|---:|
| TTC lambda p50 | 199,965 ms | 63,734 ms | **−68.1%** |
| TTC lambda p90 | 267,467 ms | 84,569 ms | −68.4% |
| TTC lambda p99 | 278,099 ms | 88,549 ms | −68.2% |
| TTC lambda max | 285,851 ms | 93,010 ms | −67.5% |
| End-to-end p50 | 314 s | 93 s | **−70.4%** |
| End-to-end max | 321 s | 105 s | −67.3% |
| Burst throughput | ~56 docs/min | ~171 docs/min | **3.1×** |
| Augmentation lambda p99 / max | 7,162 / 10,170 ms | 1,465 / 1,495 ms | −80% / −85% |
| Augmentation avg init (cold start) | 1,597 ms | 1,332 ms | −16.6% |

The improvement is uniform across the distribution (p50 through max all ≈ −68%), not just a median win. The augmentation lambda's 10 s tail disappears because the upstream burst clears 3× sooner.

### Warm path — result-cache hits (pass 2)

```mermaid
xychart-beta
    title "TTC lambda invocation duration, warm result cache (ms)"
    x-axis ["p50", "p90", "p99", "max"]
    y-axis "milliseconds" 0 --> 380
    bar [154.9, 178.3, 207.1, 341.1]
    bar [126.4, 142.4, 177.6, 185.5]
```

Median −18%, worst invocation −46% (the batched mget shows up in the tail). Both arms complete end-to-end in 2–3 s on this path.

### Reliability

Exactly 300 invocations attributed per lambda per pass (clean measurement windows, no foreign traffic), 300/300 augmented eICRs delivered in all four passes, **0 errors and 0 timeouts in either arm**.

### Correctness

Every augmented eICR's predicted LOINC translation was checked against its base case's expected code (10 curated hard cases × 30 salted variants):

- **Deterministic within each arm** — pass 1 and pass 2 produced identical match profiles (the result cache returns exactly what the live KNN path computed).
- **Same 7 known-hard cases miss in both arms** (all 30/30 variants) — pre-existing model behavior, untouched here.
- The match-count delta (60 vs 47 of 300) comes entirely from two borderline cases (pCO2 Venous 30/30 → 18/30, fentanyl screen 30/30 → 29/30). The arms embedded *different strings* (the salt marker includes the run/arm label), and the branch arm shows salt-sensitivity within itself (pCO2 matched on 18 salts, missed on 12, same code). This is consistent with salt-induced embedding noise on borderline cases rather than a ranking change; a fixed unsalted corpus run through both images offline would rule out any effect from the embedding batching if we want a definitive check.

Full interactive report (charts + complete tables): [`docs/load-tests/2026-07-10-perf-audit-improvements.html`](https://github.com/CDCgov/dibbs-text-to-code/blob/perf-audit-improvements/docs/load-tests/2026-07-10-perf-audit-improvements.html). Raw per-run JSON stays local under `load_test_runs/` (gitignored).

### Known gap

TTC lambda cold-start init stats came back null from the Logs Insights query in both arms (the report drops null fields), so TTC init time isn't compared; the augmentation lambda's cold starts (25 vs 30) confirm containers were recycled for both arms.

## Test plan

- [x] `just ruff` / `just ty` clean on the new scripts
- [x] Corpus generation smoke-tested locally (salt placement, manifest, report reuse)
- [x] Full A/B run against the deployed environment (results above)
- [x] Existing unit + e2e suites on the perf commits (earlier in branch)
