### PR TITLE
ops: OSIS pipeline

### DIFF
--- a/docs/runbooks/reingest-loinc-embeddings.md
+++ b/docs/runbooks/reingest-loinc-embeddings.md
@@ -153,7 +153,7 @@ Completion criteria (both must hold):
 - OSIS audit log group: `/aws/vendedlogs/OpenSearchIngestion/ttc-ingestion-pipeline/audit`.
 - Trigger queue draining (one message per file synced in step 4): `aws sqs get-queue-attributes --queue-url <osis-trigger-queue-url> --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible`.
 
-**If the count stalls below expected:** check OSIS log group for parse errors. Common cause: malformed NDJSON. Fix the file in `reingestion/`, re-run from step 6 (the index is already empty). Messages piling up untouched on the trigger queue mean the pipeline isn't consuming at all — check `aws osis get-pipeline`. Objects that fail three times land in `ttc-osis-trigger-queue-dlq` and raise the Slack DLQ alarm.
+**If the count stalls below expected:** check OSIS log group for parse errors; messages piling up untouched on the trigger queue instead mean the pipeline isn't consuming at all — check `aws osis get-pipeline`. Objects that fail three times land in `ttc-osis-trigger-queue-dlq` and raise the Slack DLQ alarm. To retry: fix the file in `reingestion/`, let the trigger queue empty so no in-flight retry lands in the fresh index, then re-run from step 3 — the index holds a partial load and has to be dropped again.
 **If the count exceeds expected:** indicates duplicate ingestion or a manifest mismatch. Pause and investigate before resuming TTC.
 
 ### Step 6 — Resume TTC
@@ -215,9 +215,9 @@ aws lambda invoke \
 # 2. Restore the previous embeddings
 aws s3 sync s3://<bucket>/ingestion-backup-<ts>/ s3://<bucket>/ingestion/
 
-# 3. Wait for OSIS to repopulate (poll _count as in step 7)
+# 3. Wait for OSIS to repopulate
 
-# 4. Resume TTC (same as step 8)
+# 4. Resume TTC
 aws lambda update-event-source-mapping --uuid <esm-uuid> --enabled
 aws lambda put-function-concurrency \
   --function-name ttc-lambda \
