### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,14 @@ repos:
           - --unsafe
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7 # Ruff version
+    rev: v0.15.22
     hooks:
       - id: ruff-check # Run the linter
         args: [--fix]
       - id: ruff-format # Run the formatter
 
   - repo: https://github.com/JoC0de/pre-commit-prettier
-    rev: v3.8.1
+    rev: v3.9.5
     hooks:
       - id: prettier
 


### PR DESCRIPTION
Update pre-commit hooks because the Ruff versions were out-of-sync.