### PR TITLE
Handle params in just test coverage

### DIFF
--- a/.justscripts/just/test.just
+++ b/.justscripts/just/test.just
@@ -13,8 +13,8 @@ all *ARGS:
     uv run pytest {{ ARGS }}
 
 [doc("Run tests with coverage, specifying the package to measure coverage for")]
-coverage *ARGS:
-    uv run pytest {{ ARGS }} --cov={{ARGS}} --cov-report=term-missing
+coverage PATH *ARGS:
+    uv run pytest {{ PATH }} {{ ARGS }} --cov={{ PATH }} --cov-report=term-missing
 
 [doc("Regenerate validation temp files and run validation tests")]
 validation:


### PR DESCRIPTION
the `just test coverage` command would not correct handle additional parameters, as it is only expecting a path. As an example `just test coverage ./packages/lambda-handler -v` would result in`uv run pytest ./packages/lambda-handler -v --cov=./packages/lambda-handler -v --cov-report=term-missing`.

With this fix:
```
❯ just test coverage ./packages/lambda-handler -v
uv run pytest ./packages/lambda-handler -v --cov=./packages/lambda-handler --cov-report=term-missing
```