### PR TITLE
chore: update dibbs_env.yml for Azure notebooks

### DIFF
--- a/azure_scripts/README.md
+++ b/azure_scripts/README.md
@@ -21,6 +21,11 @@ To use the environment, you need to attach it to your compute instance one time,
 1. Upload `dibbs_env.yml` to your notebook folder within Azure ML Studio.
 2. In Azure ML Studio, open a notebook and start the compute instance attached to your notebook.
 3. Once the compute instance is running, click on the 3 dots to the right of your compute instance selection and choose "Open terminal" from the dropdown.
+
+   Note: If you have a previous version of `DIBBs Env` active in your environment,
+   you need to remove it by running `conda env remove --name dibbs_env` and ensure you
+   have uploaded the newest version of `dibbs_env.yml` before proceeding.
+
 4. Once in the terminal, create the conda environment by running `conda env create -f dibbs_env.yml`
 5. Activate the environment by running `conda activate dibbs_env`
 6. Register the environment as a Jupyter kernel by running `python -m ipykernel install --user --name dibbs_env --display-name "DIBBs Env"`

--- a/azure_scripts/dibbs_env.yml
+++ b/azure_scripts/dibbs_env.yml
@@ -4,6 +4,11 @@ dependencies:
   - pip
   - pip:
       - numpy
-      - torch
+      - torch==2.10
       - sentence-transformers
       - ipykernel # required for attaching the environment to Azure ML compute
+      - azure-keyvault-secrets
+      - azure-identity
+      - azure-ai-ml
+      - azureml-fsspec
+      - setuptools<80 # required until Azure updates python version in their ML SDK to 3.12


### PR DESCRIPTION
## Description

Updates `dibbs_env.yml` file to include the Azure & Azure ML packages so you don't have to pip install them in every notebook. I also pinned two packages: `torch=2.10` and `setuptools<80`, which are specific to the Azure and model set ups we are currently using, but may need to be unpinned in the future. This new environment should result in fewer errors when getting folks started, e.g., no more issues with `pkg_resources`. 

## Related Issues

Closes #732 

## Additional Notes
If you already have `DIBBs Env` in your environment, I added directions for making sure you have a current version in the README. 