@@ -232,7 +232,7 @@ aws lambda put-function-concurrency \
 | Step 2      | Halt is in place; nothing destructive yet. Wait for the stuck Lambda to finish, then re-run pipeline.                      |
 | Step 3      | Index drop failed. Rollback (above) is a no-op (index hasn't been emptied) — just resume TTC manually and re-run pipeline. |
 | Step 4      | Sync partially complete. Run manual rollback to restore from `ingestion-backup-<ts>/`, then re-run pipeline.               |
-| Step 5      | OSIS not catching up. Investigate first; rollback is the same as step 6.                                                   |
+| Step 5      | OSIS not catching up. Investigate first; rollback is the same as for step 4.                                               |
 | Step 6      | **TTC is stuck halted.** Run the two AWS CLI commands manually and page on-call.                                           |
 | Step 7      | Smoke test failed but TTC is running. Investigate logs; do not auto-rollback.                                              |
 

--- a/docs/runbooks/reingest-loinc-embeddings.md
+++ b/docs/runbooks/reingest-loinc-embeddings.md
@@ -33,7 +33,7 @@ Confirm the upload:
 aws s3 ls s3://<bucket>/reingestion/
 ```
 
-`reingestion/` is the only prefix the model build writes to; uploading straight to `ingestion/` would be picked up by the next OSIS scan outside a halt window. The IAM scoping for this upload path is documented under [S3 Data Bucket → Access](../../terraform/README.md#access).
+`reingestion/` is the only prefix the model build writes to. Nothing watches it, so the upload is safe to do at any time. Uploading straight to `ingestion/` would instead raise the S3 event that starts an ingest immediately — outside a halt window, and against an index that still holds the old embeddings. The IAM scoping for this upload path is documented under [S3 Data Bucket → Access](../../terraform/README.md#access).
 
 ### 2. Start the GitLab pipeline
 
@@ -151,8 +151,14 @@ Completion criteria (both must hold):
 - OpenSearch console → Indices → `ttc-index` doc count climbing.
 - OSIS pipeline metrics: `aws osis get-pipeline --pipeline-name ttc-ingestion-pipeline` → look for `recordsIn` / `recordsOut`.
 - OSIS audit log group: `/aws/vendedlogs/OpenSearchIngestion/ttc-ingestion-pipeline/audit`.
+- Trigger queue drain — one message per file synced in step 4, and the pipeline deletes each one only after OpenSearch acknowledges the load:
 
-**If the count stalls below expected:** check OSIS log group for parse errors. Common cause: malformed NDJSON. Fix the file in `reingestion/`, re-run from step 6 (the index is already empty).
+  ```sh
+  aws sqs get-queue-attributes --queue-url <osis-trigger-queue-url> \
+    --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible
+  ```
+
+**If the count stalls below expected:** check OSIS log group for parse errors. Common cause: malformed NDJSON. Fix the file in `reingestion/`, re-run from step 6 (the index is already empty). If the trigger queue is empty while the doc count is short, the events were consumed and the failure is in parsing or in the sink; if messages are piling up visible and untouched, the pipeline isn't consuming — check `aws osis get-pipeline --pipeline-name ttc-ingestion-pipeline`. Objects that fail three times land in `ttc-osis-trigger-queue-dlq` and raise the Slack DLQ alarm.
 **If the count exceeds expected:** indicates duplicate ingestion or a manifest mismatch. Pause and investigate before resuming TTC.
 
 ### Step 6 — Resume TTC
@@ -193,12 +199,12 @@ The pipeline:
 
 Use this if step 3, 4, or 5 fails _before_ TTC has been resumed.
 
-```sh
-# 1. Restore the previous embeddings
-aws s3 rm s3://<bucket>/ingestion/ --recursive
-aws s3 sync s3://<bucket>/ingestion-backup-<ts>/ s3://<bucket>/ingestion/
+Clear the indices _before_ restoring the files: writing to `ingestion/` starts an ingest within seconds, and anything loaded ahead of the drop would be wiped by it.
 
-# 2. Recreate both indices (Vector Search and Result Cache) from the backup contents (OSIS will reload them)
+```sh
+# 1. Empty ingestion/ and recreate both indices (Vector Search and Result Cache)
+aws s3 rm s3://<bucket>/ingestion/ --recursive
+
 aws lambda invoke \
   --function-name ttc-index-lambda \
   --payload '{"action":"clear_index"}' \
@@ -210,6 +216,9 @@ aws lambda invoke \
   --payload '{"action":"clear_result_cache"}' \
   --cli-binary-format raw-in-base64-out \
   /tmp/index-out.json
+
+# 2. Restore the previous embeddings — this is what re-triggers OSIS
+aws s3 sync s3://<bucket>/ingestion-backup-<ts>/ s3://<bucket>/ingestion/
 
 # 3. Wait for OSIS to repopulate (poll _count as in step 7)
 

--- a/docs/runbooks/reingest-loinc-embeddings.md
+++ b/docs/runbooks/reingest-loinc-embeddings.md
@@ -33,7 +33,7 @@ Confirm the upload:
 aws s3 ls s3://<bucket>/reingestion/
 ```
 
-`reingestion/` is the only prefix the model build writes to. Nothing watches it, so the upload is safe to do at any time. Uploading straight to `ingestion/` would instead raise the S3 event that starts an ingest immediately — outside a halt window, and against an index that still holds the old embeddings. The IAM scoping for this upload path is documented under [S3 Data Bucket → Access](../../terraform/README.md#access).
+`reingestion/` is the only prefix the model build writes to, and nothing watches it; uploading straight to `ingestion/` would start an ingest on the spot, outside a halt window. The IAM scoping for this upload path is documented under [S3 Data Bucket → Access](../../terraform/README.md#access).
 
 ### 2. Start the GitLab pipeline
 
@@ -151,14 +151,9 @@ Completion criteria (both must hold):
 - OpenSearch console → Indices → `ttc-index` doc count climbing.
 - OSIS pipeline metrics: `aws osis get-pipeline --pipeline-name ttc-ingestion-pipeline` → look for `recordsIn` / `recordsOut`.
 - OSIS audit log group: `/aws/vendedlogs/OpenSearchIngestion/ttc-ingestion-pipeline/audit`.
-- Trigger queue drain — one message per file synced in step 4, and the pipeline deletes each one only after OpenSearch acknowledges the load:
+- Trigger queue draining (one message per file synced in step 4): `aws sqs get-queue-attributes --queue-url <osis-trigger-queue-url> --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible`.
 
-  ```sh
-  aws sqs get-queue-attributes --queue-url <osis-trigger-queue-url> \
-    --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible
-  ```
-
-**If the count stalls below expected:** check OSIS log group for parse errors. Common cause: malformed NDJSON. Fix the file in `reingestion/`, re-run from step 6 (the index is already empty). If the trigger queue is empty while the doc count is short, the events were consumed and the failure is in parsing or in the sink; if messages are piling up visible and untouched, the pipeline isn't consuming — check `aws osis get-pipeline --pipeline-name ttc-ingestion-pipeline`. Objects that fail three times land in `ttc-osis-trigger-queue-dlq` and raise the Slack DLQ alarm.
+**If the count stalls below expected:** check OSIS log group for parse errors. Common cause: malformed NDJSON. Fix the file in `reingestion/`, re-run from step 6 (the index is already empty). Messages piling up untouched on the trigger queue mean the pipeline isn't consuming at all — check `aws osis get-pipeline`. Objects that fail three times land in `ttc-osis-trigger-queue-dlq` and raise the Slack DLQ alarm.
 **If the count exceeds expected:** indicates duplicate ingestion or a manifest mismatch. Pause and investigate before resuming TTC.
 
 ### Step 6 — Resume TTC
@@ -199,7 +194,7 @@ The pipeline:
 
 Use this if step 3, 4, or 5 fails _before_ TTC has been resumed.
 
-Clear the indices _before_ restoring the files: writing to `ingestion/` starts an ingest within seconds, and anything loaded ahead of the drop would be wiped by it.
+Clear the indices _before_ restoring the files — the restore is what re-triggers OSIS, so a drop after it would wipe what just loaded.
 
 ```sh
 # 1. Empty ingestion/ and recreate both indices (Vector Search and Result Cache)
@@ -217,7 +212,7 @@ aws lambda invoke \
   --cli-binary-format raw-in-base64-out \
   /tmp/index-out.json
 
-# 2. Restore the previous embeddings — this is what re-triggers OSIS
+# 2. Restore the previous embeddings
 aws s3 sync s3://<bucket>/ingestion-backup-<ts>/ s3://<bucket>/ingestion/
 
 # 3. Wait for OSIS to repopulate (poll _count as in step 7)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -65,7 +65,7 @@ Each Lambda function has its own IAM role scoped to least-privilege S3 permissio
   - `AWSLambdaVPCAccessExecutionRole` — allows ENI creation for VPC placement
   - `AWSLambdaBasicExecutionRole` — allows CloudWatch Logs writes
   - Inline S3 policy — `s3:PutObject` on `AugmentationEICRV2/` and `AugmentationMetadataV2/` prefixes (no OpenSearch access needed)
-- **Ingestion Pipeline IAM Role** (`aws_iam_role.os_ingestion_pipeline_role`): Assumed by the OSIS pipeline service. Grants S3 `ListBucket`/`GetBucketLocation`/`GetObject` on the data bucket, `sqs:ReceiveMessage`/`DeleteMessage`/`GetQueueAttributes`/`ChangeMessageVisibility` on the pipeline's trigger queue, and full OpenSearch HTTP access on the domain.
+- **Ingestion Pipeline IAM Role** (`aws_iam_role.os_ingestion_pipeline_role`): Assumed by the OSIS pipeline service. Grants S3 `ListBucket`/`GetBucketLocation`/`GetObject` on the data bucket, consume access (receive/delete/visibility) on the pipeline's trigger queue, and full OpenSearch HTTP access on the domain.
 
 ### Lambda Functions (`main.tf`, `lambda/`)
 
@@ -199,24 +199,15 @@ The pipeline **depends on** the index bootstrap invocation completing first, ens
 
 #### Event-driven source
 
-The pipeline's S3 source runs in `notification_type: sqs` mode against **`ttc-osis-trigger-queue`** (`aws_sqs_queue.osis_trigger_queue`), replacing the 30-day scheduled scan (`scan.scheduling.interval = PT720H`) it used previously. This is what makes the re-ingestion runbook work: syncing new embeddings into `ingestion/` is itself the trigger, with no scan interval to wait out. See [`docs/spikes/502-reingestion-pause.md`](../docs/spikes/502-reingestion-pause.md) and [`docs/runbooks/reingest-loinc-embeddings.md`](../docs/runbooks/reingest-loinc-embeddings.md).
+The S3 source runs in `notification_type: sqs` mode against **`ttc-osis-trigger-queue`** (`aws_sqs_queue.osis_trigger_queue`), replacing the 30-day scheduled scan it used before. Writing to `ingestion/` is now itself the trigger, which is what makes the [re-ingestion runbook](../docs/runbooks/reingest-loinc-embeddings.md) work.
 
-**Events reach the queue through EventBridge** (`aws_cloudwatch_event_rule.osis_ingestion_s3_trigger` → `aws_cloudwatch_event_target.osis_trigger_sqs_target`), not through a direct S3 bucket notification. Two reasons:
+Events reach the queue through **EventBridge** (`aws_cloudwatch_event_rule.osis_ingestion_s3_trigger`) rather than a direct bucket notification: `s3.tf` already spends the bucket's one allowed notification configuration on `eventbridge = true`, and this matches how `ttc-lambda-queue` and `ttc-augmentation-lambda-queue` are wired. Hence `notification_source: eventbridge` on the source — those messages differ in shape from raw S3 notifications.
 
-1. A bucket accepts exactly one notification configuration, and `s3.tf` already declares `aws_s3_bucket_notification.ttc_eventbridge` with `eventbridge = true`. Adding queue targets means folding them into that same resource, where a mistake takes the TTC and augmentation triggers down with it.
-2. It matches how every other S3-driven consumer in this stack is wired (`ttc-lambda-queue`, `ttc-augmentation-lambda-queue`), so there is one pattern to reason about.
+- **10-minute visibility timeout** (`osis_trigger_visibility_timeout`), on both the queue and the source. With `acknowledgments: true` a message is deleted only once OpenSearch confirms the write, so it has to outlast one object's full read-and-index time.
+- **`visibility_duplication_protection: true`, `maximum_messages: 1`.** Documents carry no explicit `_id`, so a redelivered object duplicates every document in it. Batch size 1 sidesteps [data-prepper#4812](https://github.com/opensearch-project/data-prepper/issues/4812) and costs nothing at `workers: 1`.
+- **`ttc-osis-trigger-queue-dlq`** takes events that fail three times, alarming to the same Slack channel as the Lambda DLQs.
 
-The trade-off is one extra hop of latency (typically a second or two) and a dependency on the bucket's EventBridge flag staying on — acceptable for a bulk-load path. The source therefore sets `notification_source: eventbridge`, since EventBridge messages have a different shape than raw S3 event notifications.
-
-Other source settings worth knowing:
-
-- **Visibility timeout — 10 minutes** (`osis_trigger_visibility_timeout`), applied to both the queue and the source's `visibility_timeout`. With `acknowledgments: true` the pipeline deletes a message only after OpenSearch acknowledges the write, so the message must stay invisible for the entire read-plus-index time of one NDJSON object.
-- **`visibility_duplication_protection: true`** with **`maximum_messages: 1`**. Documents are indexed without an explicit `_id`, so a redelivered object becomes a second copy of every document in it — which the runbook's `_count` gate would read as an overshoot. Duplication protection extends visibility while an object is in flight; the batch size of 1 avoids a known failure of that mechanism on large objects when a full batch of 10 is claimed at once ([data-prepper#4812](https://github.com/opensearch-project/data-prepper/issues/4812)), and costs nothing since `workers: 1` processes serially regardless.
-- **`ttc-osis-trigger-queue-dlq`** takes any event that fails three times, and alarms into the same Slack channel as the Lambda DLQs. Without it a poison object would loop silently until the retention period expired.
-
-Because the source is event-driven, the pipeline only sees objects created **after** it starts polling. Files already sitting in `ingestion/` when the pipeline is created are not loaded — see [Prerequisites](#prerequisites).
-
-Two things now write to `ingestion/` and so start an ingest: the re-ingestion runbook's full swap, and the **Terminology Updates** workflow (`.github/workflows/teminology_update.yml`), which drops a dated `<terminology>_<date>_<count>.jsonl` delta per run. The deltas used to sit until the next monthly scan and now land in the index within a minute of the workflow finishing. Each run writes a new key, so nothing is re-read.
+Only objects created **after** the pipeline starts polling are ingested — files already sitting in `ingestion/` are not (see [Prerequisites](#prerequisites)). The Terminology Updates workflow also writes here, so its deltas now land within minutes instead of waiting for the next scan.
 
 Third-party deployers should ensure the following:
 
@@ -236,7 +227,7 @@ Terraform manages dependency ordering automatically, but conceptually the sequen
 4. OpenSearch domain and VPC endpoint created
 5. Lambda IAM roles created (one per Lambda function)
 6. Index bootstrap Lambda deployed and **immediately invoked** — creates the KNN index and the Result Cache index in OpenSearch.
-7. Ingestion trigger queue, its DLQ, and the EventBridge rule created; ingestion pipeline deployed — begins polling the queue for `ingestion/` object events
+7. Ingestion trigger queue, DLQ and EventBridge rule created; ingestion pipeline deployed — begins polling the queue
 8. Main TTC Lambda deployed with container image from ECR — loads model at cold start, ready to serve KNN queries
 9. Augmentation Lambda deployed with container image from ECR — ready to process augmentation requests
 
@@ -275,7 +266,7 @@ terraform/
 Before running `terraform apply`:
 
 1. **Bootstrap**: Run `terraform apply` in `bootstrap/` first to create the S3 state bucket and DynamoDB lock table.
-2. **Embedding files**: Upload NDJSON embedding files to `s3://dibbs-text-to-code/ingestion/` **after** the OSIS pipeline exists — the upload is the ingest trigger. If the files were already there before the pipeline was created (a rebuilt environment, say), re-copy them onto themselves to raise fresh `ObjectCreated` events:
+2. **Embedding files**: Upload NDJSON embedding files to `s3://dibbs-text-to-code/ingestion/` **after** the OSIS pipeline exists — the upload is the ingest trigger. Files that predate the pipeline need a self-copy to raise fresh `ObjectCreated` events:
 
    ```sh
    aws s3 cp s3://dibbs-text-to-code/ingestion/ s3://dibbs-text-to-code/ingestion/ \

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,9 +11,10 @@ S3 Bucket (dibbs-text-to-code)
     │       │  synced by the re-ingestion pipeline during a model update
     │       ▼
     ├── ingestion/ prefix
+    │       │  ObjectCreated → EventBridge → ttc-osis-trigger-queue (SQS)
     │       │
     │       └── OpenSearch Ingestion Pipeline (OSIS)
-    │               │  polls monthly, reads NDJSON
+    │               │  polls the queue, reads NDJSON
     │               ▼
     │       OpenSearch Domain (ttc-os-domain)
     │               ▲
@@ -64,7 +65,7 @@ Each Lambda function has its own IAM role scoped to least-privilege S3 permissio
   - `AWSLambdaVPCAccessExecutionRole` — allows ENI creation for VPC placement
   - `AWSLambdaBasicExecutionRole` — allows CloudWatch Logs writes
   - Inline S3 policy — `s3:PutObject` on `AugmentationEICRV2/` and `AugmentationMetadataV2/` prefixes (no OpenSearch access needed)
-- **Ingestion Pipeline IAM Role** (`aws_iam_role.os_ingestion_pipeline_role`): Assumed by the OSIS pipeline service. Grants S3 `ListBucket`/`GetObject` on the data bucket and full OpenSearch HTTP access on the domain.
+- **Ingestion Pipeline IAM Role** (`aws_iam_role.os_ingestion_pipeline_role`): Assumed by the OSIS pipeline service. Grants S3 `ListBucket`/`GetBucketLocation`/`GetObject` on the data bucket, `sqs:ReceiveMessage`/`DeleteMessage`/`GetQueueAttributes`/`ChangeMessageVisibility` on the pipeline's trigger queue, and full OpenSearch HTTP access on the domain.
 
 ### Lambda Functions (`main.tf`, `lambda/`)
 
@@ -188,13 +189,34 @@ fields @timestamp, service, function_name, function_request_id, persistence_id, 
 
 An **AWS OpenSearch Ingestion Service (OSIS)** pipeline (`aws_osis_pipeline.ttc_ingestion_pipeline`) that:
 
-- Polls `s3://dibbs-text-to-code/ingestion/` monthly for new NDJSON files
+- Ingests **on S3 event**, not on a schedule: writing an object under `s3://dibbs-text-to-code/ingestion/` starts a load within seconds
 - Parses each line as a document and bulk-writes it into the `ttc-index` OpenSearch index
 - Runs within the VPC using the same private subnets as Lambda
 - Logs audit events to CloudWatch Logs (`/aws/vendedlogs/OpenSearchIngestion/ttc-ingestion-pipeline/audit-logs`, 14-day retention)
 - Scales between 1 and 4 OCUs (OpenSearch Compute Units)
 
 The pipeline **depends on** the index bootstrap invocation completing first, ensuring the KNN-enabled index and the Result Cache Index exist before any data is loaded (wiping and refilling the Result Cache index as well as the normal Index for vector embeddings ensures that previously computed hashes do not survive either LOINC updates or model updates).
+
+#### Event-driven source
+
+The pipeline's S3 source runs in `notification_type: sqs` mode against **`ttc-osis-trigger-queue`** (`aws_sqs_queue.osis_trigger_queue`), replacing the 30-day scheduled scan (`scan.scheduling.interval = PT720H`) it used previously. This is what makes the re-ingestion runbook work: syncing new embeddings into `ingestion/` is itself the trigger, with no scan interval to wait out. See [`docs/spikes/502-reingestion-pause.md`](../docs/spikes/502-reingestion-pause.md) and [`docs/runbooks/reingest-loinc-embeddings.md`](../docs/runbooks/reingest-loinc-embeddings.md).
+
+**Events reach the queue through EventBridge** (`aws_cloudwatch_event_rule.osis_ingestion_s3_trigger` → `aws_cloudwatch_event_target.osis_trigger_sqs_target`), not through a direct S3 bucket notification. Two reasons:
+
+1. A bucket accepts exactly one notification configuration, and `s3.tf` already declares `aws_s3_bucket_notification.ttc_eventbridge` with `eventbridge = true`. Adding queue targets means folding them into that same resource, where a mistake takes the TTC and augmentation triggers down with it.
+2. It matches how every other S3-driven consumer in this stack is wired (`ttc-lambda-queue`, `ttc-augmentation-lambda-queue`), so there is one pattern to reason about.
+
+The trade-off is one extra hop of latency (typically a second or two) and a dependency on the bucket's EventBridge flag staying on — acceptable for a bulk-load path. The source therefore sets `notification_source: eventbridge`, since EventBridge messages have a different shape than raw S3 event notifications.
+
+Other source settings worth knowing:
+
+- **Visibility timeout — 10 minutes** (`osis_trigger_visibility_timeout`), applied to both the queue and the source's `visibility_timeout`. With `acknowledgments: true` the pipeline deletes a message only after OpenSearch acknowledges the write, so the message must stay invisible for the entire read-plus-index time of one NDJSON object.
+- **`visibility_duplication_protection: true`** with **`maximum_messages: 1`**. Documents are indexed without an explicit `_id`, so a redelivered object becomes a second copy of every document in it — which the runbook's `_count` gate would read as an overshoot. Duplication protection extends visibility while an object is in flight; the batch size of 1 avoids a known failure of that mechanism on large objects when a full batch of 10 is claimed at once ([data-prepper#4812](https://github.com/opensearch-project/data-prepper/issues/4812)), and costs nothing since `workers: 1` processes serially regardless.
+- **`ttc-osis-trigger-queue-dlq`** takes any event that fails three times, and alarms into the same Slack channel as the Lambda DLQs. Without it a poison object would loop silently until the retention period expired.
+
+Because the source is event-driven, the pipeline only sees objects created **after** it starts polling. Files already sitting in `ingestion/` when the pipeline is created are not loaded — see [Prerequisites](#prerequisites).
+
+Two things now write to `ingestion/` and so start an ingest: the re-ingestion runbook's full swap, and the **Terminology Updates** workflow (`.github/workflows/teminology_update.yml`), which drops a dated `<terminology>_<date>_<count>.jsonl` delta per run. The deltas used to sit until the next monthly scan and now land in the index within a minute of the workflow finishing. Each run writes a new key, so nothing is re-read.
 
 Third-party deployers should ensure the following:
 
@@ -214,7 +236,7 @@ Terraform manages dependency ordering automatically, but conceptually the sequen
 4. OpenSearch domain and VPC endpoint created
 5. Lambda IAM roles created (one per Lambda function)
 6. Index bootstrap Lambda deployed and **immediately invoked** — creates the KNN index and the Result Cache index in OpenSearch.
-7. Ingestion pipeline deployed — begins polling S3 for NDJSON embeddings to load
+7. Ingestion trigger queue, its DLQ, and the EventBridge rule created; ingestion pipeline deployed — begins polling the queue for `ingestion/` object events
 8. Main TTC Lambda deployed with container image from ECR — loads model at cold start, ready to serve KNN queries
 9. Augmentation Lambda deployed with container image from ECR — ready to process augmentation requests
 
@@ -253,7 +275,13 @@ terraform/
 Before running `terraform apply`:
 
 1. **Bootstrap**: Run `terraform apply` in `bootstrap/` first to create the S3 state bucket and DynamoDB lock table.
-2. **Embedding files**: Upload NDJSON embedding files to `s3://dibbs-text-to-code/ingestion/`. The OSIS pipeline will ingest these into OpenSearch.
+2. **Embedding files**: Upload NDJSON embedding files to `s3://dibbs-text-to-code/ingestion/` **after** the OSIS pipeline exists — the upload is the ingest trigger. If the files were already there before the pipeline was created (a rebuilt environment, say), re-copy them onto themselves to raise fresh `ObjectCreated` events:
+
+   ```sh
+   aws s3 cp s3://dibbs-text-to-code/ingestion/ s3://dibbs-text-to-code/ingestion/ \
+     --recursive --metadata-directive REPLACE
+   ```
+
 3. **Docker**: CI/CD builds all container images (`Dockerfile.ttc` for TTC lambda, `Dockerfile.index` for index lambda, `Dockerfile.augmentation` for augmentation lambda) automatically. For local development, Docker must be available to build the images.
 
 > **Note:** The SentenceTransformer model and heavy Python dependencies (sentence-transformers, torch) are baked into the Lambda container image at build time via the Dockerfile. The Dockerfile installs the real `text-to-code-lambda` package and all its workspace dependencies.
@@ -261,6 +289,5 @@ Before running `terraform apply`:
 ## Known TODOs
 
 - OpenSearch error logs should be sent to CloudWatch Logs (noted in `main.tf`)
-- Polling frequency for the OSIS pipeline is set to monthly since LOINC updates infrequently, but can be adjusted as needed
 - The `/ingestion/` and `/reingestion/` prefixes in the `dibbs-text-to-code` S3 bucket should be created as part of Terraform rather than manually (Terraform declares their names in `_variables.tf` but creates no placeholder objects — see [S3 Data Bucket](#s3-data-bucket-s3tf))
 - Neither `reingestion/` nor `ingestion-backup-<ts>/` has an S3 lifecycle rule; cleanup is a manual operator step. An expiration rule on `ingestion-backup-*` would be a reasonable safety net

--- a/terraform/_outputs.tf
+++ b/terraform/_outputs.tf
@@ -49,6 +49,11 @@ output "augmentation_lambda_function_name" {
   description = "The name of the augmentation lambda function"
 }
 
+output "osis_trigger_queue_url" {
+  value       = aws_sqs_queue.osis_trigger_queue.url
+  description = "URL of the SQS queue the OpenSearch ingestion pipeline polls for S3 ObjectCreated events on the ingestion prefix"
+}
+
 output "demo_url" {
   value       = "https://${var.demo_domain_name}"
   description = "The URL of the TTC demo (Basic auth required)"

--- a/terraform/_outputs.tf
+++ b/terraform/_outputs.tf
@@ -51,7 +51,7 @@ output "augmentation_lambda_function_name" {
 
 output "osis_trigger_queue_url" {
   value       = aws_sqs_queue.osis_trigger_queue.url
-  description = "URL of the SQS queue the OpenSearch ingestion pipeline polls for S3 ObjectCreated events on the ingestion prefix"
+  description = "URL of the SQS queue the OpenSearch ingestion pipeline polls for ingestion-prefix object events"
 }
 
 output "demo_url" {

--- a/terraform/_variables.tf
+++ b/terraform/_variables.tf
@@ -89,13 +89,13 @@ variable "ingestion_pipeline_name" {
 variable "osis_trigger_queue_name" {
   type        = string
   default     = "ttc-osis-trigger-queue"
-  description = "The SQS queue OSIS polls for S3 ObjectCreated events on ingestion_prefix. Events reach it via S3 -> EventBridge -> SQS, the same path the TTC and augmentation Lambdas use"
+  description = "The SQS queue OSIS polls for S3 ObjectCreated events on ingestion_prefix, delivered via EventBridge"
 }
 
 variable "osis_trigger_visibility_timeout" {
   type        = number
   default     = 600
-  description = "Visibility timeout in seconds for osis_trigger_queue_name, and the matching visibility_timeout on the pipeline's SQS source. 10 minutes per the SPIKE's 5-10 minute guidance: a message stays invisible for the whole time OSIS spends reading an NDJSON object and waiting for the sink acknowledgment, so a value below the per-object ingest time would redeliver the object and duplicate documents. See docs/spikes/502-reingestion-pause.md"
+  description = "Visibility timeout in seconds for osis_trigger_queue_name, mirrored onto the pipeline source. Must outlast one object's read-and-index time, since acknowledgments defer the message delete until OpenSearch confirms the write. 10 minutes, per the SPIKE's 5-10 minute guidance"
 }
 
 variable "s3_bucket" {
@@ -107,7 +107,7 @@ variable "s3_bucket" {
 variable "ingestion_prefix" {
   type        = string
   default     = "ingestion/"
-  description = "The prefix for the ingestion pipeline 'folder' in the s3 bucket. Creating a file under this prefix raises an S3 ObjectCreated event that EventBridge routes to osis_trigger_queue_name, and the ingestion pipeline loads the file into OpenSearch. The trailing slash keeps the EventBridge prefix match from also matching reingestion_prefix or ingestion_backup_prefix"
+  description = "The prefix for the ingestion pipeline 'folder' in the s3 bucket. Creating a file here raises the S3 event that triggers ingestion into OpenSearch. The trailing slash keeps the EventBridge prefix match from also matching reingestion_prefix or ingestion_backup_prefix"
 }
 
 variable "reingestion_prefix" {

--- a/terraform/_variables.tf
+++ b/terraform/_variables.tf
@@ -86,6 +86,18 @@ variable "ingestion_pipeline_name" {
   default = "ttc-ingestion-pipeline"
 }
 
+variable "osis_trigger_queue_name" {
+  type        = string
+  default     = "ttc-osis-trigger-queue"
+  description = "The SQS queue OSIS polls for S3 ObjectCreated events on ingestion_prefix. Events reach it via S3 -> EventBridge -> SQS, the same path the TTC and augmentation Lambdas use"
+}
+
+variable "osis_trigger_visibility_timeout" {
+  type        = number
+  default     = 600
+  description = "Visibility timeout in seconds for osis_trigger_queue_name, and the matching visibility_timeout on the pipeline's SQS source. 10 minutes per the SPIKE's 5-10 minute guidance: a message stays invisible for the whole time OSIS spends reading an NDJSON object and waiting for the sink acknowledgment, so a value below the per-object ingest time would redeliver the object and duplicate documents. See docs/spikes/502-reingestion-pause.md"
+}
+
 variable "s3_bucket" {
   type        = string
   default     = "dibbs-text-to-code"
@@ -95,7 +107,7 @@ variable "s3_bucket" {
 variable "ingestion_prefix" {
   type        = string
   default     = "ingestion/"
-  description = "The prefix for the ingestion pipeline 'folder' in the s3 bucket. Files added to this prefix will be ingested into OpenSearch by the ingestion pipeline. The trailing slash keeps the OSIS scan from also matching ingestion_backup_prefix"
+  description = "The prefix for the ingestion pipeline 'folder' in the s3 bucket. Creating a file under this prefix raises an S3 ObjectCreated event that EventBridge routes to osis_trigger_queue_name, and the ingestion pipeline loads the file into OpenSearch. The trailing slash keeps the EventBridge prefix match from also matching reingestion_prefix or ingestion_backup_prefix"
 }
 
 variable "reingestion_prefix" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -637,7 +637,8 @@ resource "aws_iam_role_policy" "os_ingestion_pipeline_policy" {
           "Sid" : "AllowS3BucketListing",
           "Effect" : "Allow",
           "Action" : [
-            "s3:ListBucket"
+            "s3:ListBucket",
+            "s3:GetBucketLocation"
           ],
           "Resource" : "arn:aws:s3:::${var.s3_bucket}"
         },
@@ -648,6 +649,20 @@ resource "aws_iam_role_policy" "os_ingestion_pipeline_policy" {
             "s3:GetObject"
           ],
           "Resource" : "arn:aws:s3:::${var.s3_bucket}/*"
+        },
+        {
+          # The SQS-notification source polls, reads and deletes the trigger
+          # queue's messages itself. ChangeMessageVisibility backs
+          # visibility_duplication_protection on the pipeline source.
+          "Sid" : "AllowOsisTriggerQueueConsumption",
+          "Effect" : "Allow",
+          "Action" : [
+            "sqs:ReceiveMessage",
+            "sqs:DeleteMessage",
+            "sqs:GetQueueAttributes",
+            "sqs:ChangeMessageVisibility"
+          ],
+          "Resource" : aws_sqs_queue.osis_trigger_queue.arn
         },
         {
           "Sid" : "OpenSearchAccess",
@@ -689,6 +704,98 @@ resource "aws_cloudwatch_log_group" "ttc_ingestion_pipeline_logs" {
   retention_in_days = 14
 }
 
+#############
+# Ingestion Pipeline Trigger Queue (S3 -> EventBridge -> SQS -> OSIS)
+#
+# The pipeline source is event-driven rather than a scheduled scan, so syncing
+# files into ingestion_prefix starts an ingest immediately. Events are routed
+# through EventBridge instead of a direct S3 bucket notification: the bucket
+# already carries an eventbridge-only aws_s3_bucket_notification (s3.tf), a
+# bucket accepts only one notification configuration, and adding queue targets
+# there would put this queue and the existing TTC/augmentation rules in the same
+# resource where a drift on one silently breaks the others.
+#############
+
+resource "aws_sqs_queue" "osis_trigger_dlq" {
+  name                      = "${var.osis_trigger_queue_name}-dlq"
+  message_retention_seconds = 1209600
+  tags                      = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "osis_trigger_dlq_visible_messages" {
+  alarm_name          = "${aws_sqs_queue.osis_trigger_dlq.name}-visible-messages"
+  alarm_description   = "Visible messages are present in the OSIS trigger DLQ: an ingestion/ object failed to load into OpenSearch three times."
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [aws_sns_topic.dlq_alarm_notifications.arn]
+
+  dimensions = {
+    QueueName = aws_sqs_queue.osis_trigger_dlq.name
+  }
+
+  tags = local.tags
+}
+
+resource "aws_sqs_queue" "osis_trigger_queue" {
+  name                       = var.osis_trigger_queue_name
+  visibility_timeout_seconds = var.osis_trigger_visibility_timeout
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.osis_trigger_dlq.arn
+    maxReceiveCount     = 3
+  })
+
+  tags = local.tags
+}
+
+resource "aws_sqs_queue_policy" "osis_trigger_queue_policy" {
+  queue_url = aws_sqs_queue.osis_trigger_queue.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.osis_trigger_queue.arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "osis_ingestion_s3_trigger" {
+  name        = "${var.ingestion_pipeline_name}-s3-trigger"
+  description = "Trigger the OpenSearch ingestion pipeline when embeddings are written to the ingestion prefix in S3"
+
+  # ingestion_prefix carries a trailing slash, so neither reingestion/ nor
+  # ingestion-backup-<ts>/ matches this rule.
+  event_pattern = jsonencode({
+    source      = ["aws.s3"]
+    detail-type = ["Object Created"]
+    detail = {
+      bucket = { name = [var.s3_bucket] }
+      object = { key = [{ prefix = var.ingestion_prefix }] }
+    }
+  })
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "osis_trigger_sqs_target" {
+  rule      = aws_cloudwatch_event_rule.osis_ingestion_s3_trigger.name
+  target_id = "${var.ingestion_pipeline_name}-sqs"
+  arn       = aws_sqs_queue.osis_trigger_queue.arn
+}
+
 
 resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
   pipeline_name = var.ingestion_pipeline_name
@@ -716,15 +823,19 @@ resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
       source:
         s3:
           acknowledgments: true
-          scan:
-            buckets:
-              - bucket:
-                  name: ${var.s3_bucket}
-                  filter:
-                    include_prefix:
-                      - ${var.ingestion_prefix}
-            scheduling:
-              interval: PT720H
+          notification_type: sqs
+          notification_source: eventbridge
+          sqs:
+            queue_url: ${aws_sqs_queue.osis_trigger_queue.url}
+            visibility_timeout: PT${var.osis_trigger_visibility_timeout}S
+            # Keeps a long-running object from being redelivered and ingested
+            # twice; documents carry no explicit _id, so a duplicate read is a
+            # duplicate document. Read one message at a time: duplication
+            # protection is unreliable on large objects when a full batch of 10
+            # is claimed at once (data-prepper#4812), and workers is 1 anyway,
+            # so a larger batch would buy no parallelism.
+            visibility_duplication_protection: true
+            maximum_messages: '1'
           aws:
             region: ${var.region}
             sts_role_arn: ${aws_iam_role.os_ingestion_pipeline_role.arn}
@@ -751,9 +862,14 @@ resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
       
   EOT
 
+  # OSIS validates the pipeline role's access when the pipeline is created, so
+  # the role's inline policy and the queue's send policy must be in place first;
+  # neither is reachable from the configuration body's interpolations.
   depends_on = [
     aws_lambda_invocation.index_bootstrap,
-    aws_lambda_invocation.result_cache_index_bootstrap
+    aws_lambda_invocation.result_cache_index_bootstrap,
+    aws_iam_role_policy.os_ingestion_pipeline_policy,
+    aws_sqs_queue_policy.osis_trigger_queue_policy
   ]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -651,9 +651,7 @@ resource "aws_iam_role_policy" "os_ingestion_pipeline_policy" {
           "Resource" : "arn:aws:s3:::${var.s3_bucket}/*"
         },
         {
-          # The SQS-notification source polls, reads and deletes the trigger
-          # queue's messages itself. ChangeMessageVisibility backs
-          # visibility_duplication_protection on the pipeline source.
+          # ChangeMessageVisibility backs visibility_duplication_protection.
           "Sid" : "AllowOsisTriggerQueueConsumption",
           "Effect" : "Allow",
           "Action" : [
@@ -707,13 +705,8 @@ resource "aws_cloudwatch_log_group" "ttc_ingestion_pipeline_logs" {
 #############
 # Ingestion Pipeline Trigger Queue (S3 -> EventBridge -> SQS -> OSIS)
 #
-# The pipeline source is event-driven rather than a scheduled scan, so syncing
-# files into ingestion_prefix starts an ingest immediately. Events are routed
-# through EventBridge instead of a direct S3 bucket notification: the bucket
-# already carries an eventbridge-only aws_s3_bucket_notification (s3.tf), a
-# bucket accepts only one notification configuration, and adding queue targets
-# there would put this queue and the existing TTC/augmentation rules in the same
-# resource where a drift on one silently breaks the others.
+# EventBridge rather than a direct bucket notification: s3.tf already spends the
+# bucket's one allowed notification configuration on eventbridge = true.
 #############
 
 resource "aws_sqs_queue" "osis_trigger_dlq" {
@@ -724,7 +717,7 @@ resource "aws_sqs_queue" "osis_trigger_dlq" {
 
 resource "aws_cloudwatch_metric_alarm" "osis_trigger_dlq_visible_messages" {
   alarm_name          = "${aws_sqs_queue.osis_trigger_dlq.name}-visible-messages"
-  alarm_description   = "Visible messages are present in the OSIS trigger DLQ: an ingestion/ object failed to load into OpenSearch three times."
+  alarm_description   = "Visible messages are present in the OSIS trigger DLQ."
   namespace           = "AWS/SQS"
   metric_name         = "ApproximateNumberOfMessagesVisible"
   statistic           = "Maximum"
@@ -776,8 +769,7 @@ resource "aws_cloudwatch_event_rule" "osis_ingestion_s3_trigger" {
   name        = "${var.ingestion_pipeline_name}-s3-trigger"
   description = "Trigger the OpenSearch ingestion pipeline when embeddings are written to the ingestion prefix in S3"
 
-  # ingestion_prefix carries a trailing slash, so neither reingestion/ nor
-  # ingestion-backup-<ts>/ matches this rule.
+  # The trailing slash on ingestion_prefix excludes reingestion/ and ingestion-backup-*/.
   event_pattern = jsonencode({
     source      = ["aws.s3"]
     detail-type = ["Object Created"]
@@ -828,12 +820,8 @@ resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
           sqs:
             queue_url: ${aws_sqs_queue.osis_trigger_queue.url}
             visibility_timeout: PT${var.osis_trigger_visibility_timeout}S
-            # Keeps a long-running object from being redelivered and ingested
-            # twice; documents carry no explicit _id, so a duplicate read is a
-            # duplicate document. Read one message at a time: duplication
-            # protection is unreliable on large objects when a full batch of 10
-            # is claimed at once (data-prepper#4812), and workers is 1 anyway,
-            # so a larger batch would buy no parallelism.
+            # Documents carry no explicit _id, so a redelivered object duplicates
+            # every document in it. Batch of 1 sidesteps data-prepper#4812.
             visibility_duplication_protection: true
             maximum_messages: '1'
           aws:
@@ -862,9 +850,8 @@ resource "aws_osis_pipeline" "ttc_ingestion_pipeline" {
       
   EOT
 
-  # OSIS validates the pipeline role's access when the pipeline is created, so
-  # the role's inline policy and the queue's send policy must be in place first;
-  # neither is reachable from the configuration body's interpolations.
+  # OSIS validates the pipeline role's access at create time, and neither policy
+  # is reachable through the configuration body's interpolations.
   depends_on = [
     aws_lambda_invocation.index_bootstrap,
     aws_lambda_invocation.result_cache_index_bootstrap,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -760,6 +760,11 @@ resource "aws_sqs_queue_policy" "osis_trigger_queue_policy" {
         Principal = { Service = "events.amazonaws.com" }
         Action    = "sqs:SendMessage"
         Resource  = aws_sqs_queue.osis_trigger_queue.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.osis_ingestion_s3_trigger.arn
+          }
+        }
       }
     ]
   })
@@ -1063,6 +1068,11 @@ resource "aws_sqs_queue_policy" "augmentation_queue_policy" {
         Principal = { Service = "events.amazonaws.com" }
         Action    = "sqs:SendMessage"
         Resource  = aws_sqs_queue.augmentation_queue.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.augmentation_s3_trigger.arn
+          }
+        }
       }
     ]
   })
@@ -1180,6 +1190,11 @@ resource "aws_sqs_queue_policy" "ttc_input_queue_policy" {
         Principal = { Service = "events.amazonaws.com" }
         Action    = "sqs:SendMessage"
         Resource  = aws_sqs_queue.ttc_input_queue.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.ttc_input_s3_trigger.arn
+          }
+        }
       }
     ]
   })


### PR DESCRIPTION
## Description

Makes the OSIS pipeline (`ttc-ingestion-pipeline`) event-driven. It previously ingested via a scheduled S3 scan every 30 days (`scan.scheduling.interval = PT720H`), so the re-ingestion runbook's "sync files into `ingestion/`" step had nothing to trigger. The source now consumes S3 `ObjectCreated` notifications from a new SQS queue, and a sync into `ingestion/` starts a load.

## Related Issues

Closes #695

## Additional Notes

[Add any additional context or notes that reviewers should know about.]
