### PR TITLE
Release v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dibbs-text-to-code-root"
-version = "0.2.5"
+version = "0.3.0"
 description = ""
 authors = [
   { name = "Brady Fausett", email = "bradyfausett@skylight.digital" },

--- a/uv.lock
+++ b/uv.lock
@@ -542,7 +542,7 @@ requires-dist = [
 
 [[package]]
 name = "dibbs-text-to-code-root"
-version = "0.2.5"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Description

Bumps the version to 0.3.0 to cut a new release ahead of the APHL deployment planned alongside the retrained embeddings.

Minor (rather than patch) bump because this release includes backwards-compatible new functionality since v0.2.5, notably:

- Result cache in the Lambda loop (#589)
- LOINC terminology maintenance workflow for AWS (#660)
- Demo frontend and synchronous API deployment (#714)
- 3x TTC pipeline speedup under load (#692)
- Python 3.14 upgrade (#707)

Merging this PR triggers the release workflow: tagging, image builds/pushes to GHCR and APHL ECR, GitHub Release with auto-generated notes, and the Slack notification.

## Related Issues

N/A

## Additional Notes

